### PR TITLE
Redesign dashboard: KPI strip, monitor grid, live feed, incident time…

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,14 +2,16 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Heartbeat;
+use App\Models\Incident;
 use App\Models\Monitor;
-use Illuminate\Http\Request;
+use App\Models\NotificationChannel;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class DashboardController extends Controller
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(): Response
     {
         $teamId = auth()->user()->current_team_id;
 
@@ -23,6 +25,70 @@ class DashboardController extends Controller
             ")
             ->first();
 
+        $activeMonitorIds = Monitor::query()
+            ->where('team_id', $teamId)
+            ->where('is_active', true)
+            ->pluck('id');
+
+        $teamUptime30d = null;
+        $avgResponse24h = null;
+
+        if ($activeMonitorIds->isNotEmpty()) {
+            $stats30d = Heartbeat::query()
+                ->whereIn('monitor_id', $activeMonitorIds)
+                ->where('created_at', '>=', now()->subHours(720))
+                ->selectRaw('COUNT(*) as total, SUM(CASE WHEN status = "up" THEN 1 ELSE 0 END) as up_count')
+                ->first();
+
+            if ($stats30d && $stats30d->total > 0) {
+                $teamUptime30d = round(($stats30d->up_count / $stats30d->total) * 100, 2);
+            }
+
+            $avg = Heartbeat::query()
+                ->whereIn('monitor_id', $activeMonitorIds)
+                ->where('created_at', '>=', now()->subHours(24))
+                ->whereNotNull('response_time')
+                ->avg('response_time');
+
+            $avgResponse24h = $avg ? (int) round($avg) : null;
+        }
+
+        $openIncidents = Incident::query()
+            ->whereHas('monitor', fn ($q) => $q->where('team_id', $teamId))
+            ->whereNull('resolved_at')
+            ->with('monitor:id,name')
+            ->latest('started_at')
+            ->limit(5)
+            ->get()
+            ->map(fn ($i) => [
+                'id' => $i->id,
+                'monitor_id' => $i->monitor->id,
+                'monitor_name' => $i->monitor->name,
+                'started_at' => $i->started_at->toISOString(),
+                'cause' => $i->cause,
+            ]);
+
+        $sslCerts = Monitor::query()
+            ->where('team_id', $teamId)
+            ->where('ssl_monitoring_enabled', true)
+            ->with('sslCertificate')
+            ->get()
+            ->filter(fn ($m) => $m->sslCertificate !== null)
+            ->sortBy(fn ($m) => $m->sslCertificate->days_until_expiry ?? 9999)
+            ->take(5)
+            ->map(fn ($m) => [
+                'monitor_name' => $m->name,
+                'days_until_expiry' => $m->sslCertificate->days_until_expiry,
+                'issuer' => $m->sslCertificate->issuer,
+                'is_valid' => $m->sslCertificate->is_valid,
+            ])
+            ->values();
+
+        $notificationChannels = NotificationChannel::query()
+            ->where('team_id', $teamId)
+            ->orderBy('name')
+            ->get(['name', 'type', 'is_enabled']);
+
         return inertia('dashboard', [
             'counts' => [
                 'total' => (int) $counts->total,
@@ -30,6 +96,11 @@ class DashboardController extends Controller
                 'down' => (int) $counts->down,
                 'paused' => (int) $counts->paused,
             ],
+            'team_uptime_30d' => $teamUptime30d,
+            'avg_response_24h' => $avgResponse24h,
+            'open_incidents' => $openIncidents,
+            'ssl_certs' => $sslCerts,
+            'notification_channels' => $notificationChannels,
             'monitors' => Inertia::defer(fn () => Monitor::query()
                 ->where('team_id', $teamId)
                 ->with(['tags', 'heartbeats' => fn ($q) => $q->latest('created_at')->limit(90)])

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,6 +1,6 @@
 import AppLayout from "@/layouts/app-layout"
 import type { SharedData } from "@/types/shared"
-import { Head, usePage, WhenVisible } from "@inertiajs/react"
+import { Head, router, usePage, WhenVisible } from "@inertiajs/react"
 import { useEcho } from "@laravel/echo-react"
 import { Container } from "@/components/ui/container"
 import { Badge } from "@/components/ui/badge"
@@ -16,18 +16,53 @@ import {
   ExclamationCircleIcon,
   GlobeAltIcon,
   PlusIcon,
+  ShieldCheckIcon,
+  BellIcon,
+  SignalIcon,
 } from "@heroicons/react/20/solid"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import CreateMonitorModal from "./monitors/components/create-monitor-modal"
-import { TagBadge } from "@/components/tag-badge"
 import { uptimeColor, statusBadgeIntent } from "@/lib/color"
 import monitorRoutes from "@/routes/monitors"
-import MonitorFilterBar from "@/components/monitor-filter-bar"
-import { useMonitorFilters } from "@/hooks/use-monitor-filters"
-import { heartbeatsToTracker } from "@/lib/heartbeats"
+import { heartbeatsToTracker, formatInterval } from "@/lib/heartbeats"
+
+interface OpenIncident {
+  id: number
+  monitor_id: number
+  monitor_name: string
+  started_at: string
+  cause: string | null
+}
+
+interface SslCert {
+  monitor_name: string
+  days_until_expiry: number | null
+  issuer: string | null
+  is_valid: boolean
+}
+
+interface NotifChannel {
+  name: string
+  type: string
+  is_enabled: boolean
+}
+
+interface LiveEvent {
+  id: number
+  kind: string
+  monitorName: string
+  detail: string
+  timestamp: Date
+  isAlert: boolean
+}
 
 interface Props {
   counts: { total: number; up: number; down: number; paused: number }
+  team_uptime_30d: number | null
+  avg_response_24h: number | null
+  open_incidents: OpenIncident[]
+  ssl_certs: SslCert[]
+  notification_channels: NotifChannel[]
   monitors?: Monitor[]
 }
 
@@ -46,120 +81,485 @@ interface StatusChangedPayload {
   message: string | null
 }
 
-function StatusBanner({ counts }: { counts: Props["counts"] }) {
-  if (counts.total === 0) return null
+function formatRelativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  return `${h}h ago`
+}
 
-  const allUp = counts.down === 0
+function formatElapsed(startedAt: string): string {
+  const diff = Date.now() - new Date(startedAt).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ${s % 60}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
 
-  if (allUp) {
-    return (
-      <div className="flex items-center gap-2.5 rounded-lg border border-success/20 bg-success/10 px-4 py-2.5 text-success-subtle-fg">
-        <span className="relative flex size-4 shrink-0 items-center justify-center">
-          <span className="absolute inline-flex size-full animate-ping rounded-full bg-success opacity-20" />
-          <CheckCircleIcon className="relative size-4 text-success" />
+function formatTime(date: Date): string {
+  return date.toTimeString().slice(0, 8)
+}
+
+function KPIStrip({
+  counts,
+  teamUptime30d,
+  avgResponse24h,
+  openIncidentsCount,
+}: {
+  counts: Props["counts"]
+  teamUptime30d: number | null
+  avgResponse24h: number | null
+  openIncidentsCount: number
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="flex flex-col rounded-lg border bg-overlay px-5 py-4">
+        <span className="text-[10px] uppercase tracking-widest text-muted-fg">Monitors</span>
+        <span className="mt-2 font-mono text-4xl font-medium tabular-nums">{counts.total}</span>
+        <span className="mt-1.5 text-xs text-muted-fg">
+          <span className="text-success">{counts.up} up</span>
+          {" · "}
+          {counts.down > 0 ? <span className="text-danger">{counts.down} down</span> : <span>0 down</span>}
+          {counts.paused > 0 && <span> · {counts.paused} paused</span>}
         </span>
-        <span className="text-sm font-medium">All systems operational</span>
       </div>
-    )
-  }
+
+      <div className="flex flex-col rounded-lg border bg-overlay px-5 py-4">
+        <span className="text-[10px] uppercase tracking-widest text-muted-fg">Uptime · 30d</span>
+        <span className={`mt-2 font-mono text-4xl font-medium tabular-nums ${teamUptime30d !== null ? uptimeColor(teamUptime30d) : "text-muted-fg"}`}>
+          {teamUptime30d !== null ? `${teamUptime30d}%` : "—"}
+        </span>
+        <span className="mt-1.5 text-xs text-muted-fg">team average</span>
+      </div>
+
+      <div className="flex flex-col rounded-lg border bg-overlay px-5 py-4">
+        <span className="text-[10px] uppercase tracking-widest text-muted-fg">Avg response · 24h</span>
+        <span className="mt-2 font-mono text-4xl font-medium tabular-nums">
+          {avgResponse24h !== null ? `${avgResponse24h}ms` : "—"}
+        </span>
+        <span className="mt-1.5 text-xs text-muted-fg">across all monitors</span>
+      </div>
+
+      <div className={`flex flex-col rounded-lg border px-5 py-4 ${openIncidentsCount > 0 ? "border-danger/30 bg-danger/8" : "bg-overlay"}`}>
+        <span className={`text-[10px] uppercase tracking-widest ${openIncidentsCount > 0 ? "text-danger/70" : "text-muted-fg"}`}>
+          Open incidents
+        </span>
+        <span className={`mt-2 font-mono font-medium tabular-nums ${openIncidentsCount > 0 ? "text-5xl text-danger" : "text-4xl"}`}>
+          {openIncidentsCount}
+        </span>
+        {openIncidentsCount > 0 && (
+          <span className="mt-1.5 text-xs text-danger/70">action required</span>
+        )}
+        {openIncidentsCount === 0 && (
+          <span className="mt-1.5 text-xs text-muted-fg">all clear</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ActiveIncidentBanner({ incidents }: { incidents: OpenIncident[] }) {
+  if (incidents.length === 0) return null
+  const first = incidents[0]
+  const [elapsed, setElapsed] = useState(() => formatElapsed(first.started_at))
+
+  useEffect(() => {
+    const t = setInterval(() => setElapsed(formatElapsed(first.started_at)), 1000)
+    return () => clearInterval(t)
+  }, [first.started_at])
 
   return (
-    <div className="rounded-lg border border-danger/30 bg-danger/10 px-5 py-4">
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <ExclamationCircleIcon className="size-5 shrink-0 text-danger" />
-          <div>
-            <p className="font-semibold text-danger leading-tight">
-              {counts.down} monitor{counts.down > 1 ? "s" : ""} down
-            </p>
-            <p className="text-danger-subtle-fg text-xs mt-0.5">
-              {counts.up} of {counts.total} operational
-            </p>
-          </div>
-        </div>
-        <Link
-          href={monitorRoutes.index.url({ query: { status: "down" } })}
-          className="shrink-0 rounded-md border border-danger/40 bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger/25 transition-colors"
-        >
-          View affected →
+    <div className="rounded-lg border border-danger/30 bg-danger/8 px-5 py-4">
+      <div className="flex items-center gap-3">
+        <span className="relative flex size-3 shrink-0">
+          <span className="absolute inline-flex size-full animate-ping rounded-full bg-danger opacity-30" />
+          <span className="relative inline-flex size-3 rounded-full bg-danger" />
+        </span>
+        <span className="text-xs font-bold uppercase tracking-wider text-danger">Active incident</span>
+        <span className="ml-auto font-mono text-xs text-danger/60">{elapsed}</span>
+      </div>
+      <div className="mt-2 font-semibold text-danger">{first.monitor_name}</div>
+      {first.cause && <div className="mt-0.5 text-xs text-danger/70">{first.cause}</div>}
+      {incidents.length > 1 && (
+        <div className="mt-1 text-xs text-danger/60">+{incidents.length - 1} more</div>
+      )}
+      <div className="mt-3 flex gap-2">
+        <Link href={monitorRoutes.index.url({ query: { status: "down" } })}>
+          <Button size="sm" intent="danger">
+            <ExclamationCircleIcon data-slot="icon" />
+            View affected
+          </Button>
         </Link>
       </div>
     </div>
   )
 }
 
-function StatRow({ counts }: { counts: Props["counts"] }) {
-  const hasDown = counts.down > 0
+function IncidentGantt({ monitors }: { monitors: Monitor[] }) {
+  const now = useMemo(() => Date.now(), [])
+  const windowMs = 24 * 60 * 60 * 1000
+  const windowStart = now - windowMs
+
+  const rows = useMemo(
+    () =>
+      monitors
+        .filter((m) => m.heartbeats?.some((hb) => hb.status === "down"))
+        .slice(0, 8),
+    [monitors],
+  )
+
+  if (rows.length === 0) return null
+
   return (
-    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-      <div className="flex flex-col rounded-lg border px-4 py-3">
-        <span className="text-xs text-muted-fg">Total</span>
-        <span className="mt-0.5 font-semibold text-2xl tabular-nums">{counts.total}</span>
+    <div className="rounded-lg border bg-overlay p-5">
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="font-semibold text-sm">Incident timeline · 24h</div>
+          <div className="mt-0.5 text-xs text-muted-fg">
+            {rows.length} monitor{rows.length > 1 ? "s" : ""} with incidents in the last 24 hours
+          </div>
+        </div>
+        <div className="flex items-center gap-4 text-xs text-muted-fg">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block size-2.5 rounded-sm bg-success/40" />
+            up
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block size-2.5 rounded-sm bg-danger" />
+            down
+          </span>
+        </div>
       </div>
-      <div className="flex flex-col rounded-lg border px-4 py-3">
-        <span className="text-xs text-muted-fg">Up</span>
-        <span className="mt-0.5 font-semibold text-2xl tabular-nums text-success">{counts.up}</span>
+
+      <div className="mt-4 space-y-2.5">
+        {rows.map((m) => {
+          const hbs = [...(m.heartbeats ?? [])]
+            .filter((hb) => new Date(hb.created_at).getTime() >= windowStart)
+            .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+
+          type Seg = { start: number; end: number; status: string }
+          const segs: Seg[] = []
+          const slotWidth = hbs.length > 0 ? 100 / hbs.length : 0
+
+          for (let i = 0; i < hbs.length; i++) {
+            const hb = hbs[i]
+            const t = new Date(hb.created_at).getTime()
+            const pct = ((t - windowStart) / windowMs) * 100
+            const last = segs[segs.length - 1]
+            if (!last || last.status !== hb.status) {
+              segs.push({ start: Math.max(0, pct), end: Math.min(100, pct + slotWidth), status: hb.status })
+            } else {
+              last.end = Math.min(100, pct + slotWidth)
+            }
+          }
+
+          return (
+            <div key={m.id} className="grid items-center gap-3" style={{ gridTemplateColumns: "160px 1fr" }}>
+              <div className="flex items-center gap-2 overflow-hidden">
+                <span className="truncate text-xs text-fg">{m.name}</span>
+                <span className="shrink-0 rounded bg-muted/20 px-1 py-px font-mono text-[10px] uppercase text-muted-fg">
+                  {m.type}
+                </span>
+              </div>
+              <div className="relative h-4 overflow-hidden rounded-sm bg-success/15">
+                {segs.map((seg, i) =>
+                  seg.status === "down" ? (
+                    <div
+                      key={i}
+                      className="absolute inset-y-0 bg-danger"
+                      style={{ left: `${seg.start}%`, width: `${Math.max(0.5, seg.end - seg.start)}%` }}
+                    />
+                  ) : null,
+                )}
+                <div className="absolute inset-y-0 right-0 w-px bg-primary/50" />
+              </div>
+            </div>
+          )
+        })}
       </div>
-      <div className={`flex flex-col rounded-lg border px-4 py-3 ${hasDown ? "border-danger/30 bg-danger/8" : ""}`}>
-        <span className={`text-xs ${hasDown ? "text-danger/70" : "text-muted-fg"}`}>Down</span>
-        <span className={`mt-0.5 tabular-nums font-bold ${hasDown ? "text-3xl text-danger" : "text-2xl font-semibold text-muted-fg"}`}>
-          {counts.down}
-        </span>
-      </div>
-      <div className="flex flex-col rounded-lg border px-4 py-3">
-        <span className="text-xs text-muted-fg">Paused</span>
-        <span className="mt-0.5 font-semibold text-2xl tabular-nums text-muted-fg">{counts.paused}</span>
+
+      <div className="mt-3 grid gap-3" style={{ gridTemplateColumns: "160px 1fr" }}>
+        <div />
+        <div className="flex justify-between text-[10px] text-muted-fg/60">
+          {["24h ago", "18h", "12h", "6h", "now"].map((h) => (
+            <span key={h}>{h}</span>
+          ))}
+        </div>
       </div>
     </div>
   )
 }
 
-function MonitorRow({ monitor }: { monitor: Monitor }) {
-  const prevStatus = useRef(monitor.status)
-  const [recovering, setRecovering] = useState(false)
+function StatusDot({ status }: { status: Monitor["status"] }) {
+  const colors: Record<Monitor["status"], string> = {
+    up: "bg-success",
+    down: "bg-danger",
+    pending: "bg-warning",
+    paused: "bg-muted",
+  }
+  return (
+    <span className="relative flex size-2.5 shrink-0">
+      {status === "up" && (
+        <span className="absolute inline-flex size-full animate-ping rounded-full bg-success opacity-20" />
+      )}
+      <span className={`relative inline-flex size-2.5 rounded-full ${colors[status]}`} />
+    </span>
+  )
+}
 
-  useEffect(() => {
-    const prev = prevStatus.current
-    prevStatus.current = monitor.status
-    if (prev === "down" && monitor.status === "up") {
-      setRecovering(true)
-      const timer = setTimeout(() => setRecovering(false), 2500)
-      return () => clearTimeout(timer)
-    }
-  }, [monitor.status])
+function MonitorCard({ monitor }: { monitor: Monitor }) {
+  const lastChecked = monitor.last_checked_at ? formatRelativeTime(monitor.last_checked_at) : "—"
+  const isDown = monitor.status === "down"
 
   return (
     <Link
       href={monitorRoutes.show.url(monitor.id)}
-      className={`group grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-lg border border-border px-4 py-3 transition-colors hover:border-fg/20 hover:bg-secondary/30 sm:grid-cols-[auto_1fr_auto_auto]${recovering ? " animate-recovery-flash" : ""}`}
+      className={`flex flex-col gap-3 rounded-lg border p-4 transition-colors hover:border-fg/20 hover:bg-secondary/20 ${
+        isDown ? "border-danger/30 bg-danger/5" : "border-border"
+      }`}
     >
-      <Badge intent={statusBadgeIntent[monitor.status]} className="w-18 justify-center">
-        {monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1)}
-      </Badge>
-      <div className="min-w-0">
-        <span className="block truncate font-medium text-sm">{monitor.name}</span>
-        <span className="text-xs text-muted-fg">
-          {monitor.type.toUpperCase()} · {monitor.url ?? monitor.host}
-        </span>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <StatusDot status={monitor.status} />
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium">{monitor.name}</div>
+            <div className="truncate text-xs text-muted-fg">
+              {monitor.type.toUpperCase()} · {monitor.url ?? monitor.host}
+            </div>
+          </div>
+        </div>
+        <Badge intent={statusBadgeIntent[monitor.status]} className="shrink-0 text-[10px]">
+          {monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1)}
+        </Badge>
       </div>
-      <div className="hidden sm:block">
-        <Tracker
-          data={heartbeatsToTracker(monitor.heartbeats)}
-          className="h-6 w-32"
-          aria-label={`Uptime history for ${monitor.name}`}
-        />
-      </div>
-      <div className="flex w-24 shrink-0 flex-col items-end text-right">
-        {monitor.uptime_percentage !== undefined && (
-          <span className={`text-sm font-medium tabular-nums ${uptimeColor(monitor.uptime_percentage)}`}>{monitor.uptime_percentage}%</span>
-        )}
-        {monitor.average_response_time != null && (
-          <span className="text-xs text-muted-fg tabular-nums">
-            {Math.round(monitor.average_response_time)}ms
-          </span>
-        )}
+
+      <Tracker
+        data={heartbeatsToTracker(monitor.heartbeats, 40)}
+        className="h-5 w-full"
+        aria-label={`Uptime history for ${monitor.name}`}
+      />
+
+      <div className="grid grid-cols-4 gap-1 text-center">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Uptime</div>
+          <div className={`mt-0.5 font-mono text-sm font-medium tabular-nums ${uptimeColor(monitor.uptime_percentage ?? 100)}`}>
+            {monitor.uptime_percentage !== undefined ? `${monitor.uptime_percentage}%` : "—"}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Avg</div>
+          <div className="mt-0.5 font-mono text-sm tabular-nums">
+            {monitor.average_response_time != null ? `${Math.round(monitor.average_response_time)}ms` : "—"}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Interval</div>
+          <div className="mt-0.5 font-mono text-sm tabular-nums text-muted-fg">
+            {formatInterval(monitor.interval)}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Last check</div>
+          <div className="mt-0.5 font-mono text-xs text-muted-fg">{lastChecked}</div>
+        </div>
       </div>
     </Link>
+  )
+}
+
+type GridFilter = "all" | "up" | "down" | "paused"
+
+function MonitorGrid({ monitors, onAddMonitor }: { monitors: Monitor[]; onAddMonitor: () => void }) {
+  const [filter, setFilter] = useState<GridFilter>("all")
+
+  const counts = useMemo(
+    () => ({
+      all: monitors.length,
+      up: monitors.filter((m) => m.status === "up").length,
+      down: monitors.filter((m) => m.status === "down").length,
+      paused: monitors.filter((m) => m.status === "paused" || !m.is_active).length,
+    }),
+    [monitors],
+  )
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return monitors
+    if (filter === "paused") return monitors.filter((m) => m.status === "paused" || !m.is_active)
+    return monitors.filter((m) => m.status === filter)
+  }, [monitors, filter])
+
+  const tabs: { key: GridFilter; label: string }[] = [
+    { key: "all", label: `All ${counts.all}` },
+    { key: "up", label: `Up ${counts.up}` },
+    { key: "down", label: `Down ${counts.down}` },
+    { key: "paused", label: `Paused ${counts.paused}` },
+  ]
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-1.5 rounded-lg border bg-overlay p-1">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setFilter(t.key)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                filter === t.key
+                  ? "bg-primary text-primary-fg"
+                  : "text-muted-fg hover:text-fg"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <CreateMonitorModal>
+          <Button size="sm" intent="outline">
+            <PlusIcon data-slot="icon" />
+            Add
+          </Button>
+        </CreateMonitorModal>
+      </div>
+
+      {filtered.length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((m) => (
+            <MonitorCard key={m.id} monitor={m} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-fg">
+          No {filter === "all" ? "" : filter} monitors.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SSLExpiryWidget({ certs }: { certs: SslCert[] }) {
+  if (certs.length === 0) return null
+
+  const certColor = (days: number | null, isValid: boolean) => {
+    if (!isValid) return "text-danger"
+    if (days === null) return "text-muted-fg"
+    if (days <= 7) return "text-danger"
+    if (days <= 30) return "text-warning"
+    return "text-success"
+  }
+
+  return (
+    <div className="rounded-lg border bg-overlay p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <ShieldCheckIcon className="size-4 text-muted-fg" />
+          SSL Expiry
+        </div>
+        <span className="text-xs text-muted-fg">{certs.length} monitored</span>
+      </div>
+      <div className="mt-3 space-y-0">
+        {certs.map((c, i) => (
+          <div
+            key={i}
+            className={`${i > 0 ? "border-t border-border" : ""} py-2.5`}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="min-w-0 truncate text-xs font-medium">{c.monitor_name}</span>
+              <span className={`shrink-0 font-mono text-xs font-semibold ${certColor(c.days_until_expiry, c.is_valid)}`}>
+                {c.is_valid && c.days_until_expiry !== null ? `${c.days_until_expiry}d` : c.is_valid ? "—" : "invalid"}
+              </span>
+            </div>
+            {c.issuer && (
+              <div className="mt-0.5 truncate text-[10px] text-muted-fg">{c.issuer}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function NotificationChannelsWidget({ channels }: { channels: NotifChannel[] }) {
+  if (channels.length === 0) return null
+
+  const typeLabel: Record<string, string> = {
+    email: "Email",
+    slack: "Slack",
+    discord: "Discord",
+    telegram: "Telegram",
+    webhook: "Webhook",
+  }
+
+  return (
+    <div className="rounded-lg border bg-overlay p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <BellIcon className="size-4 text-muted-fg" />
+          Notifications
+        </div>
+        <Link href="/notification-channels" className="text-xs text-primary hover:underline">
+          manage →
+        </Link>
+      </div>
+      <div className="mt-3 space-y-2">
+        {channels.map((c, i) => (
+          <div key={i} className="flex items-center gap-2.5 text-xs">
+            <span className={`size-2 shrink-0 rounded-full ${c.is_enabled ? "bg-success" : "bg-muted"}`} />
+            <span className="w-16 shrink-0 text-muted-fg">{typeLabel[c.type] ?? c.type}</span>
+            <span className="min-w-0 truncate">{c.name}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function LiveFeed({ events }: { events: LiveEvent[] }) {
+  const alertKinds = new Set(["DOWN", "DEGRADED"])
+  return (
+    <div className="rounded-lg border bg-overlay p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <SignalIcon className="size-4 text-muted-fg" />
+          Live feed
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-success">
+          <span className="relative flex size-2">
+            <span className="absolute inline-flex size-full animate-ping rounded-full bg-success opacity-40" />
+            <span className="relative inline-flex size-2 rounded-full bg-success" />
+          </span>
+          streaming
+        </div>
+      </div>
+      <div className="mt-3 font-mono text-xs">
+        {events.length === 0 ? (
+          <div className="py-6 text-center text-muted-fg">Waiting for events…</div>
+        ) : (
+          <div className="space-y-0.5">
+            {events.slice(0, 15).map((e) => (
+              <div
+                key={e.id}
+                className="grid items-center gap-3 py-1"
+                style={{ gridTemplateColumns: "5.5rem 4rem 1fr" }}
+              >
+                <span className="text-muted-fg/60">{formatTime(e.timestamp)}</span>
+                <span className={`font-semibold uppercase ${alertKinds.has(e.kind) ? "text-danger" : e.kind === "UP" ? "text-success" : "text-muted-fg"}`}>
+                  {e.kind}
+                </span>
+                <span className="truncate text-muted-fg">
+                  {e.monitorName}
+                  {e.detail ? ` · ${e.detail}` : ""}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -170,8 +570,15 @@ function EmptyState() {
       step: "01",
       title: "Add your first monitor",
       description:
-        "Point UptimeRadar at a URL, host, or IP. It will check every 60 seconds and alert you the moment something goes wrong.",
-      action: <CreateMonitorModal><Button size="sm"><PlusIcon data-slot="icon" />Add monitor</Button></CreateMonitorModal>,
+        "Point Beacon at a URL, host, or IP. It will check every 60 seconds and alert you the moment something goes wrong.",
+      action: (
+        <CreateMonitorModal>
+          <Button size="sm">
+            <PlusIcon data-slot="icon" />
+            Add monitor
+          </Button>
+        </CreateMonitorModal>
+      ),
     },
     {
       icon: BellAlertIcon,
@@ -181,7 +588,9 @@ function EmptyState() {
         "Get alerted via email, Slack, Discord, or webhook when a monitor goes down — before your users notice.",
       action: (
         <Link href="/notification-channels">
-          <Button intent="outline" size="sm">Set up channels</Button>
+          <Button intent="outline" size="sm">
+            Set up channels
+          </Button>
         </Link>
       ),
     },
@@ -193,7 +602,9 @@ function EmptyState() {
         "Create a public status page your users can bookmark. Show uptime history and communicate incidents transparently.",
       action: (
         <Link href="/status-pages">
-          <Button intent="outline" size="sm">Create page</Button>
+          <Button intent="outline" size="sm">
+            Create page
+          </Button>
         </Link>
       ),
     },
@@ -203,9 +614,7 @@ function EmptyState() {
     <div className="py-8">
       <div className="mb-10">
         <Heading level={2}>Get started</Heading>
-        <p className="mt-1 text-muted-fg text-sm">
-          Three steps to know the moment your services go down.
-        </p>
+        <p className="mt-1 text-muted-fg text-sm">Three steps to know the moment your services go down.</p>
       </div>
 
       <div className="space-y-3">
@@ -233,10 +642,21 @@ function EmptyState() {
   )
 }
 
-export default function Dashboard({ counts: initialCounts, monitors: initialMonitors }: Props) {
+export default function Dashboard({
+  counts: initialCounts,
+  monitors: initialMonitors,
+  team_uptime_30d,
+  avg_response_24h,
+  open_incidents,
+  ssl_certs,
+  notification_channels,
+}: Props) {
   const { auth } = usePage<SharedData>().props
   const [monitors, setMonitors] = useState(initialMonitors)
   const [counts, setCounts] = useState(initialCounts)
+  const [openIncidents, setOpenIncidents] = useState(open_incidents)
+  const [liveEvents, setLiveEvents] = useState<LiveEvent[]>([])
+  const liveEventIdRef = useRef(0)
 
   useEffect(() => {
     if (initialMonitors) setMonitors(initialMonitors)
@@ -246,62 +666,99 @@ export default function Dashboard({ counts: initialCounts, monitors: initialMoni
     setCounts(initialCounts)
   }, [initialCounts])
 
-  const tags = useMemo(() => {
-    if (!monitors) return []
-    const tagMap = new Map<number, Tag>()
-    monitors.forEach((m) => m.tags?.forEach((t) => tagMap.set(t.id, t)))
-    return Array.from(tagMap.values()).sort((a, b) => a.name.localeCompare(b.name))
+  useEffect(() => {
+    setOpenIncidents(open_incidents)
+  }, [open_incidents])
+
+  const monitorMap = useMemo(() => {
+    const map = new Map<number, { name: string; type: string }>()
+    monitors?.forEach((m) => map.set(m.id, { name: m.name, type: m.type }))
+    return map
   }, [monitors])
 
-  const {
-    filteredMonitors,
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    tagFilter,
-    setTagFilter,
-  } = useMonitorFilters(monitors ?? [])
+  const addLiveEvent = useCallback(
+    (event: Omit<LiveEvent, "id">) => {
+      setLiveEvents((prev) => [{ ...event, id: ++liveEventIdRef.current }, ...prev].slice(0, 20))
+    },
+    [],
+  )
 
-  const handleHeartbeat = useCallback((payload: HeartbeatPayload) => {
-    setMonitors((prev) =>
-      prev?.map((m) => {
-        if (m.id !== payload.monitorId) return m
-        const updatedHeartbeats = [...(m.heartbeats ?? []), payload.heartbeat].slice(-90)
-        return {
-          ...m,
-          status: payload.monitorStatus as Monitor["status"],
-          heartbeats: updatedHeartbeats,
-          uptime_percentage: payload.uptimePercentage,
-          average_response_time: payload.averageResponseTime,
-        }
-      }),
-    )
-  }, [])
+  const handleHeartbeat = useCallback(
+    (payload: HeartbeatPayload) => {
+      setMonitors((prev) =>
+        prev?.map((m) => {
+          if (m.id !== payload.monitorId) return m
+          const updatedHeartbeats = [...(m.heartbeats ?? []), payload.heartbeat].slice(-90)
+          return {
+            ...m,
+            status: payload.monitorStatus as Monitor["status"],
+            heartbeats: updatedHeartbeats,
+            uptime_percentage: payload.uptimePercentage,
+            average_response_time: payload.averageResponseTime,
+          }
+        }),
+      )
+      const info = monitorMap.get(payload.monitorId)
+      addLiveEvent({
+        kind: info?.type.toUpperCase() ?? "CHECK",
+        monitorName: info?.name ?? `Monitor #${payload.monitorId}`,
+        detail: [
+          payload.heartbeat.status_code ? String(payload.heartbeat.status_code) : null,
+          payload.heartbeat.response_time != null ? `${payload.heartbeat.response_time}ms` : null,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        timestamp: new Date(),
+        isAlert: payload.heartbeat.status === "down",
+      })
+    },
+    [monitorMap, addLiveEvent],
+  )
 
-  const handleStatusChanged = useCallback((payload: StatusChangedPayload) => {
-    setMonitors((prev) =>
-      prev?.map((m) =>
-        m.id === payload.monitorId ? { ...m, status: payload.newStatus as Monitor["status"] } : m,
-      ),
-    )
-    setCounts((prev) => {
-      const updated = { ...prev }
-      if (payload.oldStatus === "up") updated.up--
-      if (payload.oldStatus === "down") updated.down--
-      if (payload.newStatus === "up") updated.up++
-      if (payload.newStatus === "down") updated.down++
-      return updated
-    })
-  }, [])
+  const handleStatusChanged = useCallback(
+    (payload: StatusChangedPayload) => {
+      setMonitors((prev) =>
+        prev?.map((m) =>
+          m.id === payload.monitorId ? { ...m, status: payload.newStatus as Monitor["status"] } : m,
+        ),
+      )
+      setCounts((prev) => {
+        const updated = { ...prev }
+        if (payload.oldStatus === "up") updated.up--
+        if (payload.oldStatus === "down") updated.down--
+        if (payload.newStatus === "up") updated.up++
+        if (payload.newStatus === "down") updated.down++
+        return updated
+      })
 
-  const handleChecking = useCallback((payload: { monitorId: number }) => {
-    setMonitors((prev) =>
-      prev?.map((m) =>
-        m.id === payload.monitorId ? { ...m, status: "pending" as Monitor["status"] } : m,
-      ),
-    )
-  }, [])
+      if (payload.newStatus === "up") {
+        setOpenIncidents((prev) => prev.filter((i) => i.monitor_id !== payload.monitorId))
+      } else if (payload.newStatus === "down") {
+        router.reload({ only: ["open_incidents"], preserveUrl: true })
+      }
+
+      const info = monitorMap.get(payload.monitorId)
+      addLiveEvent({
+        kind: payload.newStatus.toUpperCase(),
+        monitorName: info?.name ?? `Monitor #${payload.monitorId}`,
+        detail: payload.message ?? (payload.newStatus === "up" ? "recovered" : "incident started"),
+        timestamp: new Date(),
+        isAlert: payload.newStatus === "down",
+      })
+    },
+    [monitorMap, addLiveEvent],
+  )
+
+  const handleChecking = useCallback(
+    (payload: { monitorId: number }) => {
+      setMonitors((prev) =>
+        prev?.map((m) =>
+          m.id === payload.monitorId ? { ...m, status: "pending" as Monitor["status"] } : m,
+        ),
+      )
+    },
+    [],
+  )
 
   useEcho(`monitors.${auth.user.id}`, ".MonitorChecking", handleChecking)
   useEcho(`monitors.${auth.user.id}`, ".HeartbeatRecorded", handleHeartbeat)
@@ -313,23 +770,26 @@ export default function Dashboard({ counts: initialCounts, monitors: initialMoni
       <Container className="space-y-4 pt-2 pb-8">
         <div className="flex items-center justify-between">
           <Heading>Dashboard</Heading>
-          {counts.total > 0 && <CreateMonitorModal />}
         </div>
 
         {counts.total > 0 && (
-          <>
-            <StatusBanner counts={counts} />
-            <StatRow counts={counts} />
-          </>
+          <KPIStrip
+            counts={counts}
+            teamUptime30d={team_uptime_30d}
+            avgResponse24h={avg_response_24h}
+            openIncidentsCount={openIncidents.length}
+          />
         )}
+
+        {openIncidents.length > 0 && <ActiveIncidentBanner incidents={openIncidents} />}
 
         <WhenVisible
           fallback={
-            <div className="space-y-2">
-              {Array(4)
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {Array(6)
                 .fill(null)
                 .map((_, i) => (
-                  <div key={i} className="h-16 animate-pulse rounded-lg bg-muted" />
+                  <div key={i} className="h-44 animate-pulse rounded-lg bg-muted/40" />
                 ))}
             </div>
           }
@@ -337,34 +797,18 @@ export default function Dashboard({ counts: initialCounts, monitors: initialMoni
         >
           {monitors && monitors.length > 0 ? (
             <div className="space-y-4">
-              <MonitorFilterBar
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                statusFilter={statusFilter}
-                onStatusFilterChange={setStatusFilter}
-                tagFilter={tagFilter}
-                onTagFilterChange={setTagFilter}
-                tags={tags}
-              />
-              {filteredMonitors.length > 0 ? (
-                <div className="space-y-2">
-                  {filteredMonitors.map((monitor) => (
-                    <MonitorRow key={monitor.id} monitor={monitor} />
-                  ))}
+              <IncidentGantt monitors={monitors} />
+
+              <div className="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_280px]">
+                <div className="space-y-4">
+                  <MonitorGrid monitors={monitors} onAddMonitor={() => {}} />
+                  <LiveFeed events={liveEvents} />
                 </div>
-              ) : (
-                <div className="py-8 text-center">
-                  <p className="text-muted-fg text-sm">No monitors match your filters.</p>
-                  <Button
-                    intent="plain"
-                    size="xs"
-                    onPress={() => { setSearchQuery(""); setStatusFilter("all"); setTagFilter(null) }}
-                    className="mt-2"
-                  >
-                    Clear filters
-                  </Button>
+                <div className="space-y-4">
+                  <SSLExpiryWidget certs={ssl_certs} />
+                  <NotificationChannelsWidget channels={notification_channels} />
                 </div>
-              )}
+              </div>
             </div>
           ) : (
             <EmptyState />


### PR DESCRIPTION
…line

Replace list view with dense card grid and add new data sections:
- 4-column KPI strip (monitors, 30d team uptime, avg response, open incidents)
- Active incident banner with live elapsed timer
- Per-monitor Gantt timeline derived from heartbeat timestamps
- Monitor grid with status filter tabs (All/Up/Down/Paused)
- Live event feed accumulated from Echo (heartbeats + status changes)
- SSL expiry and notification channels widgets in sidebar column
- open_incidents in React state: clears instantly on recovery via Echo, reloads from server when new down event fires (no full page reload)