### PR TITLE
Run tests on PR only, build/push on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   test:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,9 +40,8 @@ jobs:
             php artisan test --compact
 
   push:
-    runs-on: ubuntu-latest
-    needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Removes tests from the push-to-main trigger. Branch protection ensures tests pass before any PR can merge, so re-running them on the merge commit is redundant. Merge now only triggers the Docker build and registry push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to conditionally run tests only on pull requests.
  * Decoupled push events targeting the main branch from test job dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->