### PR TITLE
fix(ui): realtime websocket state correctness + perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+/docs
+/test-results

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
-/docs
+/docs/prds
+/docs/generated
 /test-results

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -15,16 +15,6 @@ class DashboardController extends Controller
     {
         $teamId = auth()->user()->current_team_id;
 
-        $counts = Monitor::query()
-            ->where('team_id', $teamId)
-            ->selectRaw("
-                COUNT(*) as total,
-                SUM(CASE WHEN status = 'up' THEN 1 ELSE 0 END) as up,
-                SUM(CASE WHEN status = 'down' THEN 1 ELSE 0 END) as down,
-                SUM(CASE WHEN status = 'paused' OR is_active = false THEN 1 ELSE 0 END) as paused
-            ")
-            ->first();
-
         $activeMonitorIds = Monitor::query()
             ->where('team_id', $teamId)
             ->where('is_active', true)
@@ -90,12 +80,6 @@ class DashboardController extends Controller
             ->get(['name', 'type', 'is_enabled']);
 
         return inertia('dashboard', [
-            'counts' => [
-                'total' => (int) $counts->total,
-                'up' => (int) $counts->up,
-                'down' => (int) $counts->down,
-                'paused' => (int) $counts->paused,
-            ],
             'team_uptime_30d' => $teamUptime30d,
             'avg_response_24h' => $avgResponse24h,
             'open_incidents' => $openIncidents,

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -106,11 +106,15 @@ class DashboardController extends Controller
                 ->with(['tags', 'heartbeats' => fn ($q) => $q->latest('created_at')->limit(90)])
                 ->latest()
                 ->get()
-                ->map(fn (Monitor $monitor) => [
-                    ...$monitor->toArray(),
-                    'uptime_percentage' => $monitor->uptimePercentage(24),
-                    'average_response_time' => $monitor->averageResponseTime(24),
-                ])
+                ->map(function (Monitor $monitor) {
+                    $monitor->setRelation('heartbeats', $monitor->heartbeats->reverse()->values());
+
+                    return [
+                        ...$monitor->toArray(),
+                        'uptime_percentage' => $monitor->uptimePercentage(24),
+                        'average_response_time' => $monitor->averageResponseTime(24),
+                    ];
+                })
             ),
         ]);
     }

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -29,7 +29,10 @@ class MonitorController extends Controller
             ->where('team_id', $teamId)
             ->with(['tags', 'monitorGroup', 'heartbeats' => fn ($q) => $q->latest()->limit(20)])
             ->latest()
-            ->get();
+            ->get()
+            ->each(function (Monitor $monitor) {
+                $monitor->setRelation('heartbeats', $monitor->heartbeats->reverse()->values());
+            });
 
         $tags = Tag::query()
             ->where('team_id', $teamId)
@@ -142,9 +145,12 @@ class MonitorController extends Controller
             'sslCertificate' => Inertia::defer(
                 fn () => $monitor->sslCertificate
             ),
-            'heartbeats' => Inertia::defer(
-                fn () => HeartbeatResource::collection($monitor->heartbeats()->latest()->paginate(10))
-            ),
+            'heartbeats' => Inertia::defer(function () use ($monitor) {
+                $paginator = $monitor->heartbeats()->latest()->paginate(10);
+                $paginator->setCollection($paginator->getCollection()->reverse()->values());
+
+                return HeartbeatResource::collection($paginator);
+            }),
             'incidents' => Inertia::defer(
                 fn () => $monitor->incidents()->latest('started_at')->get()
             ),

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -27,7 +27,7 @@ class MonitorController extends Controller
 
         $monitors = Monitor::query()
             ->where('team_id', $teamId)
-            ->with(['tags', 'monitorGroup', 'heartbeats' => fn ($q) => $q->latest()->limit(20)])
+            ->with(['tags', 'monitorGroup', 'heartbeats' => fn ($q) => $q->latest()->limit(90)])
             ->latest()
             ->get()
             ->each(function (Monitor $monitor) {

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -124,7 +124,8 @@ class MonitorController extends Controller
     {
         $this->authorize('view', $monitor);
 
-        $monitor->load('tags', 'notificationChannels');
+        $monitor->load(['tags', 'notificationChannels', 'heartbeats' => fn ($q) => $q->latest()->limit(90)]);
+        $monitor->setRelation('heartbeats', $monitor->heartbeats->reverse()->values());
 
         $period = request()->query('period', '24h');
         $allowedPeriods = ['1h', '24h', '7d', '30d'];

--- a/app/Http/Controllers/PublicStatusPageController.php
+++ b/app/Http/Controllers/PublicStatusPageController.php
@@ -21,7 +21,7 @@ class PublicStatusPageController extends Controller
         }]);
 
         $monitors = $statusPage->monitors->map(function ($monitor) {
-            $heartbeats = $monitor->heartbeats;
+            $heartbeats = $monitor->heartbeats->reverse()->values();
             $total = $heartbeats->count();
             $upCount = $heartbeats->where('status', 'up')->count();
             $uptimePercentage = $total > 0 ? round(($upCount / $total) * 100, 2) : 100.0;
@@ -31,7 +31,7 @@ class PublicStatusPageController extends Controller
                 'name' => $monitor->name,
                 'status' => $monitor->status,
                 'tags' => $monitor->tags,
-                'heartbeats' => $heartbeats->values(),
+                'heartbeats' => $heartbeats,
                 'uptime_percentage' => $uptimePercentage,
             ];
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7994 +1,9132 @@
 {
-    "name": "beacon",
-    "version": "1.5.6",
-    "lockfileVersion": 3,
-    "requires": true,
-    "packages": {
-        "": {
-            "version": "1.5.6",
-            "dependencies": {
-                "@heroicons/react": "^2.2.0",
-                "@internationalized/date": "^3.12.0",
-                "@laravel/echo-react": "^2.3.1",
-                "@react-aria/i18n": "^3.12.16",
-                "@types/node": "^22.15.34",
-                "laravel-echo": "^2.3.1",
-                "motion": "^12.34.1",
-                "pusher-js": "^8.4.0",
-                "react": "^19.1.0",
-                "react-aria-components": "^1.17.0",
-                "react-dom": "^19.1.0",
-                "recharts": "^3.8.0",
-                "sonner": "^2.0.7",
-                "tailwindcss-react-aria-components": "^2.0.0",
-                "tw-animate-css": "^1.3.4",
-                "vite": "^6.3.5"
-            },
-            "devDependencies": {
-                "@biomejs/biome": "2.0.6",
-                "@inertiajs/react": "^2.0.14",
-                "@laravel/vite-plugin-wayfinder": "^0.1.3",
-                "@tailwindcss/vite": "^4.1.11",
-                "@types/react": "^19.1.8",
-                "@types/react-dom": "^19.1.6",
-                "@vitejs/plugin-react": "^4.6.0",
-                "autoprefixer": "^10.4.21",
-                "axios": "^1.10.0",
-                "husky": "^9.1.7",
-                "laravel-vite-plugin": "^1.3.0",
-                "shadcn": "^4.0.6",
-                "tailwind-merge": "^3.5.0",
-                "tailwind-variants": "^3.2.2",
-                "tailwindcss": "^4.1.11",
-                "typescript": "^5.8.3",
-                "vite-plugin-run": "^0.6.1"
-            }
-        },
-        "node_modules/@antfu/ni": {
-            "version": "25.0.0",
-            "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
-            "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansis": "^4.0.0",
-                "fzf": "^0.5.2",
-                "package-manager-detector": "^1.3.0",
-                "tinyexec": "^1.0.1"
-            },
-            "bin": {
-                "na": "bin/na.mjs",
-                "nci": "bin/nci.mjs",
-                "ni": "bin/ni.mjs",
-                "nlx": "bin/nlx.mjs",
-                "nr": "bin/nr.mjs",
-                "nun": "bin/nun.mjs",
-                "nup": "bin/nup.mjs"
-            }
-        },
-        "node_modules/@antfu/utils": {
-            "version": "0.7.10",
-            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
-            "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.27.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
-                "browserslist": "^4.24.0",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-            "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-member-expression-to-functions": "^7.28.5",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.28.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.28.6",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-replace-supers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-            "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.28.5",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helpers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-            "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-            "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-            "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-react-jsx-self": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-            "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-react-jsx-source": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-            "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
-            "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-create-class-features-plugin": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-syntax-typescript": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/preset-typescript": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
-            "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-syntax-jsx": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-typescript": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@biomejs/biome": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.6.tgz",
-            "integrity": "sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==",
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "bin": {
-                "biome": "bin/biome"
-            },
-            "engines": {
-                "node": ">=14.21.3"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/biome"
-            },
-            "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.0.6",
-                "@biomejs/cli-darwin-x64": "2.0.6",
-                "@biomejs/cli-linux-arm64": "2.0.6",
-                "@biomejs/cli-linux-arm64-musl": "2.0.6",
-                "@biomejs/cli-linux-x64": "2.0.6",
-                "@biomejs/cli-linux-x64-musl": "2.0.6",
-                "@biomejs/cli-win32-arm64": "2.0.6",
-                "@biomejs/cli-win32-x64": "2.0.6"
-            }
-        },
-        "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.6.tgz",
-            "integrity": "sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.6.tgz",
-            "integrity": "sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.6.tgz",
-            "integrity": "sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.6.tgz",
-            "integrity": "sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.6.tgz",
-            "integrity": "sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.6.tgz",
-            "integrity": "sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.6.tgz",
-            "integrity": "sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.6.tgz",
-            "integrity": "sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@dotenvx/dotenvx": {
-            "version": "1.55.1",
-            "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.55.1.tgz",
-            "integrity": "sha512-WEuKyoe9CA7dfcFBnNbL0ndbCNcptaEYBygfFo9X1qEG+HD7xku4CYIplw6sbAHJavesZWbVBHeRSpvri0eKqw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "commander": "^11.1.0",
-                "dotenv": "^17.2.1",
-                "eciesjs": "^0.4.10",
-                "execa": "^5.1.1",
-                "fdir": "^6.2.0",
-                "ignore": "^5.3.0",
-                "object-treeify": "1.1.33",
-                "picomatch": "^4.0.2",
-                "which": "^4.0.0"
-            },
-            "bin": {
-                "dotenvx": "src/cli/dotenvx.js"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/@dotenvx/dotenvx/node_modules/commander": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@dotenvx/dotenvx/node_modules/which": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-            "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^3.1.1"
-            },
-            "bin": {
-                "node-which": "bin/which.js"
-            },
-            "engines": {
-                "node": "^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@ecies/ciphers": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
-            "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "bun": ">=1",
-                "deno": ">=2",
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "@noble/ciphers": "^1.0.0"
-            }
-        },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@formatjs/ecma402-abstract": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
-            "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-            "license": "MIT",
-            "dependencies": {
-                "@formatjs/fast-memoize": "2.2.7",
-                "@formatjs/intl-localematcher": "0.6.2",
-                "decimal.js": "^10.4.3",
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/@formatjs/fast-memoize": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-            "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/@formatjs/icu-messageformat-parser": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
-            "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
-            "license": "MIT",
-            "dependencies": {
-                "@formatjs/ecma402-abstract": "2.3.6",
-                "@formatjs/icu-skeleton-parser": "1.8.16",
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/@formatjs/icu-skeleton-parser": {
-            "version": "1.8.16",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
-            "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@formatjs/ecma402-abstract": "2.3.6",
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/@formatjs/intl-localematcher": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
-            "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/@heroicons/react": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-            "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": ">= 16 || ^19.0.0-rc"
-            }
-        },
-        "node_modules/@hono/node-server": {
-            "version": "1.19.11",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.14.1"
-            },
-            "peerDependencies": {
-                "hono": "^4"
-            }
-        },
-        "node_modules/@inertiajs/core": {
-            "version": "2.3.15",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.15.tgz",
-            "integrity": "sha512-C/x5w2/VhPpzfCg7SCtOxRrC8yKM7zIMvwpberMLrvSLMqPqGTFxYTJH+0E//G03RXzb+Q3+eatepbSq6tpZGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash-es": "^4.17.12",
-                "axios": "^1.13.5",
-                "laravel-precognition": "^1.0.2",
-                "lodash-es": "^4.17.23",
-                "qs": "^6.14.2"
-            }
-        },
-        "node_modules/@inertiajs/react": {
-            "version": "2.3.15",
-            "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.3.15.tgz",
-            "integrity": "sha512-/n1xNRxbRqjGFytYKpAbGC/MB8ETEwY9CHkVAmF6Q2GnC3ByQMZUwKuMyI5oyFb6PxTxWDxfl5poqmajw6XnEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inertiajs/core": "2.3.15",
-                "@types/lodash-es": "^4.17.12",
-                "laravel-precognition": "^1.0.2",
-                "lodash-es": "^4.17.23"
-            },
-            "peerDependencies": {
-                "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@inquirer/ansi": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-            "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/confirm": {
-            "version": "5.1.21",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-            "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.3.2",
-                "@inquirer/type": "^3.0.10"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/core": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-            "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/ansi": "^1.0.2",
-                "@inquirer/figures": "^1.0.15",
-                "@inquirer/type": "^3.0.10",
-                "cli-width": "^4.1.0",
-                "mute-stream": "^2.0.0",
-                "signal-exit": "^4.1.0",
-                "wrap-ansi": "^6.2.0",
-                "yoctocolors-cjs": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/core/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@inquirer/figures": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/type": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-            "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@internationalized/date": {
-            "version": "3.12.1",
-            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
-            "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            }
-        },
-        "node_modules/@internationalized/message": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
-            "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0",
-                "intl-messageformat": "^10.1.0"
-            }
-        },
-        "node_modules/@internationalized/number": {
-            "version": "3.6.6",
-            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
-            "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            }
-        },
-        "node_modules/@internationalized/string": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
-            "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            }
-        },
-        "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
-        "node_modules/@jridgewell/remapping": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@laravel/echo-react": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@laravel/echo-react/-/echo-react-2.3.1.tgz",
-            "integrity": "sha512-rNPB1BOyJwz+CqtUR6/ImNebE3v1dhRJarZMO8k7gsc9Wji0bht3ASEQ04RhSArLKULeM/UdZmyPCp2NtkOp5Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "peerDependencies": {
-                "pusher-js": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "socket.io-client": "*"
-            }
-        },
-        "node_modules/@laravel/vite-plugin-wayfinder": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@laravel/vite-plugin-wayfinder/-/vite-plugin-wayfinder-0.1.7.tgz",
-            "integrity": "sha512-yZYIr1iwuCQ7LFI+GsJk9vacw1HWMp3ZlDlW0pdfz3zXyKeu4US7oH79KmQQ031L0cYaSyaUMo/Ha1D4BosKqw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.27.1",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-            "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@hono/node-server": "^1.19.9",
-                "ajv": "^8.17.1",
-                "ajv-formats": "^3.0.1",
-                "content-type": "^1.0.5",
-                "cors": "^2.8.5",
-                "cross-spawn": "^7.0.5",
-                "eventsource": "^3.0.2",
-                "eventsource-parser": "^3.0.0",
-                "express": "^5.2.1",
-                "express-rate-limit": "^8.2.1",
-                "hono": "^4.11.4",
-                "jose": "^6.1.3",
-                "json-schema-typed": "^8.0.2",
-                "pkce-challenge": "^5.0.0",
-                "raw-body": "^3.0.0",
-                "zod": "^3.25 || ^4.0",
-                "zod-to-json-schema": "^3.25.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@cfworker/json-schema": "^4.1.1",
-                "zod": "^3.25 || ^4.0"
-            },
-            "peerDependenciesMeta": {
-                "@cfworker/json-schema": {
-                    "optional": true
-                },
-                "zod": {
-                    "optional": false
-                }
-            }
-        },
-        "node_modules/@mswjs/interceptors": {
-            "version": "0.41.3",
-            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-            "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@open-draft/deferred-promise": "^2.2.0",
-                "@open-draft/logger": "^0.3.0",
-                "@open-draft/until": "^2.0.0",
-                "is-node-process": "^1.2.0",
-                "outvariant": "^1.4.3",
-                "strict-event-emitter": "^0.5.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@noble/ciphers": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-            "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@noble/curves": {
-            "version": "1.9.7",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "1.8.0"
-            },
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@noble/hashes": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@open-draft/deferred-promise": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-            "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@open-draft/logger": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-            "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-node-process": "^1.2.0",
-                "outvariant": "^1.4.0"
-            }
-        },
-        "node_modules/@open-draft/until": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-            "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@react-aria/i18n": {
-            "version": "3.12.16",
-            "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.16.tgz",
-            "integrity": "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@internationalized/date": "^3.12.0",
-                "@internationalized/message": "^3.1.8",
-                "@internationalized/number": "^3.6.5",
-                "@internationalized/string": "^3.2.7",
-                "@react-aria/ssr": "^3.9.10",
-                "@react-aria/utils": "^3.33.1",
-                "@react-types/shared": "^3.33.1",
-                "@swc/helpers": "^0.5.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/@react-aria/ssr": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-            "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            },
-            "engines": {
-                "node": ">= 12"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/@react-aria/utils": {
-            "version": "3.33.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
-            "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@react-aria/ssr": "^3.9.10",
-                "@react-stately/flags": "^3.1.2",
-                "@react-stately/utils": "^3.11.0",
-                "@react-types/shared": "^3.33.1",
-                "@swc/helpers": "^0.5.0",
-                "clsx": "^2.0.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/@react-stately/flags": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
-            "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            }
-        },
-        "node_modules/@react-stately/utils": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
-            "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/@react-types/shared": {
-            "version": "3.34.0",
-            "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
-            "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/@reduxjs/toolkit": {
-            "version": "2.11.2",
-            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-            "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@standard-schema/spec": "^1.0.0",
-                "@standard-schema/utils": "^0.3.0",
-                "immer": "^11.0.0",
-                "redux": "^5.0.1",
-                "redux-thunk": "^3.1.0",
-                "reselect": "^5.1.0"
-            },
-            "peerDependencies": {
-                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "react-redux": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@reduxjs/toolkit/node_modules/immer": {
-            "version": "11.1.4",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-            "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/immer"
-            }
-        },
-        "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-beta.27",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
-        },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@sec-ant/readable-stream": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@sindresorhus/merge-streams": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@socket.io/component-emitter": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@standard-schema/spec": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "license": "MIT"
-        },
-        "node_modules/@standard-schema/utils": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-            "license": "MIT"
-        },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
-            "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/@tailwindcss/node": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-            "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.4",
-                "enhanced-resolve": "^5.18.3",
-                "jiti": "^2.6.1",
-                "lightningcss": "1.30.2",
-                "magic-string": "^0.30.21",
-                "source-map-js": "^1.2.1",
-                "tailwindcss": "4.1.18"
-            }
-        },
-        "node_modules/@tailwindcss/oxide": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-            "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            },
-            "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.1.18",
-                "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-                "@tailwindcss/oxide-darwin-x64": "4.1.18",
-                "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-                "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-                "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-            "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-            "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-            "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-            "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-            "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-            "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-            "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-            "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-            "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-            "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
-            "bundleDependencies": [
-                "@napi-rs/wasm-runtime",
-                "@emnapi/core",
-                "@emnapi/runtime",
-                "@tybys/wasm-util",
-                "@emnapi/wasi-threads",
-                "tslib"
-            ],
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
-                "@emnapi/wasi-threads": "^1.1.0",
-                "@napi-rs/wasm-runtime": "^1.1.0",
-                "@tybys/wasm-util": "^0.10.1",
-                "tslib": "^2.4.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-            "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-            "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@tailwindcss/vite": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
-            "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tailwindcss/node": "4.1.18",
-                "@tailwindcss/oxide": "4.1.18",
-                "tailwindcss": "4.1.18"
-            },
-            "peerDependencies": {
-                "vite": "^5.2.0 || ^6 || ^7"
-            }
-        },
-        "node_modules/@ts-morph/common": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
-            "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-glob": "^3.3.3",
-                "minimatch": "^10.0.1",
-                "path-browserify": "^1.0.1"
-            }
-        },
-        "node_modules/@ts-morph/common/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@ts-morph/common/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@types/babel__core": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.20.7",
-                "@babel/types": "^7.20.7",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
-            }
-        },
-        "node_modules/@types/babel__generator": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__traverse": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.28.2"
-            }
-        },
-        "node_modules/@types/d3-array": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-color": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-ease": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-interpolate": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-color": "*"
-            }
-        },
-        "node_modules/@types/d3-path": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-scale": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-time": "*"
-            }
-        },
-        "node_modules/@types/d3-shape": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-path": "*"
-            }
-        },
-        "node_modules/@types/d3-time": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-timer": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "license": "MIT"
-        },
-        "node_modules/@types/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/lodash-es": {
-            "version": "4.17.12",
-            "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-            "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/node": {
-            "version": "22.19.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-            "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/@types/react": {
-            "version": "19.2.14",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "csstype": "^3.2.2"
-            }
-        },
-        "node_modules/@types/react-dom": {
-            "version": "19.2.3",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "^19.2.0"
-            }
-        },
-        "node_modules/@types/statuses": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-            "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/use-sync-external-store": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/validate-npm-package-name": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
-            "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@vitejs/plugin-react": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.28.0",
-                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-                "@rolldown/pluginutils": "1.0.0-beta.27",
-                "@types/babel__core": "^7.20.5",
-                "react-refresh": "^0.17.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "peerDependencies": {
-                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-            }
-        },
-        "node_modules/accepts": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-types": "^3.0.0",
-                "negotiator": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/accepts/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/accepts/node_modules/mime-types": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "^1.54.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/ansis": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-            "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "license": "Python-2.0"
-        },
-        "node_modules/aria-hidden": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-            "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/ast-types": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
-            "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/autoprefixer": {
-            "version": "10.4.24",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
-            "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "browserslist": "^4.28.1",
-                "caniuse-lite": "^1.0.30001766",
-                "fraction.js": "^5.3.4",
-                "picocolors": "^1.1.1",
-                "postcss-value-parser": "^4.2.0"
-            },
-            "bin": {
-                "autoprefixer": "bin/autoprefixer"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            },
-            "peerDependencies": {
-                "postcss": "^8.1.0"
-            }
-        },
-        "node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/baseline-browser-mapping": {
-            "version": "2.9.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-            "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
-            }
-        },
-        "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
-                "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
-                "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            },
-            "engines": {
-                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/bundle-name": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "run-applescript": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/caniuse-lite": {
-            "version": "1.0.30001770",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-            "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "CC-BY-4.0"
-        },
-        "node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/cli-cursor": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "restore-cursor": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-spinners": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-width": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/client-only": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-            "license": "MIT"
-        },
-        "node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/clsx": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/code-block-writer": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-            "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/commander": {
-            "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/content-disposition": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/content-type": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/cookie-signature": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.6.0"
-            }
-        },
-        "node_modules/cors": {
-            "version": "2.8.6",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "object-assign": "^4",
-                "vary": "^1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/cosmiconfig": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-            "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "env-paths": "^2.2.1",
-                "import-fresh": "^3.3.0",
-                "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.5"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/cross-spawn": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/cssesc": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "cssesc": "bin/cssesc"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/csstype": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "devOptional": true,
-            "license": "MIT"
-        },
-        "node_modules/d3-array": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-            "license": "ISC",
-            "dependencies": {
-                "internmap": "1 - 2"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-ease": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-format": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-            "license": "ISC",
-            "dependencies": {
-                "d3-color": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-            "license": "ISC",
-            "dependencies": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-shape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-            "license": "ISC",
-            "dependencies": {
-                "d3-path": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-time": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-            "license": "ISC",
-            "dependencies": {
-                "d3-array": "2 - 3"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-time-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-            "license": "ISC",
-            "dependencies": {
-                "d3-time": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-timer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/data-uri-to-buffer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/decimal.js": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-            "license": "MIT"
-        },
-        "node_modules/decimal.js-light": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-            "license": "MIT"
-        },
-        "node_modules/dedent": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-            "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "babel-plugin-macros": "^3.1.0"
-            },
-            "peerDependenciesMeta": {
-                "babel-plugin-macros": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/default-browser": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bundle-name": "^4.1.0",
-                "default-browser-id": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "devOptional": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/diff": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-            "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "17.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-            "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/eciesjs": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
-            "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ecies/ciphers": "^0.2.5",
-                "@noble/ciphers": "^1.3.0",
-                "@noble/curves": "^1.9.7",
-                "@noble/hashes": "^1.8.0"
-            },
-            "engines": {
-                "bun": ">=1",
-                "deno": ">=2",
-                "node": ">=16"
-            }
-        },
-        "node_modules/ee-first": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/electron-to-chromium": {
-            "version": "1.5.286",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-            "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/encodeurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/engine.io-client": {
-            "version": "6.6.4",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-            "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.4.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.18.3",
-                "xmlhttprequest-ssl": "~2.1.1"
-            }
-        },
-        "node_modules/engine.io-parser": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/enhanced-resolve": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-            "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.0"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/error-ex": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-toolkit": {
-            "version": "1.45.1",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-            "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
-            "license": "MIT",
-            "workspaces": [
-                "docs",
-                "benchmarks"
-            ]
-        },
-        "node_modules/esbuild": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.12",
-                "@esbuild/android-arm": "0.25.12",
-                "@esbuild/android-arm64": "0.25.12",
-                "@esbuild/android-x64": "0.25.12",
-                "@esbuild/darwin-arm64": "0.25.12",
-                "@esbuild/darwin-x64": "0.25.12",
-                "@esbuild/freebsd-arm64": "0.25.12",
-                "@esbuild/freebsd-x64": "0.25.12",
-                "@esbuild/linux-arm": "0.25.12",
-                "@esbuild/linux-arm64": "0.25.12",
-                "@esbuild/linux-ia32": "0.25.12",
-                "@esbuild/linux-loong64": "0.25.12",
-                "@esbuild/linux-mips64el": "0.25.12",
-                "@esbuild/linux-ppc64": "0.25.12",
-                "@esbuild/linux-riscv64": "0.25.12",
-                "@esbuild/linux-s390x": "0.25.12",
-                "@esbuild/linux-x64": "0.25.12",
-                "@esbuild/netbsd-arm64": "0.25.12",
-                "@esbuild/netbsd-x64": "0.25.12",
-                "@esbuild/openbsd-arm64": "0.25.12",
-                "@esbuild/openbsd-x64": "0.25.12",
-                "@esbuild/openharmony-arm64": "0.25.12",
-                "@esbuild/sunos-x64": "0.25.12",
-                "@esbuild/win32-arm64": "0.25.12",
-                "@esbuild/win32-ia32": "0.25.12",
-                "@esbuild/win32-x64": "0.25.12"
-            }
-        },
-        "node_modules/escalade": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/escape-html": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/etag": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/eventemitter3": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-            "license": "MIT"
-        },
-        "node_modules/eventsource": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eventsource-parser": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/eventsource-parser": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/express": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "^2.0.0",
-                "body-parser": "^2.2.1",
-                "content-disposition": "^1.0.0",
-                "content-type": "^1.0.5",
-                "cookie": "^0.7.1",
-                "cookie-signature": "^1.2.1",
-                "debug": "^4.4.0",
-                "depd": "^2.0.0",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "etag": "^1.8.1",
-                "finalhandler": "^2.1.0",
-                "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "merge-descriptors": "^2.0.0",
-                "mime-types": "^3.0.0",
-                "on-finished": "^2.4.1",
-                "once": "^1.4.0",
-                "parseurl": "^1.3.3",
-                "proxy-addr": "^2.0.7",
-                "qs": "^6.14.0",
-                "range-parser": "^1.2.1",
-                "router": "^2.2.0",
-                "send": "^1.1.0",
-                "serve-static": "^2.2.0",
-                "statuses": "^2.0.1",
-                "type-is": "^2.0.1",
-                "vary": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/express-rate-limit": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-            "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ip-address": "10.1.0"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/express-rate-limit"
-            },
-            "peerDependencies": {
-                "express": ">= 4.11"
-            }
-        },
-        "node_modules/express/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/express/node_modules/mime-types": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "^1.54.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/fastq": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/fetch-blob": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
-        },
-        "node_modules/figures": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-unicode-supported": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/finalhandler": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.0",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "on-finished": "^2.4.1",
-                "parseurl": "^1.3.3",
-                "statuses": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fetch-blob": "^3.1.2"
-            },
-            "engines": {
-                "node": ">=12.20.0"
-            }
-        },
-        "node_modules/forwarded": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/fraction.js": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/rawify"
-            }
-        },
-        "node_modules/framer-motion": {
-            "version": "12.34.1",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.1.tgz",
-            "integrity": "sha512-kcZyNaYQfvE2LlH6+AyOaJAQV4rGp5XbzfhsZpiSZcwDMfZUHhuxLWeyRzf5I7jip3qKRpuimPA9pXXfr111kQ==",
-            "license": "MIT",
-            "dependencies": {
-                "motion-dom": "^12.34.1",
-                "motion-utils": "^12.29.2",
-                "tslib": "^2.4.0"
-            },
-            "peerDependencies": {
-                "@emotion/is-prop-valid": "*",
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/is-prop-valid": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/fresh": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "11.3.4",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-            "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/fuzzysort": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
-            "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/fzf": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
-            "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/gensync": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/get-east-asian-width": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-own-enumerable-keys": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
-            "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/graphql": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
-            "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/headers-polyfill": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-            "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/hono": {
-            "version": "4.12.8",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-            "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
-        "node_modules/http-errors": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "depd": "~2.0.0",
-                "inherits": "~2.0.4",
-                "setprototypeof": "~1.2.0",
-                "statuses": "~2.0.2",
-                "toidentifier": "~1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
-        "node_modules/husky": {
-            "version": "9.1.7",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "husky": "bin.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/typicode"
-            }
-        },
-        "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/immer": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/immer"
-            }
-        },
-        "node_modules/import-fresh": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/internmap": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/intl-messageformat": {
-            "version": "10.7.18",
-            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
-            "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@formatjs/ecma402-abstract": "2.3.6",
-                "@formatjs/fast-memoize": "2.2.7",
-                "@formatjs/icu-messageformat-parser": "2.11.4",
-                "tslib": "^2.8.0"
-            }
-        },
-        "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-in-ssh": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-            "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-interactive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-node-process": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-            "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
-            "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-plain-obj": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-promise": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/is-regexp": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-            "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-unicode-supported": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/jiti": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "devOptional": true,
-            "license": "MIT",
-            "bin": {
-                "jiti": "lib/jiti-cli.mjs"
-            }
-        },
-        "node_modules/jose": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
-            "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/panva"
-            }
-        },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/jsesc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/json-schema-typed": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/kleur": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/laravel-echo": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.3.1.tgz",
-            "integrity": "sha512-o6oD1oR+XklU9TO7OPGeLh/G9SjcZm+YrpSdGkOaAJf5HpXwZKt+wGgnULvKl5I8xUuUY/AAvqR24+y8suwZTA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "peerDependencies": {
-                "pusher-js": "*",
-                "socket.io-client": "*"
-            }
-        },
-        "node_modules/laravel-precognition": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
-            "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "axios": "^1.4.0",
-                "lodash-es": "^4.17.21"
-            }
-        },
-        "node_modules/laravel-vite-plugin": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.3.0.tgz",
-            "integrity": "sha512-P5qyG56YbYxM8OuYmK2OkhcKe0AksNVJUjq9LUZ5tOekU9fBn9LujYyctI4t9XoLjuMvHJXXpCoPntY1oKltuA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picocolors": "^1.0.0",
-                "vite-plugin-full-reload": "^1.1.0"
-            },
-            "bin": {
-                "clean-orphaned-assets": "bin/clean.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-            },
-            "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0"
-            }
-        },
-        "node_modules/lightningcss": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-            "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-            "devOptional": true,
-            "license": "MPL-2.0",
-            "dependencies": {
-                "detect-libc": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            },
-            "optionalDependencies": {
-                "lightningcss-android-arm64": "1.30.2",
-                "lightningcss-darwin-arm64": "1.30.2",
-                "lightningcss-darwin-x64": "1.30.2",
-                "lightningcss-freebsd-x64": "1.30.2",
-                "lightningcss-linux-arm-gnueabihf": "1.30.2",
-                "lightningcss-linux-arm64-gnu": "1.30.2",
-                "lightningcss-linux-arm64-musl": "1.30.2",
-                "lightningcss-linux-x64-gnu": "1.30.2",
-                "lightningcss-linux-x64-musl": "1.30.2",
-                "lightningcss-win32-arm64-msvc": "1.30.2",
-                "lightningcss-win32-x64-msvc": "1.30.2"
-            }
-        },
-        "node_modules/lightningcss-android-arm64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-            "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-            "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-x64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-            "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-            "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-            "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-            "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-            "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-            "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-            "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-            "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-            "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/log-symbols": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^5.3.0",
-                "is-unicode-supported": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/is-unicode-supported": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/magic-string": {
-            "version": "0.30.21",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/merge-descriptors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/mimic-function": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/motion": {
-            "version": "12.34.1",
-            "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.1.tgz",
-            "integrity": "sha512-N9RVNGn/NSo85OgHX1wGaUWHvReuQ7dZUwuQRhHyzY2wfVOvY3cEgn0Mw4NXOsXMHL/y7EYuzA+b59PYI6EejA==",
-            "license": "MIT",
-            "dependencies": {
-                "framer-motion": "^12.34.1",
-                "tslib": "^2.4.0"
-            },
-            "peerDependencies": {
-                "@emotion/is-prop-valid": "*",
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/is-prop-valid": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/motion-dom": {
-            "version": "12.34.1",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.1.tgz",
-            "integrity": "sha512-SC7ZC5dRcGwku2g7EsPvI4q/EzHumUbqsDNumBmZTLFg+goBO5LTJvDu9MAxx+0mtX4IA78B2be/A3aRjY0jnw==",
-            "license": "MIT",
-            "dependencies": {
-                "motion-utils": "^12.29.2"
-            }
-        },
-        "node_modules/motion-utils": {
-            "version": "12.29.2",
-            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
-            "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
-            "license": "MIT"
-        },
-        "node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
-        },
-        "node_modules/msw": {
-            "version": "2.12.10",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.10.tgz",
-            "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/confirm": "^5.0.0",
-                "@mswjs/interceptors": "^0.41.2",
-                "@open-draft/deferred-promise": "^2.2.0",
-                "@types/statuses": "^2.0.6",
-                "cookie": "^1.0.2",
-                "graphql": "^16.12.0",
-                "headers-polyfill": "^4.0.2",
-                "is-node-process": "^1.2.0",
-                "outvariant": "^1.4.3",
-                "path-to-regexp": "^6.3.0",
-                "picocolors": "^1.1.1",
-                "rettime": "^0.10.1",
-                "statuses": "^2.0.2",
-                "strict-event-emitter": "^0.5.1",
-                "tough-cookie": "^6.0.0",
-                "type-fest": "^5.2.0",
-                "until-async": "^3.0.2",
-                "yargs": "^17.7.2"
-            },
-            "bin": {
-                "msw": "cli/index.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mswjs"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.8.x"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/msw/node_modules/cookie": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/mute-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "deprecated": "Use your platform's native DOMException instead",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
-            }
-        },
-        "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-inspect": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-treeify": {
-            "version": "1.1.33",
-            "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-            "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/on-finished": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ee-first": "1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/open": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "default-browser": "^5.4.0",
-                "define-lazy-prop": "^3.0.0",
-                "is-in-ssh": "^1.0.0",
-                "is-inside-container": "^1.0.0",
-                "powershell-utils": "^0.1.0",
-                "wsl-utils": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ora": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^5.3.0",
-                "cli-cursor": "^5.0.0",
-                "cli-spinners": "^2.9.2",
-                "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^2.0.0",
-                "log-symbols": "^6.0.0",
-                "stdin-discarder": "^0.2.2",
-                "string-width": "^7.2.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/outvariant": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-            "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/package-manager-detector": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "callsites": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/parse-ms": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/parseurl": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/path-browserify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/path-to-regexp": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/picocolors": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "license": "ISC"
-        },
-        "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pkce-challenge": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.11",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-value-parser": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/powershell-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pretty-ms": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "parse-ms": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/prompts/node_modules/kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/proxy-addr": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "forwarded": "0.2.0",
-                "ipaddr.js": "1.9.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pusher-js": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0.tgz",
-            "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
-            "license": "MIT",
-            "dependencies": {
-                "tweetnacl": "^1.0.3"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/raw-body": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.7.0",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/react": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-aria": {
-            "version": "3.48.0",
-            "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
-            "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@internationalized/date": "^3.12.1",
-                "@internationalized/number": "^3.6.6",
-                "@internationalized/string": "^3.2.8",
-                "@react-types/shared": "^3.34.0",
-                "@swc/helpers": "^0.5.0",
-                "aria-hidden": "^1.2.3",
-                "clsx": "^2.0.0",
-                "react-stately": "3.46.0",
-                "use-sync-external-store": "^1.6.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/react-aria-components": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.17.0.tgz",
-            "integrity": "sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@internationalized/date": "^3.12.1",
-                "@react-types/shared": "^3.34.0",
-                "@swc/helpers": "^0.5.0",
-                "client-only": "^0.0.1",
-                "react-aria": "3.48.0",
-                "react-stately": "3.46.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.27.0"
-            },
-            "peerDependencies": {
-                "react": "^19.2.4"
-            }
-        },
-        "node_modules/react-is": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-            "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/react-redux": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/use-sync-external-store": "^0.0.6",
-                "use-sync-external-store": "^1.4.0"
-            },
-            "peerDependencies": {
-                "@types/react": "^18.2.25 || ^19",
-                "react": "^18.0 || ^19",
-                "redux": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "redux": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-refresh": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-            "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-stately": {
-            "version": "3.46.0",
-            "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
-            "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@internationalized/date": "^3.12.1",
-                "@internationalized/number": "^3.6.6",
-                "@internationalized/string": "^3.2.8",
-                "@react-types/shared": "^3.34.0",
-                "@swc/helpers": "^0.5.0",
-                "use-sync-external-store": "^1.6.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-            }
-        },
-        "node_modules/recast": {
-            "version": "0.23.11",
-            "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
-            "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ast-types": "^0.16.1",
-                "esprima": "~4.0.0",
-                "source-map": "~0.6.1",
-                "tiny-invariant": "^1.3.3",
-                "tslib": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/recharts": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
-            "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
-            "license": "MIT",
-            "workspaces": [
-                "www"
-            ],
-            "dependencies": {
-                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-                "clsx": "^2.1.1",
-                "decimal.js-light": "^2.5.1",
-                "es-toolkit": "^1.39.3",
-                "eventemitter3": "^5.0.1",
-                "immer": "^10.1.1",
-                "react-redux": "8.x.x || 9.x.x",
-                "reselect": "5.1.1",
-                "tiny-invariant": "^1.3.3",
-                "use-sync-external-store": "^1.2.2",
-                "victory-vendor": "^37.0.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/redux": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
-        },
-        "node_modules/redux-thunk": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "redux": "^5.0.0"
-            }
-        },
-        "node_modules/require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/reselect": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-            "license": "MIT"
-        },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/restore-cursor": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "onetime": "^7.0.0",
-                "signal-exit": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/onetime": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-function": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rettime": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
-            "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/reusify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rollup": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "1.0.8"
-            },
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.57.1",
-                "@rollup/rollup-android-arm64": "4.57.1",
-                "@rollup/rollup-darwin-arm64": "4.57.1",
-                "@rollup/rollup-darwin-x64": "4.57.1",
-                "@rollup/rollup-freebsd-arm64": "4.57.1",
-                "@rollup/rollup-freebsd-x64": "4.57.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-                "@rollup/rollup-linux-arm64-musl": "4.57.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-                "@rollup/rollup-linux-loong64-musl": "4.57.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-                "@rollup/rollup-linux-x64-gnu": "4.57.1",
-                "@rollup/rollup-linux-x64-musl": "4.57.1",
-                "@rollup/rollup-openbsd-x64": "4.57.1",
-                "@rollup/rollup-openharmony-arm64": "4.57.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-                "@rollup/rollup-win32-x64-gnu": "4.57.1",
-                "@rollup/rollup-win32-x64-msvc": "4.57.1",
-                "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/router": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.0",
-                "depd": "^2.0.0",
-                "is-promise": "^4.0.0",
-                "parseurl": "^1.3.3",
-                "path-to-regexp": "^8.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/router/node_modules/path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/run-applescript": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/scheduler": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-            "license": "MIT"
-        },
-        "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/send": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.3",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "etag": "^1.8.1",
-                "fresh": "^2.0.0",
-                "http-errors": "^2.0.1",
-                "mime-types": "^3.0.2",
-                "ms": "^2.1.3",
-                "on-finished": "^2.4.1",
-                "range-parser": "^1.2.1",
-                "statuses": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/send/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/send/node_modules/mime-types": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "^1.54.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/serve-static": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "parseurl": "^1.3.3",
-                "send": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/shadcn": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.0.6.tgz",
-            "integrity": "sha512-20M3ZsQPas+0QLVzrfrya2V3nryQiIPQsnJaOJg+Ylk24GtJa1vXGOLB7xwKuvWoMzM0YSLuCaoibW/NuHdDyA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@antfu/ni": "^25.0.0",
-                "@babel/core": "^7.28.0",
-                "@babel/parser": "^7.28.0",
-                "@babel/plugin-transform-typescript": "^7.28.0",
-                "@babel/preset-typescript": "^7.27.1",
-                "@dotenvx/dotenvx": "^1.48.4",
-                "@modelcontextprotocol/sdk": "^1.26.0",
-                "@types/validate-npm-package-name": "^4.0.2",
-                "browserslist": "^4.26.2",
-                "commander": "^14.0.0",
-                "cosmiconfig": "^9.0.0",
-                "dedent": "^1.6.0",
-                "deepmerge": "^4.3.1",
-                "diff": "^8.0.2",
-                "execa": "^9.6.0",
-                "fast-glob": "^3.3.3",
-                "fs-extra": "^11.3.1",
-                "fuzzysort": "^3.1.0",
-                "https-proxy-agent": "^7.0.6",
-                "kleur": "^4.1.5",
-                "msw": "^2.10.4",
-                "node-fetch": "^3.3.2",
-                "open": "^11.0.0",
-                "ora": "^8.2.0",
-                "postcss": "^8.5.6",
-                "postcss-selector-parser": "^7.1.0",
-                "prompts": "^2.4.2",
-                "recast": "^0.23.11",
-                "stringify-object": "^5.0.0",
-                "tailwind-merge": "^3.0.1",
-                "ts-morph": "^26.0.0",
-                "tsconfig-paths": "^4.2.0",
-                "validate-npm-package-name": "^7.0.1",
-                "zod": "^3.24.1",
-                "zod-to-json-schema": "^3.24.6"
-            },
-            "bin": {
-                "shadcn": "dist/index.js"
-            }
-        },
-        "node_modules/shadcn/node_modules/execa": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "cross-spawn": "^7.0.6",
-                "figures": "^6.1.0",
-                "get-stream": "^9.0.0",
-                "human-signals": "^8.0.1",
-                "is-plain-obj": "^4.1.0",
-                "is-stream": "^4.0.1",
-                "npm-run-path": "^6.0.0",
-                "pretty-ms": "^9.2.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^4.0.0",
-                "yoctocolors": "^2.1.1"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/shadcn/node_modules/get-stream": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sec-ant/readable-stream": "^0.4.1",
-                "is-stream": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/shadcn/node_modules/human-signals": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "node_modules/shadcn/node_modules/is-stream": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/shadcn/node_modules/npm-run-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0",
-                "unicorn-magic": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/shadcn/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/shadcn/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/shadcn/node_modules/strip-final-newline": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-weakmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/socket.io-client": {
-            "version": "4.8.3",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
-            "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.4.1",
-                "engine.io-client": "~6.6.1",
-                "socket.io-parser": "~4.2.4"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-            "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.4.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/sonner": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
-            "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-                "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-js": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/statuses": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/stdin-discarder": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/strict-event-emitter": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-            "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stringify-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
-            "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "get-own-enumerable-keys": "^1.0.0",
-                "is-obj": "^3.0.0",
-                "is-regexp": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/yeoman/stringify-object?sponsor=1"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.2.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tagged-tag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-            "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/tailwind-merge": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-            "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/dcastil"
-            }
-        },
-        "node_modules/tailwind-variants": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-3.2.2.tgz",
-            "integrity": "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.x",
-                "pnpm": ">=7.x"
-            },
-            "peerDependencies": {
-                "tailwind-merge": ">=3.0.0",
-                "tailwindcss": "*"
-            },
-            "peerDependenciesMeta": {
-                "tailwind-merge": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/tailwindcss": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-            "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-            "license": "MIT"
-        },
-        "node_modules/tailwindcss-react-aria-components": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/tailwindcss-react-aria-components/-/tailwindcss-react-aria-components-2.0.1.tgz",
-            "integrity": "sha512-yTAfYv9BE/gKczS+b8UiFMqxnrEYKKNE6Y4vAWzGadkHGb4Yuawp0SHbZKkZJQgFvK0KjO3JpCq/0kzR5jJ9tw==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "tailwindcss": "^4.0.0"
-            }
-        },
-        "node_modules/tapable": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/tiny-invariant": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-            "license": "MIT"
-        },
-        "node_modules/tinyexec": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tldts": {
-            "version": "7.0.25",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
-            "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tldts-core": "^7.0.25"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
-            }
-        },
-        "node_modules/tldts-core": {
-            "version": "7.0.25",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
-            "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/toidentifier": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tldts": "^7.0.5"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/ts-morph": {
-            "version": "26.0.0",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
-            "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ts-morph/common": "~0.27.0",
-                "code-block-writer": "^13.0.3"
-            }
-        },
-        "node_modules/tsconfig-paths": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "json5": "^2.2.2",
-                "minimist": "^1.2.6",
-                "strip-bom": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
-        "node_modules/tw-animate-css": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-            "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Wombosvideo"
-            }
-        },
-        "node_modules/tweetnacl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-            "license": "Unlicense"
-        },
-        "node_modules/type-fest": {
-            "version": "5.4.4",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
-            "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "dependencies": {
-                "tagged-tag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "content-type": "^1.0.5",
-                "media-typer": "^1.1.0",
-                "mime-types": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/type-is/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/type-is/node_modules/mime-types": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "^1.54.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
-        "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT"
-        },
-        "node_modules/unicorn-magic": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/unpipe": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/until-async": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-            "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/kettanaito"
-            }
-        },
-        "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
-            },
-            "peerDependencies": {
-                "browserslist": ">= 4.21.0"
-            }
-        },
-        "node_modules/use-sync-external-store": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/validate-npm-package-name": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/vary": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/victory-vendor": {
-            "version": "37.3.6",
-            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-            "license": "MIT AND ISC",
-            "dependencies": {
-                "@types/d3-array": "^3.0.3",
-                "@types/d3-ease": "^3.0.0",
-                "@types/d3-interpolate": "^3.0.1",
-                "@types/d3-scale": "^4.0.2",
-                "@types/d3-shape": "^3.1.0",
-                "@types/d3-time": "^3.0.0",
-                "@types/d3-timer": "^3.0.0",
-                "d3-array": "^3.1.6",
-                "d3-ease": "^3.0.1",
-                "d3-interpolate": "^3.0.1",
-                "d3-scale": "^4.0.2",
-                "d3-shape": "^3.1.0",
-                "d3-time": "^3.0.0",
-                "d3-timer": "^3.0.1"
-            }
-        },
-        "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "jiti": ">=1.21.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite-plugin-full-reload": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
-            "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picocolors": "^1.0.0",
-                "picomatch": "^2.3.1"
-            }
-        },
-        "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/vite-plugin-run": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-run/-/vite-plugin-run-0.6.1.tgz",
-            "integrity": "sha512-mXEEQHWhk/OD8XuK7V517eDPnXS5OrzjGsihHihSbWNFXqEBy6WNkdLNIfPY1o86JLLRDVq3VeVus3YOTiJeGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@antfu/utils": "^0.7.10",
-                "debug": "^4.3.7",
-                "execa": "5.1.1",
-                "minimatch": "^9.0.5",
-                "picocolors": "^1.1.0"
-            }
-        },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/wsl-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-wsl": "^3.1.0",
-                "powershell-utils": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/xmlhttprequest-ssl": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yoctocolors": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yoctocolors-cjs": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-            "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.25.1",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-            "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-            "dev": true,
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.25 || ^4"
-            }
+  "name": "beacon",
+  "version": "1.5.6",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.5.6",
+      "dependencies": {
+        "@heroicons/react": "^2.2.0",
+        "@internationalized/date": "^3.12.0",
+        "@laravel/echo-react": "^2.3.1",
+        "@react-aria/i18n": "^3.12.16",
+        "@types/node": "^22.15.34",
+        "laravel-echo": "^2.3.1",
+        "motion": "^12.34.1",
+        "pusher-js": "^8.4.0",
+        "react": "^19.1.0",
+        "react-aria-components": "^1.17.0",
+        "react-dom": "^19.1.0",
+        "recharts": "^3.8.0",
+        "sonner": "^2.0.7",
+        "tailwindcss-react-aria-components": "^2.0.0",
+        "tw-animate-css": "^1.3.4",
+        "vite": "^6.3.5"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.0.6",
+        "@inertiajs/react": "^2.0.14",
+        "@laravel/vite-plugin-wayfinder": "^0.1.3",
+        "@tailwindcss/vite": "^4.1.11",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
+        "@vitejs/plugin-react": "^4.6.0",
+        "autoprefixer": "^10.4.21",
+        "axios": "^1.10.0",
+        "husky": "^9.1.7",
+        "jsdom": "^25.0.1",
+        "laravel-vite-plugin": "^1.3.0",
+        "shadcn": "^4.0.6",
+        "tailwind-merge": "^3.5.0",
+        "tailwind-variants": "^3.2.2",
+        "tailwindcss": "^4.1.11",
+        "typescript": "^5.8.3",
+        "vite-plugin-run": "^0.6.1",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@antfu/ni": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
+      "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansis": "^4.0.0",
+        "fzf": "^0.5.2",
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "bin": {
+        "na": "bin/na.mjs",
+        "nci": "bin/nci.mjs",
+        "ni": "bin/ni.mjs",
+        "nlx": "bin/nlx.mjs",
+        "nr": "bin/nr.mjs",
+        "nun": "bin/nun.mjs",
+        "nup": "bin/nup.mjs"
+      }
+    },
+    "node_modules/@antfu/utils": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
+      "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.6.tgz",
+      "integrity": "sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.0.6",
+        "@biomejs/cli-darwin-x64": "2.0.6",
+        "@biomejs/cli-linux-arm64": "2.0.6",
+        "@biomejs/cli-linux-arm64-musl": "2.0.6",
+        "@biomejs/cli-linux-x64": "2.0.6",
+        "@biomejs/cli-linux-x64-musl": "2.0.6",
+        "@biomejs/cli-win32-arm64": "2.0.6",
+        "@biomejs/cli-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.6.tgz",
+      "integrity": "sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.6.tgz",
+      "integrity": "sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
         }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.55.1.tgz",
+      "integrity": "sha512-WEuKyoe9CA7dfcFBnNbL0ndbCNcptaEYBygfFo9X1qEG+HD7xku4CYIplw6sbAHJavesZWbVBHeRSpvri0eKqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "dotenv": "^17.2.1",
+        "eciesjs": "^0.4.10",
+        "execa": "^5.1.1",
+        "fdir": "^6.2.0",
+        "ignore": "^5.3.0",
+        "object-treeify": "1.1.33",
+        "picomatch": "^4.0.2",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "dotenvx": "src/cli/dotenvx.js"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@ecies/ciphers": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
+      "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2",
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inertiajs/core": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.15.tgz",
+      "integrity": "sha512-C/x5w2/VhPpzfCg7SCtOxRrC8yKM7zIMvwpberMLrvSLMqPqGTFxYTJH+0E//G03RXzb+Q3+eatepbSq6tpZGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash-es": "^4.17.12",
+        "axios": "^1.13.5",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23",
+        "qs": "^6.14.2"
+      }
+    },
+    "node_modules/@inertiajs/react": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.3.15.tgz",
+      "integrity": "sha512-/n1xNRxbRqjGFytYKpAbGC/MB8ETEwY9CHkVAmF6Q2GnC3ByQMZUwKuMyI5oyFb6PxTxWDxfl5poqmajw6XnEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inertiajs/core": "2.3.15",
+        "@types/lodash-es": "^4.17.12",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
+      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
+      "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@laravel/echo-react": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@laravel/echo-react/-/echo-react-2.3.1.tgz",
+      "integrity": "sha512-rNPB1BOyJwz+CqtUR6/ImNebE3v1dhRJarZMO8k7gsc9Wji0bht3ASEQ04RhSArLKULeM/UdZmyPCp2NtkOp5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "pusher-js": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "socket.io-client": "*"
+      }
+    },
+    "node_modules/@laravel/vite-plugin-wayfinder": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@laravel/vite-plugin-wayfinder/-/vite-plugin-wayfinder-0.1.7.tgz",
+      "integrity": "sha512-yZYIr1iwuCQ7LFI+GsJk9vacw1HWMp3ZlDlW0pdfz3zXyKeu4US7oH79KmQQ031L0cYaSyaUMo/Ha1D4BosKqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.16.tgz",
+      "integrity": "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
+      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
+      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
+      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-x64": "4.1.18",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
+      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
+      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
+      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
+      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
+      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
+      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
+      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
+      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
+      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
+      "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.1.18",
+        "@tailwindcss/oxide": "4.1.18",
+        "tailwindcss": "4.1.18"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
+      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/validate-npm-package-name": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
+      "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.24",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
+      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001766",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eciesjs": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
+      "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ecies/ciphers": "^0.2.5",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0"
+      },
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2",
+        "node": ">=16"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.34.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.1.tgz",
+      "integrity": "sha512-kcZyNaYQfvE2LlH6+AyOaJAQV4rGp5XbzfhsZpiSZcwDMfZUHhuxLWeyRzf5I7jip3qKRpuimPA9pXXfr111kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.1",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fzf": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
+      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-own-enumerable-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
+      "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
+      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
+      "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/laravel-echo": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.3.1.tgz",
+      "integrity": "sha512-o6oD1oR+XklU9TO7OPGeLh/G9SjcZm+YrpSdGkOaAJf5HpXwZKt+wGgnULvKl5I8xUuUY/AAvqR24+y8suwZTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "pusher-js": "*",
+        "socket.io-client": "*"
+      }
+    },
+    "node_modules/laravel-precognition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
+      "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.4.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/laravel-vite-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.3.0.tgz",
+      "integrity": "sha512-P5qyG56YbYxM8OuYmK2OkhcKe0AksNVJUjq9LUZ5tOekU9fBn9LujYyctI4t9XoLjuMvHJXXpCoPntY1oKltuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "vite-plugin-full-reload": "^1.1.0"
+      },
+      "bin": {
+        "clean-orphaned-assets": "bin/clean.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/motion": {
+      "version": "12.34.1",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.1.tgz",
+      "integrity": "sha512-N9RVNGn/NSo85OgHX1wGaUWHvReuQ7dZUwuQRhHyzY2wfVOvY3cEgn0Mw4NXOsXMHL/y7EYuzA+b59PYI6EejA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.34.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.1.tgz",
+      "integrity": "sha512-SC7ZC5dRcGwku2g7EsPvI4q/EzHumUbqsDNumBmZTLFg+goBO5LTJvDu9MAxx+0mtX4IA78B2be/A3aRjY0jnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.12.10",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.10.tgz",
+      "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-treeify": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pusher-js": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0.tgz",
+      "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
+      "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.46.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.17.0.tgz",
+      "integrity": "sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "3.48.0",
+        "react-stately": "3.46.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
+      "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shadcn": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.0.6.tgz",
+      "integrity": "sha512-20M3ZsQPas+0QLVzrfrya2V3nryQiIPQsnJaOJg+Ylk24GtJa1vXGOLB7xwKuvWoMzM0YSLuCaoibW/NuHdDyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/ni": "^25.0.0",
+        "@babel/core": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/plugin-transform-typescript": "^7.28.0",
+        "@babel/preset-typescript": "^7.27.1",
+        "@dotenvx/dotenvx": "^1.48.4",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@types/validate-npm-package-name": "^4.0.2",
+        "browserslist": "^4.26.2",
+        "commander": "^14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "dedent": "^1.6.0",
+        "deepmerge": "^4.3.1",
+        "diff": "^8.0.2",
+        "execa": "^9.6.0",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11.3.1",
+        "fuzzysort": "^3.1.0",
+        "https-proxy-agent": "^7.0.6",
+        "kleur": "^4.1.5",
+        "msw": "^2.10.4",
+        "node-fetch": "^3.3.2",
+        "open": "^11.0.0",
+        "ora": "^8.2.0",
+        "postcss": "^8.5.6",
+        "postcss-selector-parser": "^7.1.0",
+        "prompts": "^2.4.2",
+        "recast": "^0.23.11",
+        "stringify-object": "^5.0.0",
+        "tailwind-merge": "^3.0.1",
+        "ts-morph": "^26.0.0",
+        "tsconfig-paths": "^4.2.0",
+        "validate-npm-package-name": "^7.0.1",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "shadcn": "dist/index.js"
+      }
+    },
+    "node_modules/shadcn/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/shadcn/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shadcn/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/shadcn/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shadcn/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shadcn/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shadcn/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shadcn/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
+      "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-keys": "^1.0.0",
+        "is-obj": "^3.0.0",
+        "is-regexp": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/stringify-object?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwind-variants": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-3.2.2.tgz",
+      "integrity": "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.x",
+        "pnpm": ">=7.x"
+      },
+      "peerDependencies": {
+        "tailwind-merge": ">=3.0.0",
+        "tailwindcss": "*"
+      },
+      "peerDependenciesMeta": {
+        "tailwind-merge": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss-react-aria-components": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss-react-aria-components/-/tailwindcss-react-aria-components-2.0.1.tgz",
+      "integrity": "sha512-yTAfYv9BE/gKczS+b8UiFMqxnrEYKKNE6Y4vAWzGadkHGb4Yuawp0SHbZKkZJQgFvK0KjO3JpCq/0kzR5jJ9tw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "tailwindcss": "^4.0.0"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
+      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.27.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-full-reload": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
+      "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-plugin-run": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-run/-/vite-plugin-run-0.6.1.tgz",
+      "integrity": "sha512-mXEEQHWhk/OD8XuK7V517eDPnXS5OrzjGsihHihSbWNFXqEBy6WNkdLNIfPY1o86JLLRDVq3VeVus3YOTiJeGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/utils": "^0.7.10",
+        "debug": "^4.3.7",
+        "execa": "5.1.1",
+        "minimatch": "^9.0.5",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,26 +9,32 @@
     "format": "biome format --write resources && biome lint --fix resources",
     "lint": "biome lint --fix resources",
     "preview": "tsc && npm run build:ssr && php artisan inertia:start-ssr",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:js": "vitest run",
+    "test:js:watch": "vitest"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
     "@inertiajs/react": "^2.0.14",
     "@laravel/vite-plugin-wayfinder": "^0.1.3",
     "@tailwindcss/vite": "^4.1.11",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.21",
     "axios": "^1.10.0",
     "husky": "^9.1.7",
+    "jsdom": "^25.0.1",
     "laravel-vite-plugin": "^1.3.0",
     "shadcn": "^4.0.6",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3",
-    "vite-plugin-run": "^0.6.1"
+    "vite-plugin-run": "^0.6.1",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -176,7 +176,7 @@
     --chart-4: #8a8170;
     --chart-5: #5a5448;
 
-    --radius-lg: 0.125rem;
+    --radius-lg: 0.65rem;
     --radius-xs: calc(var(--radius-lg) * 0.5);
     --radius-sm: calc(var(--radius-lg) * 0.75);
     --radius-md: calc(var(--radius-lg) * 0.9);

--- a/resources/js/components/monitor-realtime-provider.tsx
+++ b/resources/js/components/monitor-realtime-provider.tsx
@@ -1,0 +1,75 @@
+import { usePage } from "@inertiajs/react"
+import { useEcho } from "@laravel/echo-react"
+import { useCallback, useEffect } from "react"
+import {
+  type CheckingPayload,
+  type HeartbeatPayload,
+  handleChecking,
+  handleHeartbeat,
+  handleStatusChanged,
+  hydrate,
+  type StatusChangedPayload,
+} from "@/stores/monitor-realtime"
+import type { Monitor } from "@/types/monitor"
+import type { SharedData, SidebarMonitor } from "@/types/shared"
+
+function sidebarToMonitor(s: SidebarMonitor): Monitor {
+  return {
+    id: s.id,
+    user_id: 0,
+    monitor_group_id: null,
+    name: s.name,
+    type: s.type,
+    url: s.url,
+    host: s.host,
+    port: s.port,
+    dns_record_type: null,
+    method: "GET",
+    body: null,
+    headers: null,
+    accepted_status_codes: null,
+    interval: 60,
+    timeout: 30,
+    retry_count: 0,
+    status: s.status,
+    is_active: true,
+    push_token: null,
+    ssl_monitoring_enabled: false,
+    ssl_expiry_notification_days: null,
+    last_checked_at: null,
+    next_check_at: null,
+    created_at: "",
+    updated_at: "",
+    heartbeats: [],
+  }
+}
+
+export function MonitorRealtimeProvider() {
+  const { auth, sidebarMonitors } = usePage<SharedData>().props
+  const userId = auth?.user?.id
+
+  useEffect(() => {
+    if (!sidebarMonitors || sidebarMonitors.length === 0) {
+      return
+    }
+    hydrate(sidebarMonitors.map(sidebarToMonitor))
+  }, [sidebarMonitors])
+
+  const onHeartbeat = useCallback((payload: HeartbeatPayload) => {
+    handleHeartbeat(payload)
+  }, [])
+
+  const onStatusChanged = useCallback((payload: StatusChangedPayload) => {
+    handleStatusChanged(payload)
+  }, [])
+
+  const onChecking = useCallback((payload: CheckingPayload) => {
+    handleChecking(payload)
+  }, [])
+
+  useEcho(`monitors.${userId}`, ".HeartbeatRecorded", onHeartbeat)
+  useEcho(`monitors.${userId}`, ".MonitorStatusChanged", onStatusChanged)
+  useEcho(`monitors.${userId}`, ".MonitorChecking", onChecking)
+
+  return null
+}

--- a/resources/js/components/monitor-realtime-provider.tsx
+++ b/resources/js/components/monitor-realtime-provider.tsx
@@ -2,15 +2,17 @@ import { usePage } from "@inertiajs/react"
 import { useEcho } from "@laravel/echo-react"
 import { useCallback, useEffect } from "react"
 import {
-  type CheckingPayload,
-  type HeartbeatPayload,
   handleChecking,
   handleHeartbeat,
   handleStatusChanged,
   hydrate,
-  type StatusChangedPayload,
 } from "@/stores/monitor-realtime"
-import type { Monitor } from "@/types/monitor"
+import type {
+  CheckingPayload,
+  HeartbeatPayload,
+  Monitor,
+  StatusChangedPayload,
+} from "@/types/monitor"
 import type { SharedData, SidebarMonitor } from "@/types/shared"
 
 function sidebarToMonitor(s: SidebarMonitor): Monitor {

--- a/resources/js/components/monitor-realtime-provider.tsx
+++ b/resources/js/components/monitor-realtime-provider.tsx
@@ -2,6 +2,7 @@ import { usePage } from "@inertiajs/react"
 import { useEcho } from "@laravel/echo-react"
 import { useCallback, useEffect } from "react"
 import {
+  clear,
   handleChecking,
   handleHeartbeat,
   handleStatusChanged,
@@ -52,6 +53,7 @@ export function MonitorRealtimeProvider() {
 
   useEffect(() => {
     if (!sidebarMonitors || sidebarMonitors.length === 0) {
+      clear()
       return
     }
     hydrate(sidebarMonitors.map(sidebarToMonitor))

--- a/resources/js/layouts/app-layout.tsx
+++ b/resources/js/layouts/app-layout.tsx
@@ -1,11 +1,13 @@
-import { Flash } from "@/components/flash"
-import { AppSidebar } from "@/layouts/app-sidebar"
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import type { PropsWithChildren } from "react"
+import { Flash } from "@/components/flash"
+import { MonitorRealtimeProvider } from "@/components/monitor-realtime-provider"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { AppSidebar } from "@/layouts/app-sidebar"
 
 export default function AppLayout({ children }: PropsWithChildren) {
   return (
     <SidebarProvider>
+      <MonitorRealtimeProvider />
       <AppSidebar intent="float" collapsible="dock" />
       <SidebarInset>
         <Flash />

--- a/resources/js/layouts/app-sidebar.tsx
+++ b/resources/js/layouts/app-sidebar.tsx
@@ -1,30 +1,3 @@
-import { router, usePage } from "@inertiajs/react"
-import { useEcho } from "@laravel/echo-react"
-import { useCallback, useEffect, useState } from "react"
-import { Avatar } from "@/components/ui/avatar"
-import { Logo } from "@/components/logo"
-import type { SharedData, SidebarMonitor } from "@/types/shared"
-import { Link } from "@/components/ui/link"
-import { MonitorCommandPalette } from "@/components/monitor-command-palette"
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarItem,
-  SidebarLabel,
-  SidebarSection,
-} from "@/components/ui/sidebar"
-import {
-  Menu,
-  MenuContent,
-  MenuItem,
-  MenuLabel,
-  MenuSection,
-  MenuSeparator,
-  MenuHeader,
-} from "@/components/ui/menu"
-import { Button } from "@/components/ui/button"
 import {
   ArrowRightEndOnRectangleIcon,
   ArrowRightStartOnRectangleIcon,
@@ -36,6 +9,33 @@ import {
   UserPlusIcon,
   WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline"
+import { router, usePage } from "@inertiajs/react"
+import { useEffect, useMemo, useState } from "react"
+import { Logo } from "@/components/logo"
+import { MonitorCommandPalette } from "@/components/monitor-command-palette"
+import { Avatar } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Link } from "@/components/ui/link"
+import {
+  Menu,
+  MenuContent,
+  MenuHeader,
+  MenuItem,
+  MenuLabel,
+  MenuSection,
+  MenuSeparator,
+} from "@/components/ui/menu"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarItem,
+  SidebarLabel,
+  SidebarSection,
+} from "@/components/ui/sidebar"
+import { useMonitors } from "@/stores/monitor-realtime"
+import type { SharedData, SidebarMonitor } from "@/types/shared"
 
 const statusDot: Record<string, string> = {
   up: "bg-success",
@@ -52,26 +52,27 @@ const secondaryNav = [
   { name: "Settings", href: "/settings", icon: Cog6ToothIcon },
 ]
 
-interface HeartbeatPayload {
-  monitorId: number
-  monitorStatus: string
-}
-
-interface StatusChangedPayload {
-  monitorId: number
-  newStatus: string
-}
-
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const page = usePage()
   const { auth, currentTeam, teams, sidebarMonitors: initialMonitors } = usePage<SharedData>().props
 
-  const [monitors, setMonitors] = useState<SidebarMonitor[]>(initialMonitors ?? [])
-  const [paletteOpen, setPaletteOpen] = useState(false)
+  const storeMonitors = useMonitors()
+  const monitors = useMemo<SidebarMonitor[]>(() => {
+    if (storeMonitors.length > 0) {
+      return storeMonitors.map((m) => ({
+        id: m.id,
+        name: m.name,
+        status: m.status,
+        type: m.type,
+        url: m.url,
+        host: m.host,
+        port: m.port,
+      }))
+    }
+    return initialMonitors ?? []
+  }, [storeMonitors, initialMonitors])
 
-  useEffect(() => {
-    setMonitors(initialMonitors ?? [])
-  }, [initialMonitors])
+  const [paletteOpen, setPaletteOpen] = useState(false)
   const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
 
   useEffect(() => {
@@ -84,29 +85,6 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
   }, [])
-
-  const handleHeartbeat = useCallback((payload: HeartbeatPayload) => {
-    setMonitors((prev) =>
-      prev.map((m) =>
-        m.id === payload.monitorId
-          ? { ...m, status: payload.monitorStatus as SidebarMonitor["status"] }
-          : m,
-      ),
-    )
-  }, [])
-
-  const handleStatusChanged = useCallback((payload: StatusChangedPayload) => {
-    setMonitors((prev) =>
-      prev.map((m) =>
-        m.id === payload.monitorId
-          ? { ...m, status: payload.newStatus as SidebarMonitor["status"] }
-          : m,
-      ),
-    )
-  }, [])
-
-  useEcho(`monitors.${auth.user?.id}`, ".HeartbeatRecorded", handleHeartbeat)
-  useEcho(`monitors.${auth.user?.id}`, ".MonitorStatusChanged", handleStatusChanged)
 
   return (
     <Sidebar {...props}>
@@ -122,11 +100,11 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
         <button
           type="button"
           onClick={() => setPaletteOpen(true)}
-          className="mt-3 flex w-full cursor-pointer items-center gap-2 rounded border border-border rounded-lg bg-transparent px-3 py-2 text-xs text-muted-fg transition-colors hover:border-primary/40 hover:text-fg"
+          className="mt-3 flex w-full cursor-pointer items-center gap-2 rounded rounded-lg border border-border bg-transparent px-3 py-2 text-muted-fg text-xs transition-colors hover:border-primary/40 hover:text-fg"
         >
           <span className="text-sm leading-none">⌕</span>
           <span className="flex-1 text-left">Search monitors…</span>
-          <kbd className="rounded border border-border rounded-lg px-1.5 py-0.5 font-mono text-[10px] text-muted-fg">
+          <kbd className="rounded rounded-lg border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-fg">
             {isMac ? "⌘K" : "Ctrl K"}
           </kbd>
         </button>
@@ -134,13 +112,13 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
 
       <SidebarContent className="flex flex-col overflow-hidden">
         {/* Monitor list */}
-        <div className="flex shrink-0 items-center justify-between px-4 pb-1.5 pt-0.5">
-          <span className="text-[10px] font-medium uppercase tracking-widest text-muted-fg">
+        <div className="flex shrink-0 items-center justify-between px-4 pt-0.5 pb-1.5">
+          <span className="font-medium text-[10px] text-muted-fg uppercase tracking-widest">
             Monitors · {monitors.length}
           </span>
           <Link
             href="/monitors/create"
-            className="text-[11px] font-medium text-primary transition-colors hover:text-primary/70"
+            className="font-medium text-[11px] text-primary transition-colors hover:text-primary/70"
           >
             + new
           </Link>
@@ -148,7 +126,7 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
 
         <div className="flex-1 overflow-y-auto px-2 pb-2">
           {monitors.length === 0 && (
-            <p className="px-3 py-4 text-xs text-muted-fg">No monitors yet.</p>
+            <p className="px-3 py-4 text-muted-fg text-xs">No monitors yet.</p>
           )}
           {monitors.map((monitor) => {
             const isActive =
@@ -190,11 +168,10 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
             )
           })}
         </div>
-
       </SidebarContent>
 
       {/* Secondary nav — outside scrollable content, above footer */}
-      <div className="shrink-0 border-t border-sidebar-border px-2 py-1">
+      <div className="shrink-0 border-sidebar-border border-t px-2 py-1">
         <SidebarSection>
           {secondaryNav.map((item) => (
             <SidebarItem
@@ -211,17 +188,14 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
 
         {auth.user && currentTeam && teams.length > 1 && (
           <Menu>
-            <Button intent="plain" className="w-full justify-start gap-2 text-xs text-muted-fg">
+            <Button intent="plain" className="w-full justify-start gap-2 text-muted-fg text-xs">
               <span className="truncate">{currentTeam.name}</span>
               <span className="ml-auto text-[10px] text-muted-fg/60">switch</span>
             </Button>
             <MenuContent placement="top start" className="sm:min-w-48">
               <MenuHeader separator>Switch Team</MenuHeader>
               {teams.map((team) => (
-                <MenuItem
-                  key={team.id}
-                  onAction={() => router.post(`/switch-team/${team.id}`)}
-                >
+                <MenuItem key={team.id} onAction={() => router.post(`/switch-team/${team.id}`)}>
                   <MenuLabel>{team.name}</MenuLabel>
                   {team.id === currentTeam.id && <CheckCircleIcon className="size-4" />}
                 </MenuItem>
@@ -264,15 +238,15 @@ function UserMenu() {
       <Button intent="plain" className="w-full justify-start gap-2">
         <Avatar src={auth.user.gravatar} size="sm" />
         <span className="flex min-w-0 flex-col text-start">
-          <span className="truncate text-sm font-medium">{auth.user.name}</span>
-          <span className="truncate text-xs text-muted-fg">{auth.user.email}</span>
+          <span className="truncate font-medium text-sm">{auth.user.name}</span>
+          <span className="truncate text-muted-fg text-xs">{auth.user.email}</span>
         </span>
       </Button>
       <MenuContent placement="top start" className="sm:min-w-56">
         <MenuSection>
           <MenuHeader separator className="relative">
             <div>{auth.user.name}</div>
-            <div className="truncate whitespace-nowrap pr-6 text-sm font-normal text-muted-fg">
+            <div className="truncate whitespace-nowrap pr-6 font-normal text-muted-fg text-sm">
               {auth.user.email}
             </div>
           </MenuHeader>

--- a/resources/js/layouts/app-sidebar.tsx
+++ b/resources/js/layouts/app-sidebar.tsx
@@ -122,11 +122,11 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
         <button
           type="button"
           onClick={() => setPaletteOpen(true)}
-          className="mt-3 flex w-full cursor-pointer items-center gap-2 rounded border border-border bg-transparent px-3 py-2 text-xs text-muted-fg transition-colors hover:border-primary/40 hover:text-fg"
+          className="mt-3 flex w-full cursor-pointer items-center gap-2 rounded border border-border rounded-lg bg-transparent px-3 py-2 text-xs text-muted-fg transition-colors hover:border-primary/40 hover:text-fg"
         >
           <span className="text-sm leading-none">⌕</span>
           <span className="flex-1 text-left">Search monitors…</span>
-          <kbd className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-fg">
+          <kbd className="rounded border border-border rounded-lg px-1.5 py-0.5 font-mono text-[10px] text-muted-fg">
             {isMac ? "⌘K" : "Ctrl K"}
           </kbd>
         </button>

--- a/resources/js/lib/__tests__/heartbeats.test.ts
+++ b/resources/js/lib/__tests__/heartbeats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { heartbeatsToTracker } from "@/lib/heartbeats"
+import { heartbeatsToTracker, isSlow } from "@/lib/heartbeats"
 import type { Heartbeat } from "@/types/monitor"
 
 function makeHeartbeat(overrides: Partial<Heartbeat>): Heartbeat {
@@ -57,5 +57,88 @@ describe("heartbeatsToTracker", () => {
     expect(result.slice(0, 4).every((b) => b.color === "bg-muted")).toBe(true)
     expect(result[4].color).toBe("bg-success")
     expect(result[5].color).toBe("bg-success")
+  })
+
+  it("produces deterministic snapshot for known input set", () => {
+    const heartbeats: Heartbeat[] = [
+      makeHeartbeat({ id: 1, status: "up", response_time: 100 }),
+      makeHeartbeat({ id: 2, status: "up", response_time: 120 }),
+      makeHeartbeat({ id: 3, status: "down", status_code: 500, response_time: null }),
+      makeHeartbeat({ id: 4, status: "up", response_time: 4000 }),
+      makeHeartbeat({ id: 5, status: "up", response_time: 110 }),
+    ]
+
+    const result = heartbeatsToTracker(heartbeats, 6)
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "color": "bg-muted",
+          "key": "pad-0",
+          "tooltip": "No data",
+        },
+        {
+          "color": "bg-success",
+          "key": "hb-0",
+          "tooltip": "Up — 100ms",
+        },
+        {
+          "color": "bg-success",
+          "key": "hb-1",
+          "tooltip": "Up — 120ms",
+        },
+        {
+          "color": "bg-danger",
+          "key": "hb-2",
+          "tooltip": "Down",
+        },
+        {
+          "color": "bg-warning",
+          "key": "hb-3",
+          "tooltip": "Up — 4000ms (slow)",
+        },
+        {
+          "color": "bg-success",
+          "key": "hb-4",
+          "tooltip": "Up — 110ms",
+        },
+      ]
+    `)
+  })
+})
+
+describe("isSlow", () => {
+  it("returns false for non-up heartbeats", () => {
+    const hb = makeHeartbeat({ status: "down", response_time: 9999 })
+    expect(isSlow(hb, 100)).toBe(false)
+  })
+
+  it("returns false when avg is 0 (no baseline)", () => {
+    const hb = makeHeartbeat({ status: "up", response_time: 5000 })
+    expect(isSlow(hb, 0)).toBe(false)
+  })
+
+  it("returns false at 1500ms floor when avg*2 below floor", () => {
+    // avg=100, 2*avg=200, floor=1500. 1500ms is NOT slow (must be > threshold).
+    const hb = makeHeartbeat({ status: "up", response_time: 1500 })
+    expect(isSlow(hb, 100)).toBe(false)
+  })
+
+  it("returns true just above 1500ms floor when avg*2 below floor", () => {
+    const hb = makeHeartbeat({ status: "up", response_time: 1501 })
+    expect(isSlow(hb, 100)).toBe(true)
+  })
+
+  it("uses avg*2 threshold when above 1500ms floor", () => {
+    // avg=1000, 2*avg=2000. 2000ms is NOT slow; 2001ms IS slow.
+    const atThreshold = makeHeartbeat({ status: "up", response_time: 2000 })
+    const justOver = makeHeartbeat({ status: "up", response_time: 2001 })
+    expect(isSlow(atThreshold, 1000)).toBe(false)
+    expect(isSlow(justOver, 1000)).toBe(true)
+  })
+
+  it("returns false when response_time is null", () => {
+    const hb = makeHeartbeat({ status: "up", response_time: null })
+    expect(isSlow(hb, 100)).toBe(false)
   })
 })

--- a/resources/js/lib/__tests__/heartbeats.test.ts
+++ b/resources/js/lib/__tests__/heartbeats.test.ts
@@ -2,20 +2,60 @@ import { describe, expect, it } from "vitest"
 import { heartbeatsToTracker } from "@/lib/heartbeats"
 import type { Heartbeat } from "@/types/monitor"
 
+function makeHeartbeat(overrides: Partial<Heartbeat>): Heartbeat {
+  return {
+    id: 1,
+    monitor_id: 1,
+    status: "up",
+    status_code: 200,
+    response_time: 100,
+    message: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
 describe("heartbeatsToTracker", () => {
-    it("returns array of length count when given fewer heartbeats", () => {
-        const heartbeats: Heartbeat[] = Array.from({ length: 5 }, (_, i) => ({
-            id: i + 1,
-            monitor_id: 1,
-            status: "up",
-            status_code: 200,
-            response_time: 100,
-            message: null,
-            created_at: new Date(Date.now() - i * 1000).toISOString(),
-        }))
+  it("returns array of length count when given fewer heartbeats", () => {
+    const heartbeats: Heartbeat[] = Array.from({ length: 5 }, (_, i) =>
+      makeHeartbeat({
+        id: i + 1,
+        created_at: new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString(),
+      }),
+    )
 
-        const result = heartbeatsToTracker(heartbeats, 10)
+    const result = heartbeatsToTracker(heartbeats, 10)
 
-        expect(result).toHaveLength(10)
-    })
+    expect(result).toHaveLength(10)
+  })
+
+  it("places newest heartbeat in the rightmost bar given oldest-first input", () => {
+    const heartbeats: Heartbeat[] = [
+      makeHeartbeat({ id: 1, status: "up", response_time: 100 }),
+      makeHeartbeat({ id: 2, status: "up", response_time: 100 }),
+      makeHeartbeat({ id: 3, status: "down", status_code: 500, response_time: null }),
+    ]
+
+    const result = heartbeatsToTracker(heartbeats, 5)
+
+    expect(result).toHaveLength(5)
+    expect(result[result.length - 1].color).toBe("bg-danger")
+    expect(result[result.length - 2].color).toBe("bg-success")
+    expect(result[result.length - 3].color).toBe("bg-success")
+    expect(result[0].color).toBe("bg-muted")
+  })
+
+  it("produces left-padded array of correct length when input shorter than count", () => {
+    const heartbeats: Heartbeat[] = [
+      makeHeartbeat({ id: 1, status: "up" }),
+      makeHeartbeat({ id: 2, status: "up" }),
+    ]
+
+    const result = heartbeatsToTracker(heartbeats, 6)
+
+    expect(result).toHaveLength(6)
+    expect(result.slice(0, 4).every((b) => b.color === "bg-muted")).toBe(true)
+    expect(result[4].color).toBe("bg-success")
+    expect(result[5].color).toBe("bg-success")
+  })
 })

--- a/resources/js/lib/__tests__/heartbeats.test.ts
+++ b/resources/js/lib/__tests__/heartbeats.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { heartbeatsToTracker } from "@/lib/heartbeats"
+import type { Heartbeat } from "@/types/monitor"
+
+describe("heartbeatsToTracker", () => {
+    it("returns array of length count when given fewer heartbeats", () => {
+        const heartbeats: Heartbeat[] = Array.from({ length: 5 }, (_, i) => ({
+            id: i + 1,
+            monitor_id: 1,
+            status: "up",
+            status_code: 200,
+            response_time: 100,
+            message: null,
+            created_at: new Date(Date.now() - i * 1000).toISOString(),
+        }))
+
+        const result = heartbeatsToTracker(heartbeats, 10)
+
+        expect(result).toHaveLength(10)
+    })
+})

--- a/resources/js/lib/heartbeats.ts
+++ b/resources/js/lib/heartbeats.ts
@@ -1,6 +1,15 @@
 import type { Heartbeat } from "@/types/monitor"
 import type { TrackerBlockProps } from "@/components/ui/tracker"
 
+/**
+ * Convert a heartbeat array into Tracker block props.
+ *
+ * @param heartbeats - Heartbeats sorted oldest-first (ascending by `created_at`).
+ *                     The newest heartbeat must be the last element so it renders
+ *                     in the rightmost bar.
+ * @param count - Total number of bars to render. Older slots are left-padded with
+ *                "No data" placeholders when fewer heartbeats are supplied.
+ */
 export function heartbeatsToTracker(heartbeats?: Heartbeat[], count = 90): TrackerBlockProps[] {
   if (!heartbeats || heartbeats.length === 0) {
     return Array(count)
@@ -14,12 +23,11 @@ export function heartbeatsToTracker(heartbeats?: Heartbeat[], count = 90): Track
   const avg = upTimes.length > 0 ? upTimes.reduce((a, b) => a + b, 0) / upTimes.length : 0
   const slowThreshold = Math.max(avg * 2, 1500)
 
-  const reversed = [...heartbeats].reverse()
   const padded = [
-    ...Array(Math.max(0, count - reversed.length))
+    ...Array(Math.max(0, count - heartbeats.length))
       .fill(null)
       .map((_, i) => ({ key: `pad-${i}`, tooltip: "No data", color: "bg-muted" })),
-    ...reversed.map((hb, i) => {
+    ...heartbeats.map((hb, i) => {
       const isSlow = hb.status === "up" && avg > 0 && (hb.response_time ?? 0) > slowThreshold
       const color = hb.status === "down" ? "bg-danger" : isSlow ? "bg-warning" : hb.status === "up" ? "bg-success" : "bg-warning"
       return {

--- a/resources/js/lib/heartbeats.ts
+++ b/resources/js/lib/heartbeats.ts
@@ -2,6 +2,20 @@ import type { Heartbeat } from "@/types/monitor"
 import type { TrackerBlockProps } from "@/components/ui/tracker"
 
 /**
+ * Decide whether an "up" heartbeat is slow relative to the rolling average.
+ *
+ * Threshold is `max(avg * 2, 1500ms)`. Returns false for non-up heartbeats,
+ * for null response_time, and when avg is 0 (no baseline).
+ */
+export function isSlow(hb: Heartbeat, avg: number): boolean {
+  if (hb.status !== "up" || avg <= 0 || hb.response_time == null) {
+    return false
+  }
+  const threshold = Math.max(avg * 2, 1500)
+  return hb.response_time > threshold
+}
+
+/**
  * Convert a heartbeat array into Tracker block props.
  *
  * @param heartbeats - Heartbeats sorted oldest-first (ascending by `created_at`).
@@ -21,18 +35,24 @@ export function heartbeatsToTracker(heartbeats?: Heartbeat[], count = 90): Track
     .filter((hb) => hb.status === "up" && hb.response_time != null)
     .map((hb) => hb.response_time as number)
   const avg = upTimes.length > 0 ? upTimes.reduce((a, b) => a + b, 0) / upTimes.length : 0
-  const slowThreshold = Math.max(avg * 2, 1500)
 
   const padded = [
     ...Array(Math.max(0, count - heartbeats.length))
       .fill(null)
       .map((_, i) => ({ key: `pad-${i}`, tooltip: "No data", color: "bg-muted" })),
     ...heartbeats.map((hb, i) => {
-      const isSlow = hb.status === "up" && avg > 0 && (hb.response_time ?? 0) > slowThreshold
-      const color = hb.status === "down" ? "bg-danger" : isSlow ? "bg-warning" : hb.status === "up" ? "bg-success" : "bg-warning"
+      const slow = isSlow(hb, avg)
+      const color =
+        hb.status === "down"
+          ? "bg-danger"
+          : slow
+            ? "bg-warning"
+            : hb.status === "up"
+              ? "bg-success"
+              : "bg-warning"
       return {
         key: `hb-${i}`,
-        tooltip: `${hb.status.charAt(0).toUpperCase() + hb.status.slice(1)}${hb.response_time != null ? ` — ${hb.response_time}ms` : ""}${isSlow ? " (slow)" : ""}`,
+        tooltip: `${hb.status.charAt(0).toUpperCase() + hb.status.slice(1)}${hb.response_time != null ? ` — ${hb.response_time}ms` : ""}${slow ? " (slow)" : ""}`,
         color,
       }
     }),

--- a/resources/js/lib/heartbeats.ts
+++ b/resources/js/lib/heartbeats.ts
@@ -25,6 +25,9 @@ export function isSlow(hb: Heartbeat, avg: number): boolean {
  *                "No data" placeholders when fewer heartbeats are supplied.
  */
 export function heartbeatsToTracker(heartbeats?: Heartbeat[], count = 90): TrackerBlockProps[] {
+  if (count <= 0) {
+    return []
+  }
   if (!heartbeats || heartbeats.length === 0) {
     return Array(count)
       .fill(null)

--- a/resources/js/pages/__tests__/monitor-row-memo.test.tsx
+++ b/resources/js/pages/__tests__/monitor-row-memo.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render } from "@testing-library/react"
+import { memo } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { monitorRowAreEqual } from "@/pages/monitors/index"
+import type { Monitor } from "@/types/monitor"
+
+function makeMonitor(overrides: Partial<Monitor> = {}): Monitor {
+  return {
+    id: 1,
+    user_id: 1,
+    monitor_group_id: null,
+    name: "Example",
+    type: "http",
+    url: "https://example.com",
+    host: null,
+    port: null,
+    dns_record_type: null,
+    method: "GET",
+    body: null,
+    headers: null,
+    accepted_status_codes: null,
+    interval: 60,
+    timeout: 30,
+    retry_count: 0,
+    status: "up",
+    is_active: true,
+    push_token: null,
+    ssl_monitoring_enabled: false,
+    ssl_expiry_notification_days: null,
+    last_checked_at: "2026-04-28T00:00:00Z",
+    next_check_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    heartbeats: [],
+    uptime_percentage: 100,
+    average_response_time: 200,
+    ...overrides,
+  }
+}
+
+describe("monitorRowAreEqual", () => {
+  it("returns true for identical monitor ref and isSelected", () => {
+    const monitor = makeMonitor()
+    expect(monitorRowAreEqual({ monitor, isSelected: false }, { monitor, isSelected: false })).toBe(
+      true,
+    )
+  })
+
+  it("returns false when monitor ref differs", () => {
+    const a = makeMonitor()
+    const b = makeMonitor()
+    expect(
+      monitorRowAreEqual({ monitor: a, isSelected: false }, { monitor: b, isSelected: false }),
+    ).toBe(false)
+  })
+
+  it("returns false when isSelected differs", () => {
+    const monitor = makeMonitor()
+    expect(monitorRowAreEqual({ monitor, isSelected: false }, { monitor, isSelected: true })).toBe(
+      false,
+    )
+  })
+})
+
+describe("React.memo with monitorRowAreEqual", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("skips re-render when monitor ref and isSelected are unchanged", () => {
+    const renderSpy = vi.fn(() => null)
+    const Memoized = memo(renderSpy, monitorRowAreEqual)
+    const monitor = makeMonitor()
+
+    const { rerender } = render(<Memoized monitor={monitor} isSelected={false} />)
+    rerender(<Memoized monitor={monitor} isSelected={false} />)
+    rerender(<Memoized monitor={monitor} isSelected={false} />)
+
+    expect(renderSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-renders when monitor reference changes", () => {
+    const renderSpy = vi.fn(() => null)
+    const Memoized = memo(renderSpy, monitorRowAreEqual)
+
+    const { rerender } = render(<Memoized monitor={makeMonitor()} isSelected={false} />)
+    rerender(<Memoized monitor={makeMonitor()} isSelected={false} />)
+
+    expect(renderSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it("re-renders when isSelected toggles", () => {
+    const renderSpy = vi.fn(() => null)
+    const Memoized = memo(renderSpy, monitorRowAreEqual)
+    const monitor = makeMonitor()
+
+    const { rerender } = render(<Memoized monitor={monitor} isSelected={false} />)
+    rerender(<Memoized monitor={monitor} isSelected={true} />)
+
+    expect(renderSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -9,7 +9,7 @@ import {
   SignalIcon,
 } from "@heroicons/react/20/solid"
 import { Head, WhenVisible } from "@inertiajs/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Container } from "@/components/ui/container"
@@ -326,15 +326,15 @@ function StatusDot({ status }: { status: Monitor["status"] }) {
   }
   return (
     <span className="relative flex size-2.5 shrink-0">
-      {status === "up" && (
-        <span className="absolute inline-flex size-full animate-ping rounded-full bg-success opacity-20" />
+      {status === "down" && (
+        <span className="absolute inline-flex size-full animate-ping rounded-full bg-danger opacity-30" />
       )}
       <span className={`relative inline-flex size-2.5 rounded-full ${colors[status]}`} />
     </span>
   )
 }
 
-function MonitorCard({ monitor }: { monitor: Monitor }) {
+function MonitorCardImpl({ monitor }: { monitor: Monitor }) {
   const lastChecked = monitor.last_checked_at ? formatRelativeTime(monitor.last_checked_at) : "—"
   const isDown = monitor.status === "down"
 
@@ -397,6 +397,8 @@ function MonitorCard({ monitor }: { monitor: Monitor }) {
     </Link>
   )
 }
+
+const MonitorCard = memo(MonitorCardImpl, (prev, next) => prev.monitor === next.monitor)
 
 type GridFilter = "all" | "up" | "down" | "paused"
 

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -370,9 +370,13 @@ function MonitorCardImpl({ monitor }: { monitor: Monitor }) {
         <div>
           <div className="text-[10px] text-muted-fg uppercase tracking-wide">Uptime</div>
           <div
-            className={`mt-0.5 font-medium font-mono text-sm tabular-nums ${uptimeColor(monitor.uptime_percentage ?? 100)}`}
+            className={`mt-0.5 font-medium font-mono text-sm tabular-nums ${
+              monitor.uptime_percentage != null
+                ? uptimeColor(monitor.uptime_percentage)
+                : "text-muted-fg"
+            }`}
           >
-            {monitor.uptime_percentage !== undefined ? `${monitor.uptime_percentage}%` : "—"}
+            {monitor.uptime_percentage != null ? `${monitor.uptime_percentage}%` : "—"}
           </div>
         </div>
         <div>
@@ -702,13 +706,22 @@ export default function Dashboard({
     return monitors
       .filter((m) => m.status === "down")
       .map((m) => {
-        const lastDown = [...(m.heartbeats ?? [])].reverse().find((h) => h.status === "down")
+        const history = m.heartbeats ?? []
+        let outageStart: string | undefined
+        let latestDownMessage: string | null = null
+        for (let i = history.length - 1; i >= 0; i--) {
+          if (history[i].status !== "down") break
+          outageStart = history[i].created_at
+          if (latestDownMessage === null) {
+            latestDownMessage = history[i].message ?? null
+          }
+        }
         return {
           id: m.id,
           monitor_id: m.id,
           monitor_name: m.name,
-          started_at: lastDown?.created_at ?? m.last_checked_at ?? new Date().toISOString(),
-          cause: lastDown?.message ?? null,
+          started_at: outageStart ?? m.last_checked_at ?? new Date().toISOString(),
+          cause: latestDownMessage,
         }
       })
   }, [monitors])

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -167,14 +167,17 @@ function KPIStrip({
 }
 
 function ActiveIncidentBanner({ incidents }: { incidents: OpenIncident[] }) {
-  if (incidents.length === 0) return null
   const first = incidents[0]
-  const [elapsed, setElapsed] = useState(() => formatElapsed(first.started_at))
+  const startedAt = first?.started_at ?? null
+  const [elapsed, setElapsed] = useState(() => (startedAt ? formatElapsed(startedAt) : ""))
 
   useEffect(() => {
-    const t = setInterval(() => setElapsed(formatElapsed(first.started_at)), 1000)
+    if (!startedAt) return
+    const t = setInterval(() => setElapsed(formatElapsed(startedAt)), 1000)
     return () => clearInterval(t)
-  }, [first.started_at])
+  }, [startedAt])
+
+  if (incidents.length === 0 || !first) return null
 
   return (
     <div className="rounded-lg border border-danger/30 bg-danger/8 px-5 py-4">
@@ -391,13 +394,7 @@ function MonitorCard({ monitor }: { monitor: Monitor }) {
 
 type GridFilter = "all" | "up" | "down" | "paused"
 
-function MonitorGrid({
-  monitors,
-  onAddMonitor,
-}: {
-  monitors: Monitor[]
-  onAddMonitor: () => void
-}) {
+function MonitorGrid({ monitors }: { monitors: Monitor[] }) {
   const [filter, setFilter] = useState<GridFilter>("all")
 
   const counts = useMemo(
@@ -430,6 +427,7 @@ function MonitorGrid({
           {tabs.map((t) => (
             <button
               key={t.key}
+              type="button"
               onClick={() => setFilter(t.key)}
               className={`rounded-md px-3 py-1.5 font-medium text-xs transition-colors ${
                 filter === t.key ? "bg-primary text-primary-fg" : "text-muted-fg hover:text-fg"
@@ -783,7 +781,7 @@ export default function Dashboard({
 
               <div className="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_280px]">
                 <div className="space-y-4">
-                  <MonitorGrid monitors={monitors} onAddMonitor={() => {}} />
+                  <MonitorGrid monitors={monitors} />
                   <LiveFeed events={liveEvents} />
                 </div>
                 <div className="space-y-4">

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,30 +1,34 @@
-import AppLayout from "@/layouts/app-layout"
-import type { SharedData } from "@/types/shared"
-import { Head, router, usePage, WhenVisible } from "@inertiajs/react"
-import { useEcho } from "@laravel/echo-react"
-import { Container } from "@/components/ui/container"
-import { Badge } from "@/components/ui/badge"
-import { Tracker } from "@/components/ui/tracker"
-import { Button } from "@/components/ui/button"
-import { Link } from "@/components/ui/link"
-import { Heading } from "@/components/ui/heading"
-import type { Monitor, Tag, Heartbeat } from "@/types/monitor"
 import {
   BellAlertIcon,
-  CheckCircleIcon,
+  BellIcon,
   ComputerDesktopIcon,
   ExclamationCircleIcon,
   GlobeAltIcon,
   PlusIcon,
   ShieldCheckIcon,
-  BellIcon,
   SignalIcon,
 } from "@heroicons/react/20/solid"
+import { Head, WhenVisible } from "@inertiajs/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import CreateMonitorModal from "./monitors/components/create-monitor-modal"
-import { uptimeColor, statusBadgeIntent } from "@/lib/color"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Container } from "@/components/ui/container"
+import { Heading } from "@/components/ui/heading"
+import { Link } from "@/components/ui/link"
+import { Tracker } from "@/components/ui/tracker"
+import AppLayout from "@/layouts/app-layout"
+import { statusBadgeIntent, uptimeColor } from "@/lib/color"
+import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import monitorRoutes from "@/routes/monitors"
-import { heartbeatsToTracker, formatInterval } from "@/lib/heartbeats"
+import {
+  getSnapshot,
+  subscribeToEvents,
+  useHydrateMonitors,
+  useMonitorCounts,
+  useMonitors,
+} from "@/stores/monitor-realtime"
+import type { Monitor } from "@/types/monitor"
+import CreateMonitorModal from "./monitors/components/create-monitor-modal"
 
 interface OpenIncident {
   id: number
@@ -66,21 +70,6 @@ interface Props {
   monitors?: Monitor[]
 }
 
-interface HeartbeatPayload {
-  monitorId: number
-  heartbeat: Heartbeat
-  monitorStatus: string
-  uptimePercentage: number
-  averageResponseTime: number | null
-}
-
-interface StatusChangedPayload {
-  monitorId: number
-  oldStatus: string
-  newStatus: string
-  message: string | null
-}
-
 function formatRelativeTime(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime()
   const s = Math.floor(diff / 1000)
@@ -119,44 +108,58 @@ function KPIStrip({
   return (
     <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
       <div className="flex flex-col rounded-lg border bg-overlay px-5 py-4">
-        <span className="text-[10px] uppercase tracking-widest text-muted-fg">Monitors</span>
-        <span className="mt-2 font-mono text-4xl font-medium tabular-nums">{counts.total}</span>
-        <span className="mt-1.5 text-xs text-muted-fg">
+        <span className="text-[10px] text-muted-fg uppercase tracking-widest">Monitors</span>
+        <span className="mt-2 font-medium font-mono text-4xl tabular-nums">{counts.total}</span>
+        <span className="mt-1.5 text-muted-fg text-xs">
           <span className="text-success">{counts.up} up</span>
           {" · "}
-          {counts.down > 0 ? <span className="text-danger">{counts.down} down</span> : <span>0 down</span>}
+          {counts.down > 0 ? (
+            <span className="text-danger">{counts.down} down</span>
+          ) : (
+            <span>0 down</span>
+          )}
           {counts.paused > 0 && <span> · {counts.paused} paused</span>}
         </span>
       </div>
 
       <div className="flex flex-col rounded-lg border bg-overlay px-5 py-4">
-        <span className="text-[10px] uppercase tracking-widest text-muted-fg">Uptime · 30d</span>
-        <span className={`mt-2 font-mono text-4xl font-medium tabular-nums ${teamUptime30d !== null ? uptimeColor(teamUptime30d) : "text-muted-fg"}`}>
+        <span className="text-[10px] text-muted-fg uppercase tracking-widest">Uptime · 30d</span>
+        <span
+          className={`mt-2 font-medium font-mono text-4xl tabular-nums ${teamUptime30d !== null ? uptimeColor(teamUptime30d) : "text-muted-fg"}`}
+        >
           {teamUptime30d !== null ? `${teamUptime30d}%` : "—"}
         </span>
-        <span className="mt-1.5 text-xs text-muted-fg">team average</span>
+        <span className="mt-1.5 text-muted-fg text-xs">team average</span>
       </div>
 
       <div className="flex flex-col rounded-lg border bg-overlay px-5 py-4">
-        <span className="text-[10px] uppercase tracking-widest text-muted-fg">Avg response · 24h</span>
-        <span className="mt-2 font-mono text-4xl font-medium tabular-nums">
+        <span className="text-[10px] text-muted-fg uppercase tracking-widest">
+          Avg response · 24h
+        </span>
+        <span className="mt-2 font-medium font-mono text-4xl tabular-nums">
           {avgResponse24h !== null ? `${avgResponse24h}ms` : "—"}
         </span>
-        <span className="mt-1.5 text-xs text-muted-fg">across all monitors</span>
+        <span className="mt-1.5 text-muted-fg text-xs">across all monitors</span>
       </div>
 
-      <div className={`flex flex-col rounded-lg border px-5 py-4 ${openIncidentsCount > 0 ? "border-danger/30 bg-danger/8" : "bg-overlay"}`}>
-        <span className={`text-[10px] uppercase tracking-widest ${openIncidentsCount > 0 ? "text-danger/70" : "text-muted-fg"}`}>
+      <div
+        className={`flex flex-col rounded-lg border px-5 py-4 ${openIncidentsCount > 0 ? "border-danger/30 bg-danger/8" : "bg-overlay"}`}
+      >
+        <span
+          className={`text-[10px] uppercase tracking-widest ${openIncidentsCount > 0 ? "text-danger/70" : "text-muted-fg"}`}
+        >
           Open incidents
         </span>
-        <span className={`mt-2 font-mono font-medium tabular-nums ${openIncidentsCount > 0 ? "text-5xl text-danger" : "text-4xl"}`}>
+        <span
+          className={`mt-2 font-medium font-mono tabular-nums ${openIncidentsCount > 0 ? "text-5xl text-danger" : "text-4xl"}`}
+        >
           {openIncidentsCount}
         </span>
         {openIncidentsCount > 0 && (
-          <span className="mt-1.5 text-xs text-danger/70">action required</span>
+          <span className="mt-1.5 text-danger/70 text-xs">action required</span>
         )}
         {openIncidentsCount === 0 && (
-          <span className="mt-1.5 text-xs text-muted-fg">all clear</span>
+          <span className="mt-1.5 text-muted-fg text-xs">all clear</span>
         )}
       </div>
     </div>
@@ -180,13 +183,15 @@ function ActiveIncidentBanner({ incidents }: { incidents: OpenIncident[] }) {
           <span className="absolute inline-flex size-full animate-ping rounded-full bg-danger opacity-30" />
           <span className="relative inline-flex size-3 rounded-full bg-danger" />
         </span>
-        <span className="text-xs font-bold uppercase tracking-wider text-danger">Active incident</span>
-        <span className="ml-auto font-mono text-xs text-danger/60">{elapsed}</span>
+        <span className="font-bold text-danger text-xs uppercase tracking-wider">
+          Active incident
+        </span>
+        <span className="ml-auto font-mono text-danger/60 text-xs">{elapsed}</span>
       </div>
       <div className="mt-2 font-semibold text-danger">{first.monitor_name}</div>
-      {first.cause && <div className="mt-0.5 text-xs text-danger/70">{first.cause}</div>}
+      {first.cause && <div className="mt-0.5 text-danger/70 text-xs">{first.cause}</div>}
       {incidents.length > 1 && (
-        <div className="mt-1 text-xs text-danger/60">+{incidents.length - 1} more</div>
+        <div className="mt-1 text-danger/60 text-xs">+{incidents.length - 1} more</div>
       )}
       <div className="mt-3 flex gap-2">
         <Link href={monitorRoutes.index.url({ query: { status: "down" } })}>
@@ -206,10 +211,7 @@ function IncidentGantt({ monitors }: { monitors: Monitor[] }) {
   const windowStart = now - windowMs
 
   const rows = useMemo(
-    () =>
-      monitors
-        .filter((m) => m.heartbeats?.some((hb) => hb.status === "down"))
-        .slice(0, 8),
+    () => monitors.filter((m) => m.heartbeats?.some((hb) => hb.status === "down")).slice(0, 8),
     [monitors],
   )
 
@@ -220,11 +222,11 @@ function IncidentGantt({ monitors }: { monitors: Monitor[] }) {
       <div className="flex items-start justify-between">
         <div>
           <div className="font-semibold text-sm">Incident timeline · 24h</div>
-          <div className="mt-0.5 text-xs text-muted-fg">
+          <div className="mt-0.5 text-muted-fg text-xs">
             {rows.length} monitor{rows.length > 1 ? "s" : ""} with incidents in the last 24 hours
           </div>
         </div>
-        <div className="flex items-center gap-4 text-xs text-muted-fg">
+        <div className="flex items-center gap-4 text-muted-fg text-xs">
           <span className="flex items-center gap-1.5">
             <span className="inline-block size-2.5 rounded-sm bg-success/40" />
             up
@@ -252,17 +254,25 @@ function IncidentGantt({ monitors }: { monitors: Monitor[] }) {
             const pct = ((t - windowStart) / windowMs) * 100
             const last = segs[segs.length - 1]
             if (!last || last.status !== hb.status) {
-              segs.push({ start: Math.max(0, pct), end: Math.min(100, pct + slotWidth), status: hb.status })
+              segs.push({
+                start: Math.max(0, pct),
+                end: Math.min(100, pct + slotWidth),
+                status: hb.status,
+              })
             } else {
               last.end = Math.min(100, pct + slotWidth)
             }
           }
 
           return (
-            <div key={m.id} className="grid items-center gap-3" style={{ gridTemplateColumns: "160px 1fr" }}>
+            <div
+              key={m.id}
+              className="grid items-center gap-3"
+              style={{ gridTemplateColumns: "160px 1fr" }}
+            >
               <div className="flex items-center gap-2 overflow-hidden">
-                <span className="truncate text-xs text-fg">{m.name}</span>
-                <span className="shrink-0 rounded bg-muted/20 px-1 py-px font-mono text-[10px] uppercase text-muted-fg">
+                <span className="truncate text-fg text-xs">{m.name}</span>
+                <span className="shrink-0 rounded bg-muted/20 px-1 py-px font-mono text-[10px] text-muted-fg uppercase">
                   {m.type}
                 </span>
               </div>
@@ -272,7 +282,10 @@ function IncidentGantt({ monitors }: { monitors: Monitor[] }) {
                     <div
                       key={i}
                       className="absolute inset-y-0 bg-danger"
-                      style={{ left: `${seg.start}%`, width: `${Math.max(0.5, seg.end - seg.start)}%` }}
+                      style={{
+                        left: `${seg.start}%`,
+                        width: `${Math.max(0.5, seg.end - seg.start)}%`,
+                      }}
                     />
                   ) : null,
                 )}
@@ -327,8 +340,8 @@ function MonitorCard({ monitor }: { monitor: Monitor }) {
         <div className="flex min-w-0 items-center gap-2.5">
           <StatusDot status={monitor.status} />
           <div className="min-w-0">
-            <div className="truncate text-sm font-medium">{monitor.name}</div>
-            <div className="truncate text-xs text-muted-fg">
+            <div className="truncate font-medium text-sm">{monitor.name}</div>
+            <div className="truncate text-muted-fg text-xs">
               {monitor.type.toUpperCase()} · {monitor.url ?? monitor.host}
             </div>
           </div>
@@ -346,26 +359,30 @@ function MonitorCard({ monitor }: { monitor: Monitor }) {
 
       <div className="grid grid-cols-4 gap-1 text-center">
         <div>
-          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Uptime</div>
-          <div className={`mt-0.5 font-mono text-sm font-medium tabular-nums ${uptimeColor(monitor.uptime_percentage ?? 100)}`}>
+          <div className="text-[10px] text-muted-fg uppercase tracking-wide">Uptime</div>
+          <div
+            className={`mt-0.5 font-medium font-mono text-sm tabular-nums ${uptimeColor(monitor.uptime_percentage ?? 100)}`}
+          >
             {monitor.uptime_percentage !== undefined ? `${monitor.uptime_percentage}%` : "—"}
           </div>
         </div>
         <div>
-          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Avg</div>
+          <div className="text-[10px] text-muted-fg uppercase tracking-wide">Avg</div>
           <div className="mt-0.5 font-mono text-sm tabular-nums">
-            {monitor.average_response_time != null ? `${Math.round(monitor.average_response_time)}ms` : "—"}
+            {monitor.average_response_time != null
+              ? `${Math.round(monitor.average_response_time)}ms`
+              : "—"}
           </div>
         </div>
         <div>
-          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Interval</div>
-          <div className="mt-0.5 font-mono text-sm tabular-nums text-muted-fg">
+          <div className="text-[10px] text-muted-fg uppercase tracking-wide">Interval</div>
+          <div className="mt-0.5 font-mono text-muted-fg text-sm tabular-nums">
             {formatInterval(monitor.interval)}
           </div>
         </div>
         <div>
-          <div className="text-[10px] uppercase tracking-wide text-muted-fg">Last check</div>
-          <div className="mt-0.5 font-mono text-xs text-muted-fg">{lastChecked}</div>
+          <div className="text-[10px] text-muted-fg uppercase tracking-wide">Last check</div>
+          <div className="mt-0.5 font-mono text-muted-fg text-xs">{lastChecked}</div>
         </div>
       </div>
     </Link>
@@ -374,7 +391,13 @@ function MonitorCard({ monitor }: { monitor: Monitor }) {
 
 type GridFilter = "all" | "up" | "down" | "paused"
 
-function MonitorGrid({ monitors, onAddMonitor }: { monitors: Monitor[]; onAddMonitor: () => void }) {
+function MonitorGrid({
+  monitors,
+  onAddMonitor,
+}: {
+  monitors: Monitor[]
+  onAddMonitor: () => void
+}) {
   const [filter, setFilter] = useState<GridFilter>("all")
 
   const counts = useMemo(
@@ -408,10 +431,8 @@ function MonitorGrid({ monitors, onAddMonitor }: { monitors: Monitor[]; onAddMon
             <button
               key={t.key}
               onClick={() => setFilter(t.key)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                filter === t.key
-                  ? "bg-primary text-primary-fg"
-                  : "text-muted-fg hover:text-fg"
+              className={`rounded-md px-3 py-1.5 font-medium text-xs transition-colors ${
+                filter === t.key ? "bg-primary text-primary-fg" : "text-muted-fg hover:text-fg"
               }`}
             >
               {t.label}
@@ -433,7 +454,7 @@ function MonitorGrid({ monitors, onAddMonitor }: { monitors: Monitor[]; onAddMon
           ))}
         </div>
       ) : (
-        <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-fg">
+        <div className="rounded-lg border border-dashed py-8 text-center text-muted-fg text-sm">
           No {filter === "all" ? "" : filter} monitors.
         </div>
       )}
@@ -455,22 +476,25 @@ function SSLExpiryWidget({ certs }: { certs: SslCert[] }) {
   return (
     <div className="rounded-lg border bg-overlay p-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm font-semibold">
+        <div className="flex items-center gap-2 font-semibold text-sm">
           <ShieldCheckIcon className="size-4 text-muted-fg" />
           SSL Expiry
         </div>
-        <span className="text-xs text-muted-fg">{certs.length} monitored</span>
+        <span className="text-muted-fg text-xs">{certs.length} monitored</span>
       </div>
       <div className="mt-3 space-y-0">
         {certs.map((c, i) => (
-          <div
-            key={i}
-            className={`${i > 0 ? "border-t border-border" : ""} py-2.5`}
-          >
+          <div key={i} className={`${i > 0 ? "border-border border-t" : ""} py-2.5`}>
             <div className="flex items-center justify-between gap-2">
-              <span className="min-w-0 truncate text-xs font-medium">{c.monitor_name}</span>
-              <span className={`shrink-0 font-mono text-xs font-semibold ${certColor(c.days_until_expiry, c.is_valid)}`}>
-                {c.is_valid && c.days_until_expiry !== null ? `${c.days_until_expiry}d` : c.is_valid ? "—" : "invalid"}
+              <span className="min-w-0 truncate font-medium text-xs">{c.monitor_name}</span>
+              <span
+                className={`shrink-0 font-mono font-semibold text-xs ${certColor(c.days_until_expiry, c.is_valid)}`}
+              >
+                {c.is_valid && c.days_until_expiry !== null
+                  ? `${c.days_until_expiry}d`
+                  : c.is_valid
+                    ? "—"
+                    : "invalid"}
               </span>
             </div>
             {c.issuer && (
@@ -497,18 +521,20 @@ function NotificationChannelsWidget({ channels }: { channels: NotifChannel[] }) 
   return (
     <div className="rounded-lg border bg-overlay p-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm font-semibold">
+        <div className="flex items-center gap-2 font-semibold text-sm">
           <BellIcon className="size-4 text-muted-fg" />
           Notifications
         </div>
-        <Link href="/notification-channels" className="text-xs text-primary hover:underline">
+        <Link href="/notification-channels" className="text-primary text-xs hover:underline">
           manage →
         </Link>
       </div>
       <div className="mt-3 space-y-2">
         {channels.map((c, i) => (
           <div key={i} className="flex items-center gap-2.5 text-xs">
-            <span className={`size-2 shrink-0 rounded-full ${c.is_enabled ? "bg-success" : "bg-muted"}`} />
+            <span
+              className={`size-2 shrink-0 rounded-full ${c.is_enabled ? "bg-success" : "bg-muted"}`}
+            />
             <span className="w-16 shrink-0 text-muted-fg">{typeLabel[c.type] ?? c.type}</span>
             <span className="min-w-0 truncate">{c.name}</span>
           </div>
@@ -523,11 +549,11 @@ function LiveFeed({ events }: { events: LiveEvent[] }) {
   return (
     <div className="rounded-lg border bg-overlay p-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm font-semibold">
+        <div className="flex items-center gap-2 font-semibold text-sm">
           <SignalIcon className="size-4 text-muted-fg" />
           Live feed
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-success">
+        <div className="flex items-center gap-1.5 text-success text-xs">
           <span className="relative flex size-2">
             <span className="absolute inline-flex size-full animate-ping rounded-full bg-success opacity-40" />
             <span className="relative inline-flex size-2 rounded-full bg-success" />
@@ -547,7 +573,9 @@ function LiveFeed({ events }: { events: LiveEvent[] }) {
                 style={{ gridTemplateColumns: "5.5rem 4rem 1fr" }}
               >
                 <span className="text-muted-fg/60">{formatTime(e.timestamp)}</span>
-                <span className={`font-semibold uppercase ${alertKinds.has(e.kind) ? "text-danger" : e.kind === "UP" ? "text-success" : "text-muted-fg"}`}>
+                <span
+                  className={`font-semibold uppercase ${alertKinds.has(e.kind) ? "text-danger" : e.kind === "UP" ? "text-success" : "text-muted-fg"}`}
+                >
                   {e.kind}
                 </span>
                 <span className="truncate text-muted-fg">
@@ -614,14 +642,16 @@ function EmptyState() {
     <div className="py-8">
       <div className="mb-10">
         <Heading level={2}>Get started</Heading>
-        <p className="mt-1 text-muted-fg text-sm">Three steps to know the moment your services go down.</p>
+        <p className="mt-1 text-muted-fg text-sm">
+          Three steps to know the moment your services go down.
+        </p>
       </div>
 
       <div className="space-y-3">
         {steps.map(({ icon: Icon, step, title, description, action }, index) => (
           <div
             key={step}
-            className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both flex items-start gap-4 rounded-lg border bg-bg px-5 py-4 transition-colors duration-300 hover:bg-secondary/20"
+            className="fade-in slide-in-from-bottom-2 flex animate-in items-start gap-4 rounded-lg border bg-bg fill-mode-both px-5 py-4 transition-colors duration-300 hover:bg-secondary/20"
             style={{ animationDelay: `${index * 80}ms` }}
           >
             <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md bg-primary-subtle">
@@ -629,7 +659,7 @@ function EmptyState() {
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <span className="font-mono text-xs text-muted-fg">{step}</span>
+                <span className="font-mono text-muted-fg text-xs">{step}</span>
                 <span className="font-semibold text-sm">{title}</span>
               </div>
               <p className="mt-0.5 text-muted-fg text-xs leading-relaxed">{description}</p>
@@ -647,128 +677,83 @@ export default function Dashboard({
   monitors: initialMonitors,
   team_uptime_30d,
   avg_response_24h,
-  open_incidents,
   ssl_certs,
   notification_channels,
 }: Props) {
-  const { auth } = usePage<SharedData>().props
-  const [monitors, setMonitors] = useState(initialMonitors)
-  const [counts, setCounts] = useState(initialCounts)
-  const [openIncidents, setOpenIncidents] = useState(open_incidents)
+  useHydrateMonitors(initialMonitors)
+  const monitors = useMonitors()
+  const storeCounts = useMonitorCounts()
+  const counts =
+    monitors.length > 0
+      ? {
+          total: storeCounts.total,
+          up: storeCounts.up,
+          down: storeCounts.down,
+          paused: storeCounts.paused,
+        }
+      : initialCounts
+
   const [liveEvents, setLiveEvents] = useState<LiveEvent[]>([])
   const liveEventIdRef = useRef(0)
 
-  useEffect(() => {
-    if (initialMonitors) setMonitors(initialMonitors)
-  }, [initialMonitors])
-
-  useEffect(() => {
-    setCounts(initialCounts)
-  }, [initialCounts])
-
-  useEffect(() => {
-    setOpenIncidents(open_incidents)
-  }, [open_incidents])
-
-  const monitorMap = useMemo(() => {
-    const map = new Map<number, { name: string; type: string }>()
-    monitors?.forEach((m) => map.set(m.id, { name: m.name, type: m.type }))
-    return map
+  const openIncidents = useMemo<OpenIncident[]>(() => {
+    return monitors
+      .filter((m) => m.status === "down")
+      .map((m) => {
+        const lastDown = [...(m.heartbeats ?? [])].reverse().find((h) => h.status === "down")
+        return {
+          id: m.id,
+          monitor_id: m.id,
+          monitor_name: m.name,
+          started_at: lastDown?.created_at ?? m.last_checked_at ?? new Date().toISOString(),
+          cause: lastDown?.message ?? null,
+        }
+      })
   }, [monitors])
 
-  const addLiveEvent = useCallback(
-    (event: Omit<LiveEvent, "id">) => {
-      setLiveEvents((prev) => [{ ...event, id: ++liveEventIdRef.current }, ...prev].slice(0, 20))
-    },
-    [],
-  )
+  const addLiveEvent = useCallback((event: Omit<LiveEvent, "id">) => {
+    setLiveEvents((prev) => [{ ...event, id: ++liveEventIdRef.current }, ...prev].slice(0, 20))
+  }, [])
 
-  const handleHeartbeat = useCallback(
-    (payload: HeartbeatPayload) => {
-      setMonitors((prev) =>
-        prev?.map((m) => {
-          if (m.id !== payload.monitorId) return m
-          const updatedHeartbeats = [...(m.heartbeats ?? []), payload.heartbeat].slice(-90)
-          return {
-            ...m,
-            status: payload.monitorStatus as Monitor["status"],
-            heartbeats: updatedHeartbeats,
-            uptime_percentage: payload.uptimePercentage,
-            average_response_time: payload.averageResponseTime,
-          }
-        }),
-      )
-      const info = monitorMap.get(payload.monitorId)
-      addLiveEvent({
-        kind: info?.type.toUpperCase() ?? "CHECK",
-        monitorName: info?.name ?? `Monitor #${payload.monitorId}`,
-        detail: [
-          payload.heartbeat.status_code ? String(payload.heartbeat.status_code) : null,
-          payload.heartbeat.response_time != null ? `${payload.heartbeat.response_time}ms` : null,
-        ]
-          .filter(Boolean)
-          .join(" · "),
-        timestamp: new Date(),
-        isAlert: payload.heartbeat.status === "down",
-      })
-    },
-    [monitorMap, addLiveEvent],
-  )
-
-  const handleStatusChanged = useCallback(
-    (payload: StatusChangedPayload) => {
-      setMonitors((prev) =>
-        prev?.map((m) =>
-          m.id === payload.monitorId ? { ...m, status: payload.newStatus as Monitor["status"] } : m,
-        ),
-      )
-      setCounts((prev) => {
-        const updated = { ...prev }
-        if (payload.oldStatus === "up") updated.up--
-        if (payload.oldStatus === "down") updated.down--
-        if (payload.newStatus === "up") updated.up++
-        if (payload.newStatus === "down") updated.down++
-        return updated
-      })
-
-      if (payload.newStatus === "up") {
-        setOpenIncidents((prev) => prev.filter((i) => i.monitor_id !== payload.monitorId))
-      } else if (payload.newStatus === "down") {
-        router.reload({ only: ["open_incidents"], preserveUrl: true })
+  useEffect(() => {
+    return subscribeToEvents((event) => {
+      if (event.type === "heartbeat") {
+        const info = getSnapshot().byId[event.payload.monitorId]
+        addLiveEvent({
+          kind: info?.type.toUpperCase() ?? "CHECK",
+          monitorName: info?.name ?? `Monitor #${event.payload.monitorId}`,
+          detail: [
+            event.payload.heartbeat.status_code
+              ? String(event.payload.heartbeat.status_code)
+              : null,
+            event.payload.heartbeat.response_time != null
+              ? `${event.payload.heartbeat.response_time}ms`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(" · "),
+          timestamp: new Date(),
+          isAlert: event.payload.heartbeat.status === "down",
+        })
+      } else if (event.type === "status") {
+        const info = getSnapshot().byId[event.payload.monitorId]
+        addLiveEvent({
+          kind: event.payload.newStatus.toUpperCase(),
+          monitorName: info?.name ?? `Monitor #${event.payload.monitorId}`,
+          detail:
+            event.payload.message ??
+            (event.payload.newStatus === "up" ? "recovered" : "incident started"),
+          timestamp: new Date(),
+          isAlert: event.payload.newStatus === "down",
+        })
       }
-
-      const info = monitorMap.get(payload.monitorId)
-      addLiveEvent({
-        kind: payload.newStatus.toUpperCase(),
-        monitorName: info?.name ?? `Monitor #${payload.monitorId}`,
-        detail: payload.message ?? (payload.newStatus === "up" ? "recovered" : "incident started"),
-        timestamp: new Date(),
-        isAlert: payload.newStatus === "down",
-      })
-    },
-    [monitorMap, addLiveEvent],
-  )
-
-  const handleChecking = useCallback(
-    (payload: { monitorId: number }) => {
-      setMonitors((prev) =>
-        prev?.map((m) =>
-          m.id === payload.monitorId ? { ...m, status: "pending" as Monitor["status"] } : m,
-        ),
-      )
-    },
-    [],
-  )
-
-  useEcho(`monitors.${auth.user.id}`, ".MonitorChecking", handleChecking)
-  useEcho(`monitors.${auth.user.id}`, ".HeartbeatRecorded", handleHeartbeat)
-  useEcho(`monitors.${auth.user.id}`, ".MonitorStatusChanged", handleStatusChanged)
+    })
+  }, [addLiveEvent])
 
   return (
     <>
       <Head title="Dashboard" />
       <Container className="space-y-4 pt-2 pb-8">
-
         {counts.total > 0 && (
           <KPIStrip
             counts={counts}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -61,7 +61,6 @@ interface LiveEvent {
 }
 
 interface Props {
-  counts: { total: number; up: number; down: number; paused: number }
   team_uptime_30d: number | null
   avg_response_24h: number | null
   open_incidents: OpenIncident[]
@@ -94,13 +93,20 @@ function formatTime(date: Date): string {
   return date.toTimeString().slice(0, 8)
 }
 
+interface KPICounts {
+  total: number
+  up: number
+  down: number
+  paused: number
+}
+
 function KPIStrip({
   counts,
   teamUptime30d,
   avgResponse24h,
   openIncidentsCount,
 }: {
-  counts: Props["counts"]
+  counts: KPICounts
   teamUptime30d: number | null
   avgResponse24h: number | null
   openIncidentsCount: number
@@ -671,7 +677,6 @@ function EmptyState() {
 }
 
 export default function Dashboard({
-  counts: initialCounts,
   monitors: initialMonitors,
   team_uptime_30d,
   avg_response_24h,
@@ -681,15 +686,12 @@ export default function Dashboard({
   useHydrateMonitors(initialMonitors)
   const monitors = useMonitors()
   const storeCounts = useMonitorCounts()
-  const counts =
-    monitors.length > 0
-      ? {
-          total: storeCounts.total,
-          up: storeCounts.up,
-          down: storeCounts.down,
-          paused: storeCounts.paused,
-        }
-      : initialCounts
+  const counts: KPICounts = {
+    total: storeCounts.total,
+    up: storeCounts.up,
+    down: storeCounts.down,
+    paused: storeCounts.paused,
+  }
 
   const [liveEvents, setLiveEvents] = useState<LiveEvent[]>([])
   const liveEventIdRef = useRef(0)

--- a/resources/js/pages/monitors/components/monitor-wizard.tsx
+++ b/resources/js/pages/monitors/components/monitor-wizard.tsx
@@ -649,11 +649,12 @@ export default function MonitorWizard({
                                   : [...data.notification_channel_ids, channel.id],
                               )
                             }
-                            onKeyDown={(e) =>
-                              e.key === "Enter" || e.key === " "
-                                ? e.currentTarget.click()
-                                : undefined
-                            }
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault()
+                                e.currentTarget.click()
+                              }
+                            }}
                             className={[
                               "flex cursor-pointer items-center gap-4 rounded-lg border p-3.5 transition-colors",
                               on

--- a/resources/js/pages/monitors/components/monitor-wizard.tsx
+++ b/resources/js/pages/monitors/components/monitor-wizard.tsx
@@ -1,16 +1,16 @@
+import { CheckIcon, PlusIcon, TrashIcon } from "@heroicons/react/20/solid"
+import { Link, router, useForm } from "@inertiajs/react"
 import { useState } from "react"
-import { useForm, router, Link } from "@inertiajs/react"
-import { TextField } from "@/components/ui/text-field"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { FieldError, Label } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select"
 import { NumberField, NumberInput } from "@/components/ui/number-field"
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select"
+import { TextField } from "@/components/ui/text-field"
 import { Textarea } from "@/components/ui/textarea"
-import { Checkbox } from "@/components/ui/checkbox"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
-import { CheckIcon, PlusIcon, TrashIcon } from "@heroicons/react/20/solid"
-import type { Monitor, MonitorGroup, Tag, NotificationChannel } from "@/types/monitor"
+import type { Monitor, MonitorGroup, NotificationChannel, Tag } from "@/types/monitor"
 
 interface MonitorWizardProps {
   monitor?: Monitor
@@ -20,11 +20,31 @@ interface MonitorWizardProps {
 }
 
 const monitorTypes = [
-  { id: "http", label: "HTTP(S)", desc: "GET / POST / custom methods. Assert status codes, response bodies, latency." },
-  { id: "tcp", label: "TCP", desc: "Open-socket check for databases, queues, anything with an open port." },
-  { id: "ping", label: "PING", desc: "Raw network reachability. Measures packet loss & round-trip time." },
-  { id: "dns", label: "DNS", desc: "Resolve A / AAAA / CNAME / MX / TXT and assert expected values." },
-  { id: "push", label: "PUSH", desc: "Cron or worker posts to Beacon. Alert if no ping within window." },
+  {
+    id: "http",
+    label: "HTTP(S)",
+    desc: "GET / POST / custom methods. Assert status codes, response bodies, latency.",
+  },
+  {
+    id: "tcp",
+    label: "TCP",
+    desc: "Open-socket check for databases, queues, anything with an open port.",
+  },
+  {
+    id: "ping",
+    label: "PING",
+    desc: "Raw network reachability. Measures packet loss & round-trip time.",
+  },
+  {
+    id: "dns",
+    label: "DNS",
+    desc: "Resolve A / AAAA / CNAME / MX / TXT and assert expected values.",
+  },
+  {
+    id: "push",
+    label: "PUSH",
+    desc: "Cron or worker posts to Beacon. Alert if no ping within window.",
+  },
 ]
 
 const httpMethods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
@@ -61,7 +81,12 @@ function getSearchParams(): URLSearchParams {
   return new URLSearchParams(window.location.search)
 }
 
-export default function MonitorWizard({ monitor, tags, notificationChannels, groups = [] }: MonitorWizardProps) {
+export default function MonitorWizard({
+  monitor,
+  tags,
+  notificationChannels,
+  groups = [],
+}: MonitorWizardProps) {
   const isEditing = !!monitor
   const params = !isEditing ? getSearchParams() : null
 
@@ -138,14 +163,16 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
   return (
     <div className="flex flex-col">
       {/* page header */}
-      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-bg px-6 py-4">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-border border-b bg-bg px-6 py-4">
         <div>
-          <div className="flex items-center gap-1.5 text-xs text-muted-fg">
-            <Link href="/monitors" className="hover:text-fg transition-colors">monitors</Link>
+          <div className="flex items-center gap-1.5 text-muted-fg text-xs">
+            <Link href="/monitors" className="transition-colors hover:text-fg">
+              monitors
+            </Link>
             <span>/</span>
             <span className="text-fg">{isEditing ? monitor.name : "new"}</span>
           </div>
-          <h1 className="mt-0.5 text-xl font-semibold tracking-tight">
+          <h1 className="mt-0.5 font-semibold text-xl tracking-tight">
             {isEditing ? `Edit ${monitor.name}` : "New monitor"}
           </h1>
         </div>
@@ -157,8 +184,8 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
       {/* wizard body */}
       <div className="flex gap-0">
         {/* step rail */}
-        <aside className="sticky top-[73px] h-[calc(100dvh-73px)] w-64 shrink-0 overflow-y-auto border-r border-border p-5">
-          <p className="mb-3 text-[11px] uppercase tracking-widest text-muted-fg">// setup</p>
+        <aside className="sticky top-[73px] h-[calc(100dvh-73px)] w-64 shrink-0 overflow-y-auto border-border border-r p-5">
+          <p className="mb-3 text-[11px] text-muted-fg uppercase tracking-widest">{"// setup"}</p>
           <div className="flex flex-col gap-0.5">
             {visibleSteps.map((s) => {
               const state = stepState(s.key)
@@ -172,18 +199,18 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     state === "active"
                       ? "border-primary bg-primary-subtle"
                       : state === "done"
-                      ? "border-primary/30 hover:bg-sidebar"
-                      : "border-transparent hover:bg-sidebar",
+                        ? "border-primary/30 hover:bg-sidebar"
+                        : "border-transparent hover:bg-sidebar",
                   ].join(" ")}
                 >
                   <div
                     className={[
-                      "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
+                      "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border font-semibold text-[10px]",
                       state === "active"
                         ? "border-primary bg-primary text-primary-fg"
                         : state === "done"
-                        ? "border-primary text-primary"
-                        : "border-border text-muted-fg",
+                          ? "border-primary text-primary"
+                          : "border-border text-muted-fg",
                     ].join(" ")}
                   >
                     {state === "done" ? <CheckIcon className="size-2.5" /> : s.n}
@@ -191,13 +218,13 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                   <div className="min-w-0">
                     <p
                       className={[
-                        "text-sm font-medium",
+                        "font-medium text-sm",
                         state === "active" ? "text-fg" : "text-muted-fg",
                       ].join(" ")}
                     >
                       {s.title}
                     </p>
-                    <p className="mt-0.5 text-[11px] leading-relaxed text-muted-fg">{s.blurb}</p>
+                    <p className="mt-0.5 text-[11px] text-muted-fg leading-relaxed">{s.blurb}</p>
                   </div>
                 </button>
               )
@@ -205,11 +232,11 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
           </div>
 
           {/* summary */}
-          <div className="mt-5 rounded-lg border border-border rounded-lg bg-sidebar p-3.5">
-            <p className="mb-2 text-xs font-medium text-fg">Summary</p>
-            <div className="space-y-1 text-[11px] leading-relaxed text-muted-fg">
+          <div className="mt-5 rounded-lg rounded-lg border border-border bg-sidebar p-3.5">
+            <p className="mb-2 font-medium text-fg text-xs">Summary</p>
+            <div className="space-y-1 text-[11px] text-muted-fg leading-relaxed">
               <p>
-                <span className="font-mono uppercase text-primary">{data.type}</span>
+                <span className="font-mono text-primary uppercase">{data.type}</span>
                 {data.name && <span> · {data.name}</span>}
               </p>
               {data.url && <p className="truncate">{data.url}</p>}
@@ -221,7 +248,8 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
               )}
               <p>
                 every{" "}
-                {intervalOptions.find((o) => o.value === data.interval)?.label ?? `${data.interval}s`}
+                {intervalOptions.find((o) => o.value === data.interval)?.label ??
+                  `${data.interval}s`}
                 {" · "}
                 {data.retry_count} {data.retry_count === 1 ? "retry" : "retries"}
               </p>
@@ -240,11 +268,11 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
           <div className="mx-auto max-w-2xl">
             {/* step header */}
             <div className="mb-8">
-              <p className="mb-2 font-mono text-[11px] uppercase tracking-widest text-primary">
+              <p className="mb-2 font-mono text-[11px] text-primary uppercase tracking-widest">
                 step {currentStep.n} / {String(visibleSteps.length).padStart(2, "0")}
               </p>
-              <h2 className="text-2xl font-semibold tracking-tight">{currentStep.title}</h2>
-              <p className="mt-1 text-sm text-muted-fg">{currentStep.blurb}</p>
+              <h2 className="font-semibold text-2xl tracking-tight">{currentStep.title}</h2>
+              <p className="mt-1 text-muted-fg text-sm">{currentStep.blurb}</p>
             </div>
 
             {/* — Step: type — */}
@@ -269,7 +297,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     <div className="flex items-center justify-between">
                       <span
                         className={[
-                          "font-mono text-sm font-semibold tracking-wide",
+                          "font-mono font-semibold text-sm tracking-wide",
                           data.type === t.id ? "text-primary" : "text-fg",
                         ].join(" ")}
                       >
@@ -281,10 +309,12 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                           data.type === t.id ? "border-primary bg-primary" : "border-border",
                         ].join(" ")}
                       >
-                        {data.type === t.id && <div className="size-1.5 rounded-full bg-primary-fg" />}
+                        {data.type === t.id && (
+                          <div className="size-1.5 rounded-full bg-primary-fg" />
+                        )}
                       </div>
                     </div>
-                    <p className="mt-2 text-[11px] leading-relaxed text-muted-fg">{t.desc}</p>
+                    <p className="mt-2 text-[11px] text-muted-fg leading-relaxed">{t.desc}</p>
                   </button>
                 ))}
               </div>
@@ -351,18 +381,18 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     {/* headers table */}
                     <div>
                       <Label>Headers</Label>
-                      <div className="mt-2 overflow-hidden rounded-lg border border-border rounded-lg">
+                      <div className="mt-2 overflow-hidden rounded-lg rounded-lg border border-border">
                         {headerRows.length > 0 && (
-                          <div className="grid grid-cols-[1fr_1fr_36px] bg-sidebar text-[11px] uppercase tracking-wider text-muted-fg">
-                            <div className="border-b border-border px-3 py-2">Key</div>
-                            <div className="border-b border-l border-border px-3 py-2">Value</div>
-                            <div className="border-b border-l border-border" />
+                          <div className="grid grid-cols-[1fr_1fr_36px] bg-sidebar text-[11px] text-muted-fg uppercase tracking-wider">
+                            <div className="border-border border-b px-3 py-2">Key</div>
+                            <div className="border-border border-b border-l px-3 py-2">Value</div>
+                            <div className="border-border border-b border-l" />
                           </div>
                         )}
                         {headerRows.map((row, i) => (
                           <div key={i} className="grid grid-cols-[1fr_1fr_36px]">
                             <input
-                              className="border-b border-border bg-transparent px-3 py-2.5 text-sm text-fg outline-none placeholder:text-muted-fg focus:bg-sidebar"
+                              className="border-border border-b bg-transparent px-3 py-2.5 text-fg text-sm outline-none placeholder:text-muted-fg focus:bg-sidebar"
                               placeholder="Authorization"
                               value={row.key}
                               onChange={(e) => {
@@ -372,7 +402,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                               }}
                             />
                             <input
-                              className="border-b border-l border-border bg-transparent px-3 py-2.5 text-sm text-fg outline-none placeholder:text-muted-fg focus:bg-sidebar"
+                              className="border-border border-b border-l bg-transparent px-3 py-2.5 text-fg text-sm outline-none placeholder:text-muted-fg focus:bg-sidebar"
                               placeholder="Bearer …"
                               value={row.value}
                               onChange={(e) => {
@@ -383,8 +413,10 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                             />
                             <button
                               type="button"
-                              onClick={() => updateHeaderRows(headerRows.filter((_, idx) => idx !== i))}
-                              className="flex items-center justify-center border-b border-l border-border text-muted-fg hover:text-danger"
+                              onClick={() =>
+                                updateHeaderRows(headerRows.filter((_, idx) => idx !== i))
+                              }
+                              className="flex items-center justify-center border-border border-b border-l text-muted-fg hover:text-danger"
                             >
                               <TrashIcon className="size-3.5" />
                             </button>
@@ -393,7 +425,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                         <button
                           type="button"
                           onClick={() => updateHeaderRows([...headerRows, { key: "", value: "" }])}
-                          className="flex w-full items-center gap-1.5 px-3 py-2.5 text-xs text-muted-fg hover:text-fg"
+                          className="flex w-full items-center gap-1.5 px-3 py-2.5 text-muted-fg text-xs hover:text-fg"
                         >
                           <PlusIcon className="size-3.5" />
                           Add header
@@ -401,7 +433,9 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                       </div>
                     </div>
 
-                    {(data.method === "POST" || data.method === "PUT" || data.method === "PATCH") && (
+                    {(data.method === "POST" ||
+                      data.method === "PUT" ||
+                      data.method === "PATCH") && (
                       <TextField value={data.body ?? ""} onChange={(v) => setData("body", v)}>
                         <Label>Request body</Label>
                         <Textarea placeholder='{"key": "value"}' rows={4} />
@@ -446,11 +480,11 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                 )}
 
                 {data.type === "push" && (
-                  <div className="rounded-lg border border-border rounded-lg bg-sidebar p-4">
-                    <p className="text-sm text-muted-fg">
-                      After creating this monitor, you'll receive a unique push URL. Your cron job or worker should POST
-                      to it on each successful run. If no ping is received within the check interval, Beacon will fire
-                      an alert.
+                  <div className="rounded-lg rounded-lg border border-border bg-sidebar p-4">
+                    <p className="text-muted-fg text-sm">
+                      After creating this monitor, you'll receive a unique push URL. Your cron job
+                      or worker should POST to it on each successful run. If no ping is received
+                      within the check interval, Beacon will fire an alert.
                     </p>
                   </div>
                 )}
@@ -516,7 +550,9 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
 
                     {data.ssl_monitoring_enabled && (
                       <fieldset className="pl-6">
-                        <legend className="mb-3 text-sm font-medium text-fg">Alert when SSL expires within</legend>
+                        <legend className="mb-3 font-medium text-fg text-sm">
+                          Alert when SSL expires within
+                        </legend>
                         <div className="flex flex-wrap gap-3">
                           {sslExpiryDays.map((days) => (
                             <Checkbox
@@ -526,7 +562,9 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                                 setData(
                                   "ssl_expiry_notification_days",
                                   checked
-                                    ? [...data.ssl_expiry_notification_days, days].sort((a, b) => b - a)
+                                    ? [...data.ssl_expiry_notification_days, days].sort(
+                                        (a, b) => b - a,
+                                      )
                                     : data.ssl_expiry_notification_days.filter((d) => d !== days),
                                 )
                               }}
@@ -546,8 +584,8 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
             {activeKey === "assertions" && (
               <div className="space-y-5">
                 <div>
-                  <p className="mb-1 text-sm font-medium text-fg">Accepted status codes</p>
-                  <p className="mb-4 text-xs text-muted-fg">
+                  <p className="mb-1 font-medium text-fg text-sm">Accepted status codes</p>
+                  <p className="mb-4 text-muted-fg text-xs">
                     Monitor is UP when the response matches any selected code.
                   </p>
                   <div className="flex flex-wrap gap-2">
@@ -577,9 +615,11 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                   </div>
                 </div>
 
-                <div className="rounded-lg border border-border rounded-lg bg-sidebar p-4">
-                  <p className="font-mono text-xs text-muted-fg">
-                    // monitor is DOWN when status code is not in the accepted list, or when the request times out
+                <div className="rounded-lg rounded-lg border border-border bg-sidebar p-4">
+                  <p className="font-mono text-muted-fg text-xs">
+                    {
+                      "// monitor is DOWN when status code is not in the accepted list, or when the request times out"
+                    }
                   </p>
                 </div>
               </div>
@@ -590,7 +630,9 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
               <div className="space-y-6">
                 {notificationChannels.length > 0 ? (
                   <fieldset>
-                    <legend className="mb-3 text-sm font-medium text-fg">Notification channels</legend>
+                    <legend className="mb-3 font-medium text-fg text-sm">
+                      Notification channels
+                    </legend>
                     <div className="space-y-2">
                       {notificationChannels.map((channel) => {
                         const on = data.notification_channel_ids.includes(channel.id)
@@ -607,10 +649,16 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                                   : [...data.notification_channel_ids, channel.id],
                               )
                             }
-                            onKeyDown={(e) => e.key === "Enter" || e.key === " " ? e.currentTarget.click() : undefined}
+                            onKeyDown={(e) =>
+                              e.key === "Enter" || e.key === " "
+                                ? e.currentTarget.click()
+                                : undefined
+                            }
                             className={[
                               "flex cursor-pointer items-center gap-4 rounded-lg border p-3.5 transition-colors",
-                              on ? "border-primary/50 bg-primary-subtle" : "border-border hover:border-primary/30",
+                              on
+                                ? "border-primary/50 bg-primary-subtle"
+                                : "border-border hover:border-primary/30",
                             ].join(" ")}
                           >
                             {/* toggle knob */}
@@ -628,8 +676,8 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                               />
                             </div>
                             <div className="min-w-0 flex-1">
-                              <p className="text-sm font-medium text-fg">{channel.name}</p>
-                              <p className="text-xs capitalize text-muted-fg">{channel.type}</p>
+                              <p className="font-medium text-fg text-sm">{channel.name}</p>
+                              <p className="text-muted-fg text-xs capitalize">{channel.type}</p>
                             </div>
                           </div>
                         )
@@ -637,11 +685,11 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     </div>
                   </fieldset>
                 ) : (
-                  <div className="rounded-lg border border-border rounded-lg bg-sidebar p-5 text-center">
-                    <p className="text-sm text-muted-fg">No notification channels configured.</p>
+                  <div className="rounded-lg rounded-lg border border-border bg-sidebar p-5 text-center">
+                    <p className="text-muted-fg text-sm">No notification channels configured.</p>
                     <Link
                       href="/notification-channels/create"
-                      className="mt-2 block text-xs text-primary hover:underline"
+                      className="mt-2 block text-primary text-xs hover:underline"
                     >
                       Set one up →
                     </Link>
@@ -650,7 +698,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
 
                 {tags.length > 0 && (
                   <fieldset>
-                    <legend className="mb-3 text-sm font-medium text-fg">Tags</legend>
+                    <legend className="mb-3 font-medium text-fg text-sm">Tags</legend>
                     <div className="flex flex-wrap gap-3">
                       {tags.map((tag) => (
                         <Checkbox
@@ -679,7 +727,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
             )}
 
             {/* footer nav */}
-            <div className="mt-12 flex items-center justify-between border-t border-border pt-6">
+            <div className="mt-12 flex items-center justify-between border-border border-t pt-6">
               <Button type="button" intent="outline" onPress={goPrev} isDisabled={isFirst}>
                 ← Back
               </Button>
@@ -691,7 +739,11 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     key={s.key}
                     className={[
                       "h-1 rounded-full transition-all duration-200",
-                      s.key === activeKey ? "w-6 bg-primary" : i < activeIndex ? "w-4 bg-primary/40" : "w-4 bg-border",
+                      s.key === activeKey
+                        ? "w-6 bg-primary"
+                        : i < activeIndex
+                          ? "w-4 bg-primary/40"
+                          : "w-4 bg-border",
                     ].join(" ")}
                   />
                 ))}
@@ -702,7 +754,9 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                   {isEditing ? "Save changes" : "Create monitor"}
                 </Button>
               ) : (
-                <Button key="continue" type="button" onPress={goNext}>Continue →</Button>
+                <Button key="continue" type="button" onPress={goNext}>
+                  Continue →
+                </Button>
               )}
             </div>
           </div>

--- a/resources/js/pages/monitors/components/monitor-wizard.tsx
+++ b/resources/js/pages/monitors/components/monitor-wizard.tsx
@@ -205,7 +205,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
           </div>
 
           {/* summary */}
-          <div className="mt-5 rounded-lg border border-border bg-sidebar p-3.5">
+          <div className="mt-5 rounded-lg border border-border rounded-lg bg-sidebar p-3.5">
             <p className="mb-2 text-xs font-medium text-fg">Summary</p>
             <div className="space-y-1 text-[11px] leading-relaxed text-muted-fg">
               <p>
@@ -351,7 +351,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     {/* headers table */}
                     <div>
                       <Label>Headers</Label>
-                      <div className="mt-2 overflow-hidden rounded-lg border border-border">
+                      <div className="mt-2 overflow-hidden rounded-lg border border-border rounded-lg">
                         {headerRows.length > 0 && (
                           <div className="grid grid-cols-[1fr_1fr_36px] bg-sidebar text-[11px] uppercase tracking-wider text-muted-fg">
                             <div className="border-b border-border px-3 py-2">Key</div>
@@ -446,7 +446,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                 )}
 
                 {data.type === "push" && (
-                  <div className="rounded-lg border border-border bg-sidebar p-4">
+                  <div className="rounded-lg border border-border rounded-lg bg-sidebar p-4">
                     <p className="text-sm text-muted-fg">
                       After creating this monitor, you'll receive a unique push URL. Your cron job or worker should POST
                       to it on each successful run. If no ping is received within the check interval, Beacon will fire
@@ -577,7 +577,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                   </div>
                 </div>
 
-                <div className="rounded-lg border border-border bg-sidebar p-4">
+                <div className="rounded-lg border border-border rounded-lg bg-sidebar p-4">
                   <p className="font-mono text-xs text-muted-fg">
                     // monitor is DOWN when status code is not in the accepted list, or when the request times out
                   </p>
@@ -637,7 +637,7 @@ export default function MonitorWizard({ monitor, tags, notificationChannels, gro
                     </div>
                   </fieldset>
                 ) : (
-                  <div className="rounded-lg border border-border bg-sidebar p-5 text-center">
+                  <div className="rounded-lg border border-border rounded-lg bg-sidebar p-5 text-center">
                     <p className="text-sm text-muted-fg">No notification channels configured.</p>
                     <Link
                       href="/notification-channels/create"

--- a/resources/js/pages/monitors/index.tsx
+++ b/resources/js/pages/monitors/index.tsx
@@ -4,10 +4,11 @@ import { useCallback, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Link } from "@/components/ui/link"
+import { Tracker } from "@/components/ui/tracker"
 import { useMonitorFilters } from "@/hooks/use-monitor-filters"
 import AppLayout from "@/layouts/app-layout"
 import { uptimeColor } from "@/lib/color"
-import { formatInterval } from "@/lib/heartbeats"
+import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import monitorRoutes from "@/routes/monitors"
 import { useHydrateMonitors, useMonitors } from "@/stores/monitor-realtime"
 import type { Heartbeat, Monitor, MonitorGroup, Tag } from "@/types/monitor"
@@ -45,34 +46,15 @@ function statusCounts(monitors: Monitor[]) {
   }
 }
 
-type BarState = "up" | "slow" | "down" | "empty"
-
-function HeartbeatBars({ heartbeats, status }: { heartbeats?: Heartbeat[]; status: string }) {
-  const bars = useMemo<BarState[]>(() => {
-    const result: BarState[] = Array(HEARTBEAT_COUNT).fill("empty")
-    if (!heartbeats || heartbeats.length === 0) return result
-
-    // compute avg response time to detect slow ("degraded") beats
-    const upTimes = heartbeats
-      .filter((hb) => hb.status === "up" && hb.response_time != null)
-      .map((hb) => hb.response_time as number)
-    const avg = upTimes.length > 0 ? upTimes.reduce((a, b) => a + b, 0) / upTimes.length : 0
-    const slowThreshold = Math.max(avg * 2, 1500) // 2× avg, min 1.5 s
-
-    const recent = [...heartbeats].slice(-HEARTBEAT_COUNT)
-    const offset = HEARTBEAT_COUNT - recent.length
-    recent.forEach((hb, i) => {
-      if (hb.status === "down") {
-        result[offset + i] = "down"
-      } else if (hb.response_time != null && avg > 0 && hb.response_time > slowThreshold) {
-        result[offset + i] = "slow"
-      } else {
-        result[offset + i] = "up"
-      }
-    })
-    return result
-  }, [heartbeats])
-
+function HeartbeatBars({
+  heartbeats,
+  status,
+  monitorName,
+}: {
+  heartbeats?: Heartbeat[]
+  status: string
+  monitorName: string
+}) {
   if (status === "paused") {
     return (
       <div className="flex h-[22px] items-center">
@@ -82,29 +64,11 @@ function HeartbeatBars({ heartbeats, status }: { heartbeats?: Heartbeat[]; statu
   }
 
   return (
-    <div
-      className="grid h-[22px] w-full gap-[1.5px]"
-      style={{ gridTemplateColumns: `repeat(${HEARTBEAT_COUNT}, 1fr)` }}
-    >
-      {bars.map((b, i) => (
-        <div
-          key={i}
-          style={{
-            borderRadius: 1,
-            height: "100%",
-            background:
-              b === "up"
-                ? "var(--color-success)"
-                : b === "slow"
-                  ? "var(--color-warning)"
-                  : b === "down"
-                    ? "var(--color-danger)"
-                    : "var(--color-muted-fg)",
-            opacity: b === "up" ? 0.4 : b === "empty" ? 0.18 : 1,
-          }}
-        />
-      ))}
-    </div>
+    <Tracker
+      data={heartbeatsToTracker(heartbeats, HEARTBEAT_COUNT)}
+      className="h-[22px] w-full"
+      aria-label={`Uptime history for ${monitorName} — last ${HEARTBEAT_COUNT} checks`}
+    />
   )
 }
 
@@ -247,7 +211,11 @@ function MonitorRow({
       </div>
 
       {/* heartbeats */}
-      <HeartbeatBars heartbeats={monitor.heartbeats} status={monitor.status} />
+      <HeartbeatBars
+        heartbeats={monitor.heartbeats}
+        status={monitor.status}
+        monitorName={monitor.name}
+      />
 
       {/* uptime */}
       <div>

--- a/resources/js/pages/monitors/index.tsx
+++ b/resources/js/pages/monitors/index.tsx
@@ -244,7 +244,7 @@ function MonitorRow({
 
       {/* type */}
       <div>
-        <span className="border border-border text-muted-fg text-xs px-2 py-0.5 rounded-sm font-mono">
+        <span className="border border-border rounded-lg text-muted-fg text-xs px-2 py-0.5 rounded-sm font-mono">
           {monitor.type.toUpperCase()}
         </span>
       </div>
@@ -354,7 +354,7 @@ function MonitorToolbar({
                 "flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors",
                 active
                   ? "bg-primary text-primary-fg"
-                  : "border border-border text-muted-fg hover:text-fg hover:border-fg/30",
+                  : "border border-border rounded-lg text-muted-fg hover:text-fg hover:border-fg/30",
               ].join(" ")}
             >
               <span>{label}</span>
@@ -378,7 +378,7 @@ function MonitorToolbar({
                     "px-3 py-1 rounded-full text-xs transition-colors",
                     active
                       ? "border-2 font-medium"
-                      : "border border-border text-muted-fg hover:text-fg hover:border-fg/30",
+                      : "border border-border rounded-lg text-muted-fg hover:text-fg hover:border-fg/30",
                   ].join(" ")}
                   style={
                     active
@@ -403,9 +403,9 @@ function MonitorToolbar({
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="name, url, tag…"
-            className="pl-8 pr-8 py-1.5 text-xs rounded-md border border-border bg-transparent text-fg placeholder:text-muted-fg focus:outline-none focus:ring-1 focus:ring-ring w-52"
+            className="pl-8 pr-8 py-1.5 text-xs rounded-md border border-border rounded-lg bg-transparent text-fg placeholder:text-muted-fg focus:outline-none focus:ring-1 focus:ring-ring w-52"
           />
-          <span className="absolute right-2 text-[10px] text-muted-fg border border-border rounded px-1 pointer-events-none">
+          <span className="absolute right-2 text-[10px] text-muted-fg border border-border rounded-lg rounded px-1 pointer-events-none">
             /
           </span>
         </div>

--- a/resources/js/pages/monitors/index.tsx
+++ b/resources/js/pages/monitors/index.tsx
@@ -1,6 +1,6 @@
 import { MagnifyingGlassIcon, PlusIcon } from "@heroicons/react/20/solid"
 import { Head, router, WhenVisible } from "@inertiajs/react"
-import { useCallback, useMemo, useRef, useState } from "react"
+import { memo, useCallback, useId, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Link } from "@/components/ui/link"
@@ -73,7 +73,7 @@ function HeartbeatBars({
 }
 
 function ResponseSparkline({ heartbeats, status }: { heartbeats?: Heartbeat[]; status: string }) {
-  const id = useRef(`spark-${Math.random().toString(36).slice(2)}`)
+  const id = useId()
 
   const path = useMemo(() => {
     if (!heartbeats || heartbeats.length < 2 || status === "paused") return null
@@ -111,12 +111,12 @@ function ResponseSparkline({ heartbeats, status }: { heartbeats?: Heartbeat[]; s
       className="mt-1 block"
     >
       <defs>
-        <linearGradient id={id.current} x1="0" x2="0" y1="0" y2="1">
+        <linearGradient id={id} x1="0" x2="0" y1="0" y2="1">
           <stop offset="0%" stopColor={colorVar} stopOpacity="0.3" />
           <stop offset="100%" stopColor={colorVar} stopOpacity="0" />
         </linearGradient>
       </defs>
-      <path d={path.fill} fill={`url(#${id.current})`} />
+      <path d={path.fill} fill={`url(#${id})`} />
       <path d={path.line} fill="none" stroke={colorVar} strokeWidth="1.2" />
     </svg>
   )
@@ -161,15 +161,20 @@ function TableHeader() {
   )
 }
 
-function MonitorRow({
-  monitor,
-  isSelected,
-  onToggleSelect,
-}: {
+type MonitorRowProps = {
   monitor: Monitor
   isSelected?: boolean
   onToggleSelect?: (id: number) => void
-}) {
+}
+
+export function monitorRowAreEqual(
+  prev: Pick<MonitorRowProps, "monitor" | "isSelected">,
+  next: Pick<MonitorRowProps, "monitor" | "isSelected">,
+): boolean {
+  return prev.monitor === next.monitor && prev.isSelected === next.isSelected
+}
+
+function MonitorRowImpl({ monitor, isSelected, onToggleSelect }: MonitorRowProps) {
   const dot = STATUS_DOT_CLASS[monitor.status] ?? "bg-muted-fg"
   const labelClass = STATUS_LABEL_CLASS[monitor.status] ?? "text-muted-fg"
 
@@ -275,6 +280,8 @@ function MonitorRow({
     </div>
   )
 }
+
+const MonitorRow = memo(MonitorRowImpl, monitorRowAreEqual)
 
 function MonitorToolbar({
   monitors,

--- a/resources/js/pages/monitors/index.tsx
+++ b/resources/js/pages/monitors/index.tsx
@@ -1,37 +1,27 @@
-import AppLayout from "@/layouts/app-layout"
-import type { SharedData } from "@/types/shared"
-import { Head, router, usePage, WhenVisible } from "@inertiajs/react"
-import { useEcho } from "@laravel/echo-react"
+import { MagnifyingGlassIcon, PlusIcon } from "@heroicons/react/20/solid"
+import { Head, router, WhenVisible } from "@inertiajs/react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Link } from "@/components/ui/link"
-import type { Monitor, Tag, Heartbeat, MonitorGroup } from "@/types/monitor"
 import { Checkbox } from "@/components/ui/checkbox"
-import { PlusIcon, MagnifyingGlassIcon } from "@heroicons/react/20/solid"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Link } from "@/components/ui/link"
+import { useMonitorFilters } from "@/hooks/use-monitor-filters"
+import AppLayout from "@/layouts/app-layout"
+import { uptimeColor } from "@/lib/color"
+import { formatInterval } from "@/lib/heartbeats"
+import monitorRoutes from "@/routes/monitors"
+import { useHydrateMonitors, useMonitors } from "@/stores/monitor-realtime"
+import type { Heartbeat, Monitor, MonitorGroup, Tag } from "@/types/monitor"
+import BulkActionToolbar from "./components/bulk-action-toolbar"
 import CreateMonitorModal from "./components/create-monitor-modal"
+import ImportExportSection from "./components/import-export-section"
 import MonitorGroupModal from "./components/monitor-group-modal"
 import MonitorGroupSection from "./components/monitor-group-section"
-import BulkActionToolbar from "./components/bulk-action-toolbar"
-import ImportExportSection from "./components/import-export-section"
-import { useMonitorFilters } from "@/hooks/use-monitor-filters"
-import { uptimeColor, statusBadgeIntent } from "@/lib/color"
-import monitorRoutes from "@/routes/monitors"
-import { formatInterval } from "@/lib/heartbeats"
 
 interface Props {
   monitors?: Monitor[]
   tags: Tag[]
   groups: MonitorGroup[]
   trashedCount: number
-}
-
-interface HeartbeatPayload {
-  monitorId: number
-  heartbeat: Heartbeat
-  monitorStatus: string
-  uptimePercentage: number
-  averageResponseTime: number | null
 }
 
 const HEARTBEAT_COUNT = 48
@@ -85,14 +75,17 @@ function HeartbeatBars({ heartbeats, status }: { heartbeats?: Heartbeat[]; statu
 
   if (status === "paused") {
     return (
-      <div className="flex items-center h-[22px]">
+      <div className="flex h-[22px] items-center">
         <span className="text-muted-fg text-xs">—</span>
       </div>
     )
   }
 
   return (
-    <div className="grid gap-[1.5px] h-[22px] w-full" style={{ gridTemplateColumns: `repeat(${HEARTBEAT_COUNT}, 1fr)` }}>
+    <div
+      className="grid h-[22px] w-full gap-[1.5px]"
+      style={{ gridTemplateColumns: `repeat(${HEARTBEAT_COUNT}, 1fr)` }}
+    >
       {bars.map((b, i) => (
         <div
           key={i}
@@ -100,10 +93,13 @@ function HeartbeatBars({ heartbeats, status }: { heartbeats?: Heartbeat[]; statu
             borderRadius: 1,
             height: "100%",
             background:
-              b === "up"    ? "var(--color-success)" :
-              b === "slow"  ? "var(--color-warning)" :
-              b === "down"  ? "var(--color-danger)"  :
-                              "var(--color-muted-fg)",
+              b === "up"
+                ? "var(--color-success)"
+                : b === "slow"
+                  ? "var(--color-warning)"
+                  : b === "down"
+                    ? "var(--color-danger)"
+                    : "var(--color-muted-fg)",
             opacity: b === "up" ? 0.4 : b === "empty" ? 0.18 : 1,
           }}
         />
@@ -136,7 +132,7 @@ function ResponseSparkline({ heartbeats, status }: { heartbeats?: Heartbeat[]; s
   }, [heartbeats, status])
 
   if (!path) {
-    return <div className="h-8 flex items-center text-muted-fg text-xs">—</div>
+    return <div className="flex h-8 items-center text-muted-fg text-xs">—</div>
   }
 
   const isDown = status === "down"
@@ -148,7 +144,7 @@ function ResponseSparkline({ heartbeats, status }: { heartbeats?: Heartbeat[]; s
       height="32"
       viewBox="0 0 120 24"
       preserveAspectRatio="none"
-      className="block mt-1"
+      className="mt-1 block"
     >
       <defs>
         <linearGradient id={id.current} x1="0" x2="0" y1="0" y2="1">
@@ -178,13 +174,14 @@ const STATUS_LABEL_CLASS: Record<string, string> = {
 
 // Matches design: 32px 280px 70px 0.9fr 88px 220px 84px 110px 36px
 const COL_STYLE: React.CSSProperties = {
-  gridTemplateColumns: "32px minmax(0, 280px) 70px minmax(0, 0.9fr) 88px minmax(0, 220px) 84px 110px 36px",
+  gridTemplateColumns:
+    "32px minmax(0, 280px) 70px minmax(0, 0.9fr) 88px minmax(0, 220px) 84px 110px 36px",
 }
 
 function TableHeader() {
   return (
     <div
-      className="grid gap-x-4 px-6 py-3 bg-muted/30 border-b border-border text-muted-fg text-xs uppercase tracking-wider font-medium"
+      className="grid gap-x-4 border-border border-b bg-muted/30 px-6 py-3 font-medium text-muted-fg text-xs uppercase tracking-wider"
       style={COL_STYLE}
     >
       <div />
@@ -214,7 +211,7 @@ function MonitorRow({
 
   return (
     <div
-      className="grid gap-x-4 px-6 py-3.5 border-t border-border items-center text-sm transition-colors hover:bg-muted/20"
+      className="grid items-center gap-x-4 border-border border-t px-6 py-3.5 text-sm transition-colors hover:bg-muted/20"
       style={COL_STYLE}
     >
       {/* checkbox */}
@@ -231,12 +228,12 @@ function MonitorRow({
       {/* name + url */}
       <Link
         href={monitorRoutes.show.url(monitor.id)}
-        className="flex items-center gap-3 min-w-0 no-underline"
+        className="flex min-w-0 items-center gap-3 no-underline"
       >
-        <span className={`shrink-0 w-2.5 h-2.5 rounded-full ${dot}`} />
+        <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${dot}`} />
         <div className="min-w-0">
-          <div className="font-medium text-fg text-sm truncate">{monitor.name}</div>
-          <div className="text-muted-fg text-xs truncate mt-0.5">
+          <div className="truncate font-medium text-fg text-sm">{monitor.name}</div>
+          <div className="mt-0.5 truncate text-muted-fg text-xs">
             {monitor.url || monitor.host || "—"}
           </div>
         </div>
@@ -244,7 +241,7 @@ function MonitorRow({
 
       {/* type */}
       <div>
-        <span className="border border-border rounded-lg text-muted-fg text-xs px-2 py-0.5 rounded-sm font-mono">
+        <span className="rounded-lg rounded-sm border border-border px-2 py-0.5 font-mono text-muted-fg text-xs">
           {monitor.type.toUpperCase()}
         </span>
       </div>
@@ -255,7 +252,7 @@ function MonitorRow({
       {/* uptime */}
       <div>
         <div
-          className={`font-medium tabular-nums text-sm ${
+          className={`font-medium text-sm tabular-nums ${
             monitor.uptime_percentage !== undefined
               ? uptimeColor(monitor.uptime_percentage)
               : "text-muted-fg"
@@ -265,12 +262,12 @@ function MonitorRow({
             ? `${monitor.uptime_percentage.toFixed(2)}%`
             : "—"}
         </div>
-        <div className="text-muted-fg text-xs mt-0.5">30d</div>
+        <div className="mt-0.5 text-muted-fg text-xs">30d</div>
       </div>
 
       {/* response + sparkline */}
       <div>
-        <div className="text-fg tabular-nums text-sm">
+        <div className="text-fg text-sm tabular-nums">
           {monitor.average_response_time != null
             ? `${Math.round(monitor.average_response_time)} ms`
             : "—"}
@@ -279,16 +276,16 @@ function MonitorRow({
       </div>
 
       {/* interval */}
-      <div className="text-muted-fg text-xs font-mono">
+      <div className="font-mono text-muted-fg text-xs">
         every {formatInterval(monitor.interval)}
       </div>
 
       {/* last check */}
       <div className="text-right">
-        <div className="text-muted-fg text-xs font-mono">
+        <div className="font-mono text-muted-fg text-xs">
           {monitor.status === "paused" ? "paused" : timeAgo(monitor.last_checked_at)}
         </div>
-        <div className={`text-[10px] mt-0.5 uppercase tracking-wide font-mono ${labelClass}`}>
+        <div className={`mt-0.5 font-mono text-[10px] uppercase tracking-wide ${labelClass}`}>
           {monitor.status}
         </div>
       </div>
@@ -301,7 +298,7 @@ function MonitorRow({
             e.preventDefault()
             router.visit(monitorRoutes.show.url(monitor.id))
           }}
-          className="text-muted-fg hover:text-fg text-base leading-none p-1 rounded"
+          className="rounded p-1 text-base text-muted-fg leading-none hover:text-fg"
           aria-label={`Actions for ${monitor.name}`}
         >
           ⋯
@@ -340,7 +337,7 @@ function MonitorToolbar({
   ]
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-3 border-b border-border">
+    <div className="flex flex-wrap items-center justify-between gap-3 border-border border-b px-6 py-3">
       {/* left: status + tag pills */}
       <div className="flex flex-wrap items-center gap-2">
         {statusPills.map(({ key, label, count }) => {
@@ -351,10 +348,10 @@ function MonitorToolbar({
               type="button"
               onClick={() => onStatusFilterChange(key)}
               className={[
-                "flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors",
+                "flex items-center gap-1.5 rounded-full px-3 py-1 font-medium text-xs transition-colors",
                 active
                   ? "bg-primary text-primary-fg"
-                  : "border border-border rounded-lg text-muted-fg hover:text-fg hover:border-fg/30",
+                  : "rounded-lg border border-border text-muted-fg hover:border-fg/30 hover:text-fg",
               ].join(" ")}
             >
               <span>{label}</span>
@@ -365,7 +362,7 @@ function MonitorToolbar({
 
         {tags.length > 0 && (
           <>
-            <div className="w-px h-4 bg-border mx-1" />
+            <div className="mx-1 h-4 w-px bg-border" />
             <span className="text-muted-fg text-xs">tags</span>
             {tags.map((tag) => {
               const active = tagFilter === tag.id
@@ -375,16 +372,12 @@ function MonitorToolbar({
                   type="button"
                   onClick={() => onTagFilterChange(active ? null : tag.id)}
                   className={[
-                    "px-3 py-1 rounded-full text-xs transition-colors",
+                    "rounded-full px-3 py-1 text-xs transition-colors",
                     active
                       ? "border-2 font-medium"
-                      : "border border-border rounded-lg text-muted-fg hover:text-fg hover:border-fg/30",
+                      : "rounded-lg border border-border text-muted-fg hover:border-fg/30 hover:text-fg",
                   ].join(" ")}
-                  style={
-                    active
-                      ? { borderColor: tag.color, color: tag.color }
-                      : undefined
-                  }
+                  style={active ? { borderColor: tag.color, color: tag.color } : undefined}
                 >
                   #{tag.name}
                 </button>
@@ -395,17 +388,17 @@ function MonitorToolbar({
       </div>
 
       {/* right: search */}
-      <div className="flex items-center gap-2 shrink-0">
+      <div className="flex shrink-0 items-center gap-2">
         <div className="relative flex items-center">
-          <MagnifyingGlassIcon className="absolute left-2.5 size-3.5 text-muted-fg pointer-events-none" />
+          <MagnifyingGlassIcon className="pointer-events-none absolute left-2.5 size-3.5 text-muted-fg" />
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="name, url, tag…"
-            className="pl-8 pr-8 py-1.5 text-xs rounded-md border border-border rounded-lg bg-transparent text-fg placeholder:text-muted-fg focus:outline-none focus:ring-1 focus:ring-ring w-52"
+            className="w-52 rounded-lg rounded-md border border-border bg-transparent py-1.5 pr-8 pl-8 text-fg text-xs placeholder:text-muted-fg focus:outline-none focus:ring-1 focus:ring-ring"
           />
-          <span className="absolute right-2 text-[10px] text-muted-fg border border-border rounded-lg rounded px-1 pointer-events-none">
+          <span className="pointer-events-none absolute right-2 rounded rounded-lg border border-border px-1 text-[10px] text-muted-fg">
             /
           </span>
         </div>
@@ -468,13 +461,13 @@ function MonitorTable({
   return (
     <div>
       {/* select-all row */}
-      <div className="flex items-center gap-2 px-6 py-2 border-b border-border">
+      <div className="flex items-center gap-2 border-border border-b px-6 py-2">
         <Checkbox
           isSelected={selectedIds.length === filteredMonitors.length && filteredMonitors.length > 0}
           onChange={toggleSelectAll}
           aria-label="Select all monitors"
         />
-        <span className="text-xs text-muted-fg">Select all</span>
+        <span className="text-muted-fg text-xs">Select all</span>
       </div>
 
       <TableHeader />
@@ -501,7 +494,7 @@ function MonitorTable({
       {ungroupedMonitors.length > 0 && (
         <div>
           {hasGroups && groupedMonitors[0] && (
-            <div className="px-6 py-2 text-muted-fg text-xs uppercase tracking-wider font-medium border-b border-border">
+            <div className="border-border border-b px-6 py-2 font-medium text-muted-fg text-xs uppercase tracking-wider">
               Ungrouped
             </div>
           )}
@@ -521,23 +514,22 @@ function MonitorTable({
           .filter((g) => !groupedMonitors[g.id]?.length)
           .map((group) => (
             <MonitorGroupSection key={group.id} group={group} monitorCount={0}>
-              <p className="py-4 text-center text-muted-fg text-sm">
-                No monitors in this group.
-              </p>
+              <p className="py-4 text-center text-muted-fg text-sm">No monitors in this group.</p>
             </MonitorGroupSection>
           ))}
     </div>
   )
 }
 
-export default function MonitorsIndex({ monitors: initialMonitors, tags, groups, trashedCount }: Props) {
-  const { auth } = usePage<SharedData>().props
-  const [monitors, setMonitors] = useState(initialMonitors)
+export default function MonitorsIndex({
+  monitors: initialMonitors,
+  tags,
+  groups,
+  trashedCount,
+}: Props) {
+  useHydrateMonitors(initialMonitors)
+  const monitors = useMonitors()
   const [selectedIds, setSelectedIds] = useState<number[]>([])
-
-  useEffect(() => {
-    if (initialMonitors) setMonitors(initialMonitors)
-  }, [initialMonitors])
 
   const {
     filteredMonitors,
@@ -548,53 +540,10 @@ export default function MonitorsIndex({ monitors: initialMonitors, tags, groups,
     tagFilter,
     setTagFilter,
     isFiltering,
-  } = useMonitorFilters(monitors ?? [])
-
-  const handleChecking = useCallback((payload: { monitorId: number }) => {
-    setMonitors((prev) =>
-      prev?.map((m) =>
-        m.id === payload.monitorId ? { ...m, status: "pending" as Monitor["status"] } : m,
-      ),
-    )
-  }, [])
-
-  const handleHeartbeat = useCallback((payload: HeartbeatPayload) => {
-    setMonitors((prev) =>
-      prev?.map((m) => {
-        if (m.id !== payload.monitorId) return m
-        const updatedHeartbeats = [...(m.heartbeats ?? []), payload.heartbeat].slice(-90)
-        return {
-          ...m,
-          status: payload.monitorStatus as Monitor["status"],
-          heartbeats: updatedHeartbeats,
-          uptime_percentage: payload.uptimePercentage,
-          average_response_time: payload.averageResponseTime,
-        }
-      }),
-    )
-  }, [])
-
-  const handleStatusChanged = useCallback(
-    (payload: { monitorId: number; newStatus: string }) => {
-      setMonitors((prev) =>
-        prev?.map((m) =>
-          m.id === payload.monitorId
-            ? { ...m, status: payload.newStatus as Monitor["status"] }
-            : m,
-        ),
-      )
-    },
-    [],
-  )
-
-  useEcho(`monitors.${auth.user.id}`, ".MonitorChecking", handleChecking)
-  useEcho(`monitors.${auth.user.id}`, ".HeartbeatRecorded", handleHeartbeat)
-  useEcho(`monitors.${auth.user.id}`, ".MonitorStatusChanged", handleStatusChanged)
+  } = useMonitorFilters(monitors)
 
   const toggleSelect = useCallback((id: number) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id],
-    )
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]))
   }, [])
 
   const toggleSelectAll = useCallback(() => {
@@ -605,23 +554,26 @@ export default function MonitorsIndex({ monitors: initialMonitors, tags, groups,
     }
   }, [filteredMonitors, selectedIds.length])
 
-  const totalCount = monitors?.length ?? 0
+  const totalCount = monitors.length
 
   return (
     <>
       <Head title="Monitors" />
       <div className="min-h-screen">
         {/* page header */}
-        <div className="flex items-center justify-between px-6 py-5 border-b border-border gap-4">
+        <div className="flex items-center justify-between gap-4 border-border border-b px-6 py-5">
           <div>
-            <h1 className="text-2xl font-medium tracking-tight text-fg">
-              Monitors{" "}
-              <span className="text-muted-fg font-normal text-lg">· {totalCount}</span>
+            <h1 className="font-medium text-2xl text-fg tracking-tight">
+              Monitors <span className="font-normal text-lg text-muted-fg">· {totalCount}</span>
             </h1>
           </div>
           <div className="flex items-center gap-2">
             {trashedCount > 0 && (
-              <Button intent="outline" size="sm" onPress={() => router.visit(monitorRoutes.trashed.url())}>
+              <Button
+                intent="outline"
+                size="sm"
+                onPress={() => router.visit(monitorRoutes.trashed.url())}
+              >
                 Trash ({trashedCount})
               </Button>
             )}
@@ -665,10 +617,7 @@ export default function MonitorsIndex({ monitors: initialMonitors, tags, groups,
                 tagFilter={tagFilter}
                 onTagFilterChange={setTagFilter}
               />
-              <BulkActionToolbar
-                selectedIds={selectedIds}
-                onClear={() => setSelectedIds([])}
-              />
+              <BulkActionToolbar selectedIds={selectedIds} onClear={() => setSelectedIds([])} />
               <MonitorTable
                 filteredMonitors={filteredMonitors}
                 groups={groups}
@@ -682,7 +631,7 @@ export default function MonitorsIndex({ monitors: initialMonitors, tags, groups,
               />
 
               {/* footer */}
-              <div className="flex items-center justify-between px-6 py-4 border-t border-border text-xs text-muted-fg font-mono">
+              <div className="flex items-center justify-between border-border border-t px-6 py-4 font-mono text-muted-fg text-xs">
                 <div>
                   showing {filteredMonitors.length} of {totalCount}
                 </div>
@@ -694,7 +643,7 @@ export default function MonitorsIndex({ monitors: initialMonitors, tags, groups,
           ) : (
             <div className="py-16 text-center">
               <p className="font-medium text-fg">No monitors yet</p>
-              <p className="mt-1 text-sm text-muted-fg">
+              <p className="mt-1 text-muted-fg text-sm">
                 Add a URL, host, or IP to start tracking uptime.
               </p>
               <CreateMonitorModal>

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -1,12 +1,22 @@
-import AppLayout from "@/layouts/app-layout"
-import type { SharedData } from "@/types/shared"
+import {
+  ArrowPathIcon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  TrashIcon,
+} from "@heroicons/react/20/solid"
 import { Head, router, usePage, WhenVisible } from "@inertiajs/react"
 import { useEcho } from "@laravel/echo-react"
-import { Container } from "@/components/ui/container"
-import { Button } from "@/components/ui/button"
+import { useCallback, useEffect, useState } from "react"
+import { Area, AreaChart } from "recharts"
+import CheckSslCertificateController from "@/actions/App/Http/Controllers/CheckSslCertificateController"
+import ConfirmDeleteModal from "@/components/confirm-delete-modal"
+import { TagBadge } from "@/components/tag-badge"
 import { Badge } from "@/components/ui/badge"
-import { Tracker } from "@/components/ui/tracker"
-import { Tabs, TabList, Tab, TabPanel } from "@/components/ui/tabs"
+import { Button } from "@/components/ui/button"
+import { CartesianGrid, Chart, ChartTooltip, XAxis, YAxis } from "@/components/ui/chart"
+import { Container } from "@/components/ui/container"
+import { Heading } from "@/components/ui/heading"
 import {
   Table,
   TableBody,
@@ -15,18 +25,21 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import type { Monitor, Heartbeat, Incident, UptimeStats, ChartDataPoint, SslCertificate } from "@/types/monitor"
-import { PencilIcon, PauseIcon, PlayIcon, TrashIcon, ArrowPathIcon } from "@heroicons/react/20/solid"
-import ConfirmDeleteModal from "@/components/confirm-delete-modal"
-import { TagBadge } from "@/components/tag-badge"
-import { Heading } from "@/components/ui/heading"
-import { uptimeColor, statusBadgeIntent } from "@/lib/color"
+import { Tab, TabList, TabPanel, Tabs } from "@/components/ui/tabs"
+import { Tracker } from "@/components/ui/tracker"
+import AppLayout from "@/layouts/app-layout"
+import { statusBadgeIntent, uptimeColor } from "@/lib/color"
+import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import monitorRoutes from "@/routes/monitors"
-import CheckSslCertificateController from "@/actions/App/Http/Controllers/CheckSslCertificateController"
-import { heartbeatsToTracker, formatInterval } from "@/lib/heartbeats"
-import { Chart, CartesianGrid, XAxis, YAxis, ChartTooltip } from "@/components/ui/chart"
-import { Area, AreaChart } from "recharts"
-import { useCallback, useEffect, useState } from "react"
+import type {
+  ChartDataPoint,
+  Heartbeat,
+  Incident,
+  Monitor,
+  SslCertificate,
+  UptimeStats,
+} from "@/types/monitor"
+import type { SharedData } from "@/types/shared"
 
 interface PaginationLinks {
   first: string | null
@@ -120,9 +133,7 @@ const periodLabels: Record<string, string> = {
 }
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="text-xs font-medium uppercase tracking-widest text-primary">{children}</p>
-  )
+  return <p className="font-medium text-primary text-xs uppercase tracking-widest">{children}</p>
 }
 
 export default function MonitorsShow({
@@ -207,9 +218,12 @@ export default function MonitorsShow({
       }))
       setHeartbeats((prev) => {
         if (!prev) return prev
-        return { ...prev, data: [payload.heartbeat, ...prev.data] }
+        return { ...prev, data: [...prev.data, payload.heartbeat].slice(-90) }
       })
-      if (payload.heartbeat.response_time !== null && (chartPeriod === "1h" || chartPeriod === "24h")) {
+      if (
+        payload.heartbeat.response_time !== null &&
+        (chartPeriod === "1h" || chartPeriod === "24h")
+      ) {
         setChartData((prev) => {
           if (!prev) return prev
           return [
@@ -268,25 +282,28 @@ export default function MonitorsShow({
   useEcho(`monitors.${auth.user.id}`, ".MonitorStatusChanged", handleStatusChanged)
 
   const trackerData = heartbeatsToTracker(heartbeats?.data)
+  const heartbeatsNewestFirst = heartbeats ? [...heartbeats.data].reverse() : []
 
   return (
     <>
       <Head title={monitor.name} />
-      <Container className="pb-8 pt-4">
-
+      <Container className="pt-4 pb-8">
         {/* ── Flat header ── */}
-        <div className="border-b border-border pb-6">
+        <div className="border-border border-b pb-6">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <div className="flex items-center gap-2.5">
-                <Badge intent={statusBadgeIntent[monitor.status]} className="shrink-0 text-xs font-bold uppercase tracking-wide">
+                <Badge
+                  intent={statusBadgeIntent[monitor.status]}
+                  className="shrink-0 font-bold text-xs uppercase tracking-wide"
+                >
                   {monitor.status}
                 </Badge>
-                <Heading level={2} className="truncate text-xl font-semibold leading-tight">
+                <Heading level={2} className="truncate font-semibold text-xl leading-tight">
                   {monitor.name}
                 </Heading>
               </div>
-              <p className="mt-0.5 text-sm text-muted-fg">
+              <p className="mt-0.5 text-muted-fg text-sm">
                 {monitor.url || `${monitor.host}${monitor.port ? `:${monitor.port}` : ""}`}
                 {" · "}
                 {monitor.type.toUpperCase()}
@@ -343,7 +360,7 @@ export default function MonitorsShow({
                   {Array(3)
                     .fill(null)
                     .map((_, i) => (
-                      <div key={i} className="border-r border-border p-4">
+                      <div key={i} className="border-border border-r p-4">
                         <div className="mb-2 h-2.5 w-20 animate-pulse rounded-sm bg-muted" />
                         <div className="h-7 w-16 animate-pulse rounded-sm bg-muted" />
                       </div>
@@ -352,29 +369,39 @@ export default function MonitorsShow({
               }
             >
               <>
-                <div className="border-r border-border p-4">
-                  <p className="text-xs uppercase tracking-widest text-muted-fg">30d Uptime</p>
-                  <p className={`mt-1 text-2xl font-medium ${uptimeStats ? uptimeColor(uptimeStats.uptime_30d) : "text-fg"}`}>
+                <div className="border-border border-r p-4">
+                  <p className="text-muted-fg text-xs uppercase tracking-widest">30d Uptime</p>
+                  <p
+                    className={`mt-1 font-medium text-2xl ${uptimeStats ? uptimeColor(uptimeStats.uptime_30d) : "text-fg"}`}
+                  >
                     {uptimeStats ? `${uptimeStats.uptime_30d}%` : "—"}
                   </p>
                 </div>
-                <div className="border-r border-border p-4">
-                  <p className="text-xs uppercase tracking-widest text-muted-fg">Avg Response · 24h</p>
-                  <p className="mt-1 text-2xl font-medium text-fg">
-                    {uptimeStats?.avg_response_24h ? `${Math.round(uptimeStats.avg_response_24h)} ms` : "—"}
+                <div className="border-border border-r p-4">
+                  <p className="text-muted-fg text-xs uppercase tracking-widest">
+                    Avg Response · 24h
+                  </p>
+                  <p className="mt-1 font-medium text-2xl text-fg">
+                    {uptimeStats?.avg_response_24h
+                      ? `${Math.round(uptimeStats.avg_response_24h)} ms`
+                      : "—"}
                   </p>
                 </div>
-                <div className="border-r border-border p-4">
-                  <p className="text-xs uppercase tracking-widest text-muted-fg">Avg Response · 30d</p>
-                  <p className="mt-1 text-2xl font-medium text-fg">
-                    {uptimeStats?.avg_response_30d ? `${Math.round(uptimeStats.avg_response_30d)} ms` : "—"}
+                <div className="border-border border-r p-4">
+                  <p className="text-muted-fg text-xs uppercase tracking-widest">
+                    Avg Response · 30d
+                  </p>
+                  <p className="mt-1 font-medium text-2xl text-fg">
+                    {uptimeStats?.avg_response_30d
+                      ? `${Math.round(uptimeStats.avg_response_30d)} ms`
+                      : "—"}
                   </p>
                 </div>
               </>
             </WhenVisible>
             <div className="p-4">
-              <p className="text-xs uppercase tracking-widest text-muted-fg">Last Check</p>
-              <p className="mt-1 text-2xl font-medium text-fg">
+              <p className="text-muted-fg text-xs uppercase tracking-widest">Last Check</p>
+              <p className="mt-1 font-medium text-2xl text-fg">
                 {monitor.last_checked_at ? formatTimeAgo(monitor.last_checked_at) : "Never"}
               </p>
             </div>
@@ -395,14 +422,12 @@ export default function MonitorsShow({
           {/* ── Overview ── */}
           <TabPanel id="overview" className="pt-6">
             <div className="grid gap-6 lg:grid-cols-3">
-
               {/* Left: main content */}
               <div className="space-y-4 lg:col-span-2">
-
                 {/* Uptime Tracker */}
                 <div className="border border-border p-4">
                   <SectionLabel>Uptime Tracker</SectionLabel>
-                  <p className="mb-3 mt-1 text-xs text-muted-fg">Last 90 heartbeats</p>
+                  <p className="mt-1 mb-3 text-muted-fg text-xs">Last 90 heartbeats</p>
                   <WhenVisible
                     fallback={<div className="h-8 animate-pulse rounded-sm bg-muted" />}
                     data="heartbeats"
@@ -416,7 +441,7 @@ export default function MonitorsShow({
 
                 {/* Response Time + Distribution */}
                 <div className="border border-border">
-                  <div className="flex items-center justify-between border-b border-border px-4 py-3">
+                  <div className="flex items-center justify-between border-border border-b px-4 py-3">
                     <SectionLabel>
                       Response Time · {periodLabels[chartPeriod] ?? chartPeriod}
                     </SectionLabel>
@@ -449,11 +474,16 @@ export default function MonitorsShow({
                           const minTime = chartPoints[0]?.time ?? 0
                           const maxTime = chartPoints[chartPoints.length - 1]?.time ?? 0
                           const TICK_COUNT = 5
-                          const xTicks = chartPoints.length <= TICK_COUNT
-                            ? chartPoints.map((p) => p.time)
-                            : Array.from({ length: TICK_COUNT }, (_, i) =>
-                                chartPoints[Math.round(i * (chartPoints.length - 1) / (TICK_COUNT - 1))].time
-                              )
+                          const xTicks =
+                            chartPoints.length <= TICK_COUNT
+                              ? chartPoints.map((p) => p.time)
+                              : Array.from(
+                                  { length: TICK_COUNT },
+                                  (_, i) =>
+                                    chartPoints[
+                                      Math.round((i * (chartPoints.length - 1)) / (TICK_COUNT - 1))
+                                    ].time,
+                                )
                           return (
                             <>
                               <Chart
@@ -462,26 +492,42 @@ export default function MonitorsShow({
                                 dataKey="time"
                                 containerHeight={200}
                               >
-                                <AreaChart data={chartPoints} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+                                <AreaChart
+                                  data={chartPoints}
+                                  margin={{ top: 4, right: 16, bottom: 0, left: 0 }}
+                                >
                                   <CartesianGrid />
                                   <XAxis
                                     dataKey="time"
                                     type="number"
                                     domain={[minTime, maxTime]}
                                     ticks={xTicks}
-                                    tickFormatter={(v: number) => formatTime(new Date(v).toISOString())}
+                                    tickFormatter={(v: number) =>
+                                      formatTime(new Date(v).toISOString())
+                                    }
                                     tick={{ transform: "translate(0, 6)" }}
                                     padding={{ left: 12, right: 12 }}
                                   />
-                                  <YAxis tickFormatter={(v: number) => `${Math.round(v)}ms`} width={56} />
+                                  <YAxis
+                                    tickFormatter={(v: number) => `${Math.round(v)}ms`}
+                                    width={56}
+                                  />
                                   <ChartTooltip
                                     content={({ active, payload }) => {
                                       if (!active || !payload?.length) return null
                                       const point = payload[0]
                                       return (
                                         <div className="border border-border bg-secondary px-3 py-2 font-mono text-xs">
-                                          <p className="text-muted-fg">{point?.payload?.time ? formatTime(new Date(point.payload.time).toISOString()) : null}</p>
-                                          <p className="font-semibold text-primary">{point?.value}ms</p>
+                                          <p className="text-muted-fg">
+                                            {point?.payload?.time
+                                              ? formatTime(
+                                                  new Date(point.payload.time).toISOString(),
+                                                )
+                                              : null}
+                                          </p>
+                                          <p className="font-semibold text-primary">
+                                            {point?.value}ms
+                                          </p>
                                         </div>
                                       )
                                     }}
@@ -498,7 +544,7 @@ export default function MonitorsShow({
                               </Chart>
 
                               {percentiles && (
-                                <div className="mt-4 grid grid-cols-4 border-t border-border pt-4 text-center">
+                                <div className="mt-4 grid grid-cols-4 border-border border-t pt-4 text-center">
                                   {(
                                     [
                                       { label: "P25", value: percentiles.p25 },
@@ -507,9 +553,12 @@ export default function MonitorsShow({
                                       { label: "P95", value: percentiles.p95 },
                                     ] as const
                                   ).map(({ label, value }, i) => (
-                                    <div key={label} className={i > 0 ? "border-l border-border" : ""}>
-                                      <p className="text-xl font-medium text-fg">{value} ms</p>
-                                      <p className="mt-0.5 text-xs uppercase tracking-widest text-muted-fg">
+                                    <div
+                                      key={label}
+                                      className={i > 0 ? "border-border border-l" : ""}
+                                    >
+                                      <p className="font-medium text-fg text-xl">{value} ms</p>
+                                      <p className="mt-0.5 text-muted-fg text-xs uppercase tracking-widest">
                                         {label}
                                       </p>
                                     </div>
@@ -520,7 +569,7 @@ export default function MonitorsShow({
                           )
                         })()
                       ) : (
-                        <p className="py-8 text-center text-sm text-muted-fg">
+                        <p className="py-8 text-center text-muted-fg text-sm">
                           No response time data available yet.
                         </p>
                       )}
@@ -531,7 +580,6 @@ export default function MonitorsShow({
 
               {/* Right: sidebar */}
               <div className="space-y-4">
-
                 {/* SSL Certificate */}
                 {monitor.type === "http" && monitor.ssl_monitoring_enabled && (
                   <div className="border border-border p-4">
@@ -543,13 +591,20 @@ export default function MonitorsShow({
                         isDisabled={scanningSSL}
                         onPress={() => {
                           setScanningSSL(true)
-                          router.post(CheckSslCertificateController.url(monitor.id), {}, {
-                            preserveScroll: true,
-                            onFinish: () => setScanningSSL(false),
-                          })
+                          router.post(
+                            CheckSslCertificateController.url(monitor.id),
+                            {},
+                            {
+                              preserveScroll: true,
+                              onFinish: () => setScanningSSL(false),
+                            },
+                          )
                         }}
                       >
-                        <ArrowPathIcon data-slot="icon" className={scanningSSL ? "animate-spin" : ""} />
+                        <ArrowPathIcon
+                          data-slot="icon"
+                          className={scanningSSL ? "animate-spin" : ""}
+                        />
                         {scanningSSL ? "Scanning…" : "Scan now"}
                       </Button>
                     </div>
@@ -561,11 +616,13 @@ export default function MonitorsShow({
                         <div className="mt-3 space-y-3">
                           <div className="flex items-center justify-between">
                             <span
-                              className={`text-sm font-medium ${sslCertificate.is_valid ? "text-success" : "text-danger"}`}
+                              className={`font-medium text-sm ${sslCertificate.is_valid ? "text-success" : "text-danger"}`}
                             >
                               {sslCertificate.is_valid ? "Valid" : "Invalid"}
                             </span>
-                            <span className={`text-sm ${sslExpiryColor(sslCertificate.days_until_expiry)}`}>
+                            <span
+                              className={`text-sm ${sslExpiryColor(sslCertificate.days_until_expiry)}`}
+                            >
                               {sslCertificate.days_until_expiry !== null
                                 ? sslCertificate.days_until_expiry <= 0
                                   ? "Expired"
@@ -576,50 +633,49 @@ export default function MonitorsShow({
 
                           {sslCertificate.valid_from &&
                             sslCertificate.valid_to &&
-                            sslCertificate.days_until_expiry !== null && (
-                              (() => {
-                                const totalDays = Math.max(
-                                  1,
-                                  Math.round(
-                                    (new Date(sslCertificate.valid_to).getTime() -
-                                      new Date(sslCertificate.valid_from).getTime()) /
-                                      86400000,
-                                  ),
-                                )
-                                const pct = Math.max(
-                                  0,
-                                  Math.min(
-                                    100,
-                                    Math.round((sslCertificate.days_until_expiry / totalDays) * 100),
-                                  ),
-                                )
-                                return (
-                                  <div className="h-1 overflow-hidden rounded-full bg-muted">
-                                    <div
-                                      className={`h-full rounded-full ${
-                                        sslCertificate.days_until_expiry <= 14
-                                          ? "bg-danger"
-                                          : sslCertificate.days_until_expiry <= 30
-                                            ? "bg-warning"
-                                            : "bg-success"
-                                      }`}
-                                      style={{ width: `${pct}%` }}
-                                    />
-                                  </div>
-                                )
-                              })()
-                            )}
+                            sslCertificate.days_until_expiry !== null &&
+                            (() => {
+                              const totalDays = Math.max(
+                                1,
+                                Math.round(
+                                  (new Date(sslCertificate.valid_to).getTime() -
+                                    new Date(sslCertificate.valid_from).getTime()) /
+                                    86400000,
+                                ),
+                              )
+                              const pct = Math.max(
+                                0,
+                                Math.min(
+                                  100,
+                                  Math.round((sslCertificate.days_until_expiry / totalDays) * 100),
+                                ),
+                              )
+                              return (
+                                <div className="h-1 overflow-hidden rounded-full bg-muted">
+                                  <div
+                                    className={`h-full rounded-full ${
+                                      sslCertificate.days_until_expiry <= 14
+                                        ? "bg-danger"
+                                        : sslCertificate.days_until_expiry <= 30
+                                          ? "bg-warning"
+                                          : "bg-success"
+                                    }`}
+                                    style={{ width: `${pct}%` }}
+                                  />
+                                </div>
+                              )
+                            })()}
 
                           {sslCertificate.issuer && (
                             <div>
-                              <p className="text-xs text-muted-fg">Issuer</p>
-                              <p className="truncate text-sm text-fg">{sslCertificate.issuer}</p>
+                              <p className="text-muted-fg text-xs">Issuer</p>
+                              <p className="truncate text-fg text-sm">{sslCertificate.issuer}</p>
                             </div>
                           )}
                           {sslCertificate.valid_to && (
                             <div>
-                              <p className="text-xs text-muted-fg">Expires</p>
-                              <p className="text-sm text-fg">
+                              <p className="text-muted-fg text-xs">Expires</p>
+                              <p className="text-fg text-sm">
                                 {new Date(sslCertificate.valid_to).toLocaleDateString(undefined, {
                                   dateStyle: "medium",
                                 })}
@@ -628,7 +684,7 @@ export default function MonitorsShow({
                           )}
                         </div>
                       ) : (
-                        <p className="mt-3 text-sm text-muted-fg">No SSL data yet.</p>
+                        <p className="mt-3 text-muted-fg text-sm">No SSL data yet.</p>
                       )}
                     </WhenVisible>
                   </div>
@@ -644,16 +700,21 @@ export default function MonitorsShow({
                     {incidents && incidents.length > 0 ? (
                       <div className="mt-3 space-y-2">
                         {incidents.slice(0, 5).map((incident) => (
-                          <div key={incident.id} className="flex items-start justify-between gap-2 py-1">
+                          <div
+                            key={incident.id}
+                            className="flex items-start justify-between gap-2 py-1"
+                          >
                             <div className="min-w-0">
-                              <p className="truncate text-sm text-fg">{incident.cause ?? "Outage"}</p>
-                              <p className="text-xs text-muted-fg">
+                              <p className="truncate text-fg text-sm">
+                                {incident.cause ?? "Outage"}
+                              </p>
+                              <p className="text-muted-fg text-xs">
                                 {formatDuration(incident.started_at, incident.resolved_at)}
                                 {incident.resolved_at ? " · resolved" : " · ongoing"}
                               </p>
                             </div>
                             <span
-                              className={`mt-0.5 shrink-0 text-xs font-bold ${
+                              className={`mt-0.5 shrink-0 font-bold text-xs ${
                                 incident.resolved_at ? "text-success" : "text-danger"
                               }`}
                             >
@@ -663,7 +724,7 @@ export default function MonitorsShow({
                         ))}
                       </div>
                     ) : (
-                      <p className="mt-3 text-sm text-muted-fg">No incidents recorded.</p>
+                      <p className="mt-3 text-muted-fg text-sm">No incidents recorded.</p>
                     )}
                   </WhenVisible>
                 </div>
@@ -675,8 +736,8 @@ export default function MonitorsShow({
                     <div className="mt-3 space-y-1.5">
                       {monitor.notification_channels.map((ch) => (
                         <div key={ch.id} className="flex items-center justify-between">
-                          <span className="text-sm text-fg">{ch.name}</span>
-                          <span className="text-xs text-muted-fg">{ch.type}</span>
+                          <span className="text-fg text-sm">{ch.name}</span>
+                          <span className="text-muted-fg text-xs">{ch.type}</span>
                         </div>
                       ))}
                     </div>
@@ -692,7 +753,7 @@ export default function MonitorsShow({
                   >
                     {heartbeats && heartbeats.data.length > 0 ? (
                       <div className="mt-3 space-y-1.5 font-mono">
-                        {heartbeats.data.slice(0, 15).map((hb) => (
+                        {heartbeatsNewestFirst.slice(0, 15).map((hb) => (
                           <div key={hb.id} className="flex items-start gap-2.5 text-xs">
                             <span className="shrink-0 text-muted-fg">
                               {new Date(hb.created_at).toLocaleTimeString([], {
@@ -709,13 +770,13 @@ export default function MonitorsShow({
                               {hb.status.toUpperCase()}
                             </span>
                             <span className="truncate text-muted-fg">
-                              {hb.response_time ? `${hb.response_time}ms` : hb.message ?? "—"}
+                              {hb.response_time ? `${hb.response_time}ms` : (hb.message ?? "—")}
                             </span>
                           </div>
                         ))}
                       </div>
                     ) : (
-                      <p className="mt-3 text-sm text-muted-fg">No heartbeats yet.</p>
+                      <p className="mt-3 text-muted-fg text-sm">No heartbeats yet.</p>
                     )}
                   </WhenVisible>
                 </div>
@@ -727,7 +788,7 @@ export default function MonitorsShow({
           <TabPanel id="heartbeats" className="pt-4">
             <div className="border border-border">
               <WhenVisible
-                fallback={<div className="h-64 animate-pulse rounded-sm bg-muted m-4" />}
+                fallback={<div className="m-4 h-64 animate-pulse rounded-sm bg-muted" />}
                 data="heartbeats"
               >
                 {heartbeats && heartbeats.data.length > 0 ? (
@@ -739,7 +800,7 @@ export default function MonitorsShow({
                         <TableColumn>Response Time</TableColumn>
                         <TableColumn>Time</TableColumn>
                       </TableHeader>
-                      <TableBody items={heartbeats.data}>
+                      <TableBody items={heartbeatsNewestFirst}>
                         {(hb) => (
                           <TableRow id={hb.id}>
                             <TableCell>
@@ -770,7 +831,7 @@ export default function MonitorsShow({
                       </TableBody>
                     </Table>
                     {(heartbeats.meta?.last_page ?? 1) > 1 && (
-                      <div className="flex items-center justify-between border-t border-border px-4 py-3 text-sm text-muted-fg">
+                      <div className="flex items-center justify-between border-border border-t px-4 py-3 text-muted-fg text-sm">
                         <span>
                           Page {heartbeats.meta?.current_page} of {heartbeats.meta?.last_page}
                           {(heartbeats.meta?.total ?? 0) > 0 && ` · ${heartbeats.meta.total} total`}
@@ -794,7 +855,8 @@ export default function MonitorsShow({
                             intent="outline"
                             size="sm"
                             isDisabled={
-                              (heartbeats.meta?.current_page ?? 1) >= (heartbeats.meta?.last_page ?? 1)
+                              (heartbeats.meta?.current_page ?? 1) >=
+                              (heartbeats.meta?.last_page ?? 1)
                             }
                             onPress={() =>
                               router.reload({
@@ -811,7 +873,9 @@ export default function MonitorsShow({
                     )}
                   </div>
                 ) : (
-                  <p className="py-8 text-center text-sm text-muted-fg">No heartbeats recorded yet.</p>
+                  <p className="py-8 text-center text-muted-fg text-sm">
+                    No heartbeats recorded yet.
+                  </p>
                 )}
               </WhenVisible>
             </div>
@@ -832,8 +896,8 @@ export default function MonitorsShow({
                         className="flex items-center justify-between border border-border p-4"
                       >
                         <div>
-                          <p className="text-sm font-medium">{incident.cause ?? "Unknown cause"}</p>
-                          <p className="text-xs text-muted-fg">
+                          <p className="font-medium text-sm">{incident.cause ?? "Unknown cause"}</p>
+                          <p className="text-muted-fg text-xs">
                             Started:{" "}
                             {new Date(incident.started_at).toLocaleString(undefined, {
                               dateStyle: "medium",
@@ -845,7 +909,7 @@ export default function MonitorsShow({
                           <Badge intent={incident.resolved_at ? "success" : "danger"}>
                             {incident.resolved_at ? "Resolved" : "Ongoing"}
                           </Badge>
-                          <p className="mt-1 text-xs text-muted-fg">
+                          <p className="mt-1 text-muted-fg text-xs">
                             Duration: {formatDuration(incident.started_at, incident.resolved_at)}
                           </p>
                         </div>
@@ -853,7 +917,7 @@ export default function MonitorsShow({
                     ))}
                   </div>
                 ) : (
-                  <p className="py-8 text-center text-sm text-muted-fg">
+                  <p className="py-8 text-center text-muted-fg text-sm">
                     No incidents — this service has been running clean.
                   </p>
                 )}
@@ -873,10 +937,14 @@ export default function MonitorsShow({
                     isDisabled={scanningSSL}
                     onPress={() => {
                       setScanningSSL(true)
-                      router.post(CheckSslCertificateController.url(monitor.id), {}, {
-                        preserveScroll: true,
-                        onFinish: () => setScanningSSL(false),
-                      })
+                      router.post(
+                        CheckSslCertificateController.url(monitor.id),
+                        {},
+                        {
+                          preserveScroll: true,
+                          onFinish: () => setScanningSSL(false),
+                        },
+                      )
                     }}
                   >
                     <ArrowPathIcon data-slot="icon" className={scanningSSL ? "animate-spin" : ""} />
@@ -891,17 +959,17 @@ export default function MonitorsShow({
                     <div className="space-y-4">
                       <div className="grid gap-4 sm:grid-cols-2">
                         <div className="border border-border p-4">
-                          <p className="text-sm text-muted-fg">Status</p>
+                          <p className="text-muted-fg text-sm">Status</p>
                           <p
-                            className={`mt-1 text-lg font-semibold ${sslCertificate.is_valid ? "text-success" : "text-danger"}`}
+                            className={`mt-1 font-semibold text-lg ${sslCertificate.is_valid ? "text-success" : "text-danger"}`}
                           >
                             {sslCertificate.is_valid ? "Valid" : "Invalid"}
                           </p>
                         </div>
                         <div className="border border-border p-4">
-                          <p className="text-sm text-muted-fg">Days Until Expiry</p>
+                          <p className="text-muted-fg text-sm">Days Until Expiry</p>
                           <p
-                            className={`mt-1 text-lg font-semibold ${sslExpiryColor(sslCertificate.days_until_expiry)}`}
+                            className={`mt-1 font-semibold text-lg ${sslExpiryColor(sslCertificate.days_until_expiry)}`}
                           >
                             {sslCertificate.days_until_expiry !== null
                               ? sslCertificate.days_until_expiry <= 0
@@ -913,15 +981,15 @@ export default function MonitorsShow({
                       </div>
                       <div className="grid gap-4 sm:grid-cols-2">
                         <div>
-                          <p className="text-sm text-muted-fg">Issuer</p>
+                          <p className="text-muted-fg text-sm">Issuer</p>
                           <p className="font-medium">{sslCertificate.issuer ?? "Unknown"}</p>
                         </div>
                         <div>
-                          <p className="text-sm text-muted-fg">Subject</p>
+                          <p className="text-muted-fg text-sm">Subject</p>
                           <p className="font-medium">{sslCertificate.subject ?? "Unknown"}</p>
                         </div>
                         <div>
-                          <p className="text-sm text-muted-fg">Valid From</p>
+                          <p className="text-muted-fg text-sm">Valid From</p>
                           <p className="font-medium">
                             {sslCertificate.valid_from
                               ? new Date(sslCertificate.valid_from).toLocaleDateString(undefined, {
@@ -931,7 +999,7 @@ export default function MonitorsShow({
                           </p>
                         </div>
                         <div>
-                          <p className="text-sm text-muted-fg">Valid To</p>
+                          <p className="text-muted-fg text-sm">Valid To</p>
                           <p className="font-medium">
                             {sslCertificate.valid_to
                               ? new Date(sslCertificate.valid_to).toLocaleDateString(undefined, {
@@ -943,11 +1011,11 @@ export default function MonitorsShow({
                       </div>
                       {sslCertificate.error_message && (
                         <div className="border border-danger/30 bg-danger/5 p-4">
-                          <p className="text-sm text-danger">{sslCertificate.error_message}</p>
+                          <p className="text-danger text-sm">{sslCertificate.error_message}</p>
                         </div>
                       )}
                       {sslCertificate.last_checked_at && (
-                        <p className="text-xs text-muted-fg">
+                        <p className="text-muted-fg text-xs">
                           Last checked:{" "}
                           {new Date(sslCertificate.last_checked_at).toLocaleString(undefined, {
                             dateStyle: "medium",
@@ -957,7 +1025,7 @@ export default function MonitorsShow({
                       )}
                     </div>
                   ) : (
-                    <p className="py-8 text-center text-sm text-muted-fg">
+                    <p className="py-8 text-center text-muted-fg text-sm">
                       No SSL certificate data available yet. The next check will run automatically.
                     </p>
                   )}

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -352,7 +352,7 @@ export default function MonitorsShow({
           </div>
 
           {/* KPI strip */}
-          <div className="mt-5 grid grid-cols-2 border border-border sm:grid-cols-4">
+          <div className="mt-5 grid grid-cols-2 border border-border rounded-lg sm:grid-cols-4">
             <WhenVisible
               data="uptimeStats"
               fallback={
@@ -425,7 +425,7 @@ export default function MonitorsShow({
               {/* Left: main content */}
               <div className="space-y-4 lg:col-span-2">
                 {/* Uptime Tracker */}
-                <div className="border border-border p-4">
+                <div className="border border-border rounded-lg p-4">
                   <SectionLabel>Uptime Tracker</SectionLabel>
                   <p className="mt-1 mb-3 text-muted-fg text-xs">Last 90 heartbeats</p>
                   <WhenVisible
@@ -440,7 +440,7 @@ export default function MonitorsShow({
                 </div>
 
                 {/* Response Time + Distribution */}
-                <div className="border border-border">
+                <div className="border border-border rounded-lg">
                   <div className="flex items-center justify-between border-border border-b px-4 py-3">
                     <SectionLabel>
                       Response Time · {periodLabels[chartPeriod] ?? chartPeriod}
@@ -517,7 +517,7 @@ export default function MonitorsShow({
                                       if (!active || !payload?.length) return null
                                       const point = payload[0]
                                       return (
-                                        <div className="border border-border bg-secondary px-3 py-2 font-mono text-xs">
+                                        <div className="border border-border rounded-lg bg-secondary px-3 py-2 font-mono text-xs">
                                           <p className="text-muted-fg">
                                             {point?.payload?.time
                                               ? formatTime(
@@ -582,7 +582,7 @@ export default function MonitorsShow({
               <div className="space-y-4">
                 {/* SSL Certificate */}
                 {monitor.type === "http" && monitor.ssl_monitoring_enabled && (
-                  <div className="border border-border p-4">
+                  <div className="border border-border rounded-lg p-4">
                     <div className="flex items-center justify-between">
                       <SectionLabel>SSL Certificate</SectionLabel>
                       <Button
@@ -691,7 +691,7 @@ export default function MonitorsShow({
                 )}
 
                 {/* Recent Incidents */}
-                <div className="border border-border p-4">
+                <div className="border border-border rounded-lg p-4">
                   <SectionLabel>Incidents</SectionLabel>
                   <WhenVisible
                     data="incidents"
@@ -731,7 +731,7 @@ export default function MonitorsShow({
 
                 {/* Notification Channels */}
                 {monitor.notification_channels && monitor.notification_channels.length > 0 && (
-                  <div className="border border-border p-4">
+                  <div className="border border-border rounded-lg p-4">
                     <SectionLabel>Notification channels</SectionLabel>
                     <div className="mt-3 space-y-1.5">
                       {monitor.notification_channels.map((ch) => (
@@ -745,7 +745,7 @@ export default function MonitorsShow({
                 )}
 
                 {/* Live Log */}
-                <div className="border border-border p-4">
+                <div className="border border-border rounded-lg p-4">
                   <SectionLabel>Live log</SectionLabel>
                   <WhenVisible
                     data="heartbeats"
@@ -786,7 +786,7 @@ export default function MonitorsShow({
 
           {/* ── Heartbeats tab ── */}
           <TabPanel id="heartbeats" className="pt-4">
-            <div className="border border-border">
+            <div className="border border-border rounded-lg">
               <WhenVisible
                 fallback={<div className="m-4 h-64 animate-pulse rounded-sm bg-muted" />}
                 data="heartbeats"
@@ -883,7 +883,7 @@ export default function MonitorsShow({
 
           {/* ── Incidents tab ── */}
           <TabPanel id="incidents" className="pt-4">
-            <div className="border border-border p-4">
+            <div className="border border-border rounded-lg p-4">
               <WhenVisible
                 fallback={<div className="h-64 animate-pulse rounded-sm bg-muted" />}
                 data="incidents"
@@ -893,7 +893,7 @@ export default function MonitorsShow({
                     {incidents.map((incident) => (
                       <div
                         key={incident.id}
-                        className="flex items-center justify-between border border-border p-4"
+                        className="flex items-center justify-between border border-border rounded-lg p-4"
                       >
                         <div>
                           <p className="font-medium text-sm">{incident.cause ?? "Unknown cause"}</p>
@@ -928,7 +928,7 @@ export default function MonitorsShow({
           {/* ── SSL tab ── */}
           {monitor.type === "http" && monitor.ssl_monitoring_enabled && (
             <TabPanel id="ssl" className="pt-4">
-              <div className="border border-border p-4">
+              <div className="border border-border rounded-lg p-4">
                 <div className="mb-4 flex items-center justify-between">
                   <SectionLabel>SSL Certificate</SectionLabel>
                   <Button
@@ -958,7 +958,7 @@ export default function MonitorsShow({
                   {sslCertificate ? (
                     <div className="space-y-4">
                       <div className="grid gap-4 sm:grid-cols-2">
-                        <div className="border border-border p-4">
+                        <div className="border border-border rounded-lg p-4">
                           <p className="text-muted-fg text-sm">Status</p>
                           <p
                             className={`mt-1 font-semibold text-lg ${sslCertificate.is_valid ? "text-success" : "text-danger"}`}
@@ -966,7 +966,7 @@ export default function MonitorsShow({
                             {sslCertificate.is_valid ? "Valid" : "Invalid"}
                           </p>
                         </div>
-                        <div className="border border-border p-4">
+                        <div className="border border-border rounded-lg p-4">
                           <p className="text-muted-fg text-sm">Days Until Expiry</p>
                           <p
                             className={`mt-1 font-semibold text-lg ${sslExpiryColor(sslCertificate.days_until_expiry)}`}

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -30,7 +30,7 @@ import AppLayout from "@/layouts/app-layout"
 import { statusBadgeIntent, uptimeColor } from "@/lib/color"
 import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import monitorRoutes from "@/routes/monitors"
-import { subscribeToEvents, useHydrateMonitor, useMonitor } from "@/stores/monitor-realtime"
+import { hydrate, subscribeToEvents, useMonitor } from "@/stores/monitor-realtime"
 import type {
   ChartDataPoint,
   Heartbeat,
@@ -128,7 +128,16 @@ export default function MonitorsShow({
   sslCertificate,
   chartPeriod: initialChartPeriod,
 }: Props) {
-  useHydrateMonitor(initialMonitor)
+  useEffect(() => {
+    const seed: Monitor = {
+      ...initialMonitor,
+      heartbeats:
+        initialHeartbeats?.data && initialHeartbeats.meta?.current_page === 1
+          ? initialHeartbeats.data
+          : initialMonitor.heartbeats,
+    }
+    hydrate([seed])
+  }, [initialMonitor, initialHeartbeats])
   const monitor = useMonitor(initialMonitor.id) ?? initialMonitor
   const [heartbeats, setHeartbeats] = useState(initialHeartbeats)
   const [incidents, setIncidents] = useState(initialIncidents)
@@ -193,10 +202,6 @@ export default function MonitorsShow({
     return subscribeToEvents((event) => {
       if (event.payload.monitorId !== monitorId) return
       if (event.type === "heartbeat") {
-        setHeartbeats((prev) => {
-          if (!prev) return prev
-          return { ...prev, data: [...prev.data, event.payload.heartbeat].slice(-90) }
-        })
         if (
           event.payload.heartbeat.response_time !== null &&
           (chartPeriod === "1h" || chartPeriod === "24h")
@@ -239,8 +244,10 @@ export default function MonitorsShow({
     })
   }, [monitorId, chartPeriod])
 
-  const trackerData = heartbeatsToTracker(heartbeats?.data)
-  const heartbeatsNewestFirst = heartbeats ? [...heartbeats.data].reverse() : []
+  const liveHeartbeats = monitor.heartbeats ?? []
+  const trackerData = heartbeatsToTracker(liveHeartbeats)
+  const liveHeartbeatsNewestFirst = [...liveHeartbeats].reverse()
+  const heartbeatsTableNewestFirst = heartbeats ? [...heartbeats.data].reverse() : []
 
   return (
     <>
@@ -699,38 +706,33 @@ export default function MonitorsShow({
                 {/* Live Log */}
                 <div className="rounded-lg border border-border p-4">
                   <SectionLabel>Live log</SectionLabel>
-                  <WhenVisible
-                    data="heartbeats"
-                    fallback={<div className="mt-3 h-32 animate-pulse rounded-sm bg-muted" />}
-                  >
-                    {heartbeats && heartbeats.data.length > 0 ? (
-                      <div className="mt-3 space-y-1.5 font-mono">
-                        {heartbeatsNewestFirst.slice(0, 15).map((hb) => (
-                          <div key={hb.id} className="flex items-start gap-2.5 text-xs">
-                            <span className="shrink-0 text-muted-fg">
-                              {new Date(hb.created_at).toLocaleTimeString([], {
-                                hour: "2-digit",
-                                minute: "2-digit",
-                                second: "2-digit",
-                              })}
-                            </span>
-                            <span
-                              className={`shrink-0 font-semibold ${
-                                hb.status === "up" ? "text-success" : "text-danger"
-                              }`}
-                            >
-                              {hb.status.toUpperCase()}
-                            </span>
-                            <span className="truncate text-muted-fg">
-                              {hb.response_time ? `${hb.response_time}ms` : (hb.message ?? "—")}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="mt-3 text-muted-fg text-sm">No heartbeats yet.</p>
-                    )}
-                  </WhenVisible>
+                  {liveHeartbeats.length > 0 ? (
+                    <div className="mt-3 space-y-1.5 font-mono">
+                      {liveHeartbeatsNewestFirst.slice(0, 15).map((hb) => (
+                        <div key={hb.id} className="flex items-start gap-2.5 text-xs">
+                          <span className="shrink-0 text-muted-fg">
+                            {new Date(hb.created_at).toLocaleTimeString([], {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              second: "2-digit",
+                            })}
+                          </span>
+                          <span
+                            className={`shrink-0 font-semibold ${
+                              hb.status === "up" ? "text-success" : "text-danger"
+                            }`}
+                          >
+                            {hb.status.toUpperCase()}
+                          </span>
+                          <span className="truncate text-muted-fg">
+                            {hb.response_time ? `${hb.response_time}ms` : (hb.message ?? "—")}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-muted-fg text-sm">No heartbeats yet.</p>
+                  )}
                 </div>
               </div>
             </div>
@@ -752,7 +754,7 @@ export default function MonitorsShow({
                         <TableColumn>Response Time</TableColumn>
                         <TableColumn>Time</TableColumn>
                       </TableHeader>
-                      <TableBody items={heartbeatsNewestFirst}>
+                      <TableBody items={heartbeatsTableNewestFirst}>
                         {(hb) => (
                           <TableRow id={hb.id}>
                             <TableCell>

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -5,9 +5,8 @@ import {
   PlayIcon,
   TrashIcon,
 } from "@heroicons/react/20/solid"
-import { Head, router, usePage, WhenVisible } from "@inertiajs/react"
-import { useEcho } from "@laravel/echo-react"
-import { useCallback, useEffect, useState } from "react"
+import { Head, router, WhenVisible } from "@inertiajs/react"
+import { useEffect, useState } from "react"
 import { Area, AreaChart } from "recharts"
 import CheckSslCertificateController from "@/actions/App/Http/Controllers/CheckSslCertificateController"
 import ConfirmDeleteModal from "@/components/confirm-delete-modal"
@@ -31,6 +30,7 @@ import AppLayout from "@/layouts/app-layout"
 import { statusBadgeIntent, uptimeColor } from "@/lib/color"
 import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import monitorRoutes from "@/routes/monitors"
+import { subscribeToEvents, useHydrateMonitor, useMonitor } from "@/stores/monitor-realtime"
 import type {
   ChartDataPoint,
   Heartbeat,
@@ -39,7 +39,6 @@ import type {
   SslCertificate,
   UptimeStats,
 } from "@/types/monitor"
-import type { SharedData } from "@/types/shared"
 
 interface PaginationLinks {
   first: string | null
@@ -65,22 +64,6 @@ interface Props {
   uptimeStats?: UptimeStats
   sslCertificate?: SslCertificate | null
   chartPeriod?: string
-}
-
-interface HeartbeatPayload {
-  monitorId: number
-  heartbeat: Heartbeat
-  monitorStatus: string
-  lastCheckedAt: string
-  uptimePercentage: number
-  averageResponseTime: number | null
-}
-
-interface StatusChangedPayload {
-  monitorId: number
-  oldStatus: string
-  newStatus: string
-  message: string | null
 }
 
 function formatDuration(start: string, end: string | null): string {
@@ -145,8 +128,8 @@ export default function MonitorsShow({
   sslCertificate,
   chartPeriod: initialChartPeriod,
 }: Props) {
-  const { auth } = usePage<SharedData>().props
-  const [monitor, setMonitor] = useState(initialMonitor)
+  useHydrateMonitor(initialMonitor)
+  const monitor = useMonitor(initialMonitor.id) ?? initialMonitor
   const [heartbeats, setHeartbeats] = useState(initialHeartbeats)
   const [incidents, setIncidents] = useState(initialIncidents)
   const [chartData, setChartData] = useState(initialChartData)
@@ -167,10 +150,6 @@ export default function MonitorsShow({
     params.set("tab", tab)
     window.history.replaceState({}, "", `${window.location.pathname}?${params.toString()}`)
   }
-
-  useEffect(() => {
-    setMonitor(initialMonitor)
-  }, [initialMonitor])
 
   useEffect(() => {
     if (initialHeartbeats) setHeartbeats(initialHeartbeats)
@@ -208,78 +187,57 @@ export default function MonitorsShow({
     return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
   }
 
-  const handleHeartbeat = useCallback(
-    (payload: HeartbeatPayload) => {
-      if (payload.monitorId !== monitor.id) return
-      setMonitor((prev) => ({
-        ...prev,
-        status: payload.monitorStatus as Monitor["status"],
-        last_checked_at: payload.lastCheckedAt,
-      }))
-      setHeartbeats((prev) => {
-        if (!prev) return prev
-        return { ...prev, data: [...prev.data, payload.heartbeat].slice(-90) }
-      })
-      if (
-        payload.heartbeat.response_time !== null &&
-        (chartPeriod === "1h" || chartPeriod === "24h")
-      ) {
-        setChartData((prev) => {
+  const monitorId = monitor.id
+
+  useEffect(() => {
+    return subscribeToEvents((event) => {
+      if (event.payload.monitorId !== monitorId) return
+      if (event.type === "heartbeat") {
+        setHeartbeats((prev) => {
           if (!prev) return prev
-          return [
-            ...prev,
-            {
-              created_at: payload.heartbeat.created_at,
-              response_time: payload.heartbeat.response_time,
-              status: payload.heartbeat.status,
-            },
-          ]
+          return { ...prev, data: [...prev.data, event.payload.heartbeat].slice(-90) }
         })
+        if (
+          event.payload.heartbeat.response_time !== null &&
+          (chartPeriod === "1h" || chartPeriod === "24h")
+        ) {
+          setChartData((prev) => {
+            if (!prev) return prev
+            return [
+              ...prev,
+              {
+                created_at: event.payload.heartbeat.created_at,
+                response_time: event.payload.heartbeat.response_time,
+                status: event.payload.heartbeat.status,
+              },
+            ]
+          })
+        }
+      } else if (event.type === "status") {
+        if (event.payload.newStatus === "down" && event.payload.oldStatus !== "down") {
+          setIncidents((prev) => [
+            {
+              id: Date.now(),
+              monitor_id: monitorId,
+              started_at: new Date().toISOString(),
+              resolved_at: null,
+              cause: event.payload.message ?? null,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            } as Incident,
+            ...(prev ?? []),
+          ])
+        }
+        if (event.payload.newStatus === "up" && event.payload.oldStatus === "down") {
+          setIncidents((prev) =>
+            (prev ?? []).map((inc) =>
+              inc.resolved_at === null ? { ...inc, resolved_at: new Date().toISOString() } : inc,
+            ),
+          )
+        }
       }
-    },
-    [monitor.id, chartPeriod],
-  )
-
-  const handleStatusChanged = useCallback(
-    (payload: StatusChangedPayload) => {
-      if (payload.monitorId !== monitor.id) return
-      setMonitor((prev) => ({ ...prev, status: payload.newStatus as Monitor["status"] }))
-      if (payload.newStatus === "down" && payload.oldStatus !== "down") {
-        setIncidents((prev) => [
-          {
-            id: Date.now(),
-            monitor_id: monitor.id,
-            started_at: new Date().toISOString(),
-            resolved_at: null,
-            cause: payload.message ?? null,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-          } as Incident,
-          ...(prev ?? []),
-        ])
-      }
-      if (payload.newStatus === "up" && payload.oldStatus === "down") {
-        setIncidents((prev) =>
-          (prev ?? []).map((inc) =>
-            inc.resolved_at === null ? { ...inc, resolved_at: new Date().toISOString() } : inc,
-          ),
-        )
-      }
-    },
-    [monitor.id],
-  )
-
-  const handleChecking = useCallback(
-    (payload: { monitorId: number }) => {
-      if (payload.monitorId !== monitor.id) return
-      setMonitor((prev) => ({ ...prev, status: "pending" as Monitor["status"] }))
-    },
-    [monitor.id],
-  )
-
-  useEcho(`monitors.${auth.user.id}`, ".MonitorChecking", handleChecking)
-  useEcho(`monitors.${auth.user.id}`, ".HeartbeatRecorded", handleHeartbeat)
-  useEcho(`monitors.${auth.user.id}`, ".MonitorStatusChanged", handleStatusChanged)
+    })
+  }, [monitorId, chartPeriod])
 
   const trackerData = heartbeatsToTracker(heartbeats?.data)
   const heartbeatsNewestFirst = heartbeats ? [...heartbeats.data].reverse() : []
@@ -352,52 +310,46 @@ export default function MonitorsShow({
           </div>
 
           {/* KPI strip */}
-          <div className="mt-5 grid grid-cols-2 border border-border rounded-lg sm:grid-cols-4">
+          <div className="mt-5 grid grid-cols-2 rounded-lg border border-border sm:grid-cols-4">
             <WhenVisible
               data="uptimeStats"
-              fallback={
-                <>
-                  {Array(3)
-                    .fill(null)
-                    .map((_, i) => (
-                      <div key={i} className="border-border border-r p-4">
-                        <div className="mb-2 h-2.5 w-20 animate-pulse rounded-sm bg-muted" />
-                        <div className="h-7 w-16 animate-pulse rounded-sm bg-muted" />
-                      </div>
-                    ))}
-                </>
-              }
+              fallback={Array(3)
+                .fill(null)
+                .map((_, i) => (
+                  <div key={i} className="border-border border-r p-4">
+                    <div className="mb-2 h-2.5 w-20 animate-pulse rounded-sm bg-muted" />
+                    <div className="h-7 w-16 animate-pulse rounded-sm bg-muted" />
+                  </div>
+                ))}
             >
-              <>
-                <div className="border-border border-r p-4">
-                  <p className="text-muted-fg text-xs uppercase tracking-widest">30d Uptime</p>
-                  <p
-                    className={`mt-1 font-medium text-2xl ${uptimeStats ? uptimeColor(uptimeStats.uptime_30d) : "text-fg"}`}
-                  >
-                    {uptimeStats ? `${uptimeStats.uptime_30d}%` : "—"}
-                  </p>
-                </div>
-                <div className="border-border border-r p-4">
-                  <p className="text-muted-fg text-xs uppercase tracking-widest">
-                    Avg Response · 24h
-                  </p>
-                  <p className="mt-1 font-medium text-2xl text-fg">
-                    {uptimeStats?.avg_response_24h
-                      ? `${Math.round(uptimeStats.avg_response_24h)} ms`
-                      : "—"}
-                  </p>
-                </div>
-                <div className="border-border border-r p-4">
-                  <p className="text-muted-fg text-xs uppercase tracking-widest">
-                    Avg Response · 30d
-                  </p>
-                  <p className="mt-1 font-medium text-2xl text-fg">
-                    {uptimeStats?.avg_response_30d
-                      ? `${Math.round(uptimeStats.avg_response_30d)} ms`
-                      : "—"}
-                  </p>
-                </div>
-              </>
+              <div className="border-border border-r p-4">
+                <p className="text-muted-fg text-xs uppercase tracking-widest">30d Uptime</p>
+                <p
+                  className={`mt-1 font-medium text-2xl ${uptimeStats ? uptimeColor(uptimeStats.uptime_30d) : "text-fg"}`}
+                >
+                  {uptimeStats ? `${uptimeStats.uptime_30d}%` : "—"}
+                </p>
+              </div>
+              <div className="border-border border-r p-4">
+                <p className="text-muted-fg text-xs uppercase tracking-widest">
+                  Avg Response · 24h
+                </p>
+                <p className="mt-1 font-medium text-2xl text-fg">
+                  {uptimeStats?.avg_response_24h
+                    ? `${Math.round(uptimeStats.avg_response_24h)} ms`
+                    : "—"}
+                </p>
+              </div>
+              <div className="border-border border-r p-4">
+                <p className="text-muted-fg text-xs uppercase tracking-widest">
+                  Avg Response · 30d
+                </p>
+                <p className="mt-1 font-medium text-2xl text-fg">
+                  {uptimeStats?.avg_response_30d
+                    ? `${Math.round(uptimeStats.avg_response_30d)} ms`
+                    : "—"}
+                </p>
+              </div>
             </WhenVisible>
             <div className="p-4">
               <p className="text-muted-fg text-xs uppercase tracking-widest">Last Check</p>
@@ -425,7 +377,7 @@ export default function MonitorsShow({
               {/* Left: main content */}
               <div className="space-y-4 lg:col-span-2">
                 {/* Uptime Tracker */}
-                <div className="border border-border rounded-lg p-4">
+                <div className="rounded-lg border border-border p-4">
                   <SectionLabel>Uptime Tracker</SectionLabel>
                   <p className="mt-1 mb-3 text-muted-fg text-xs">Last 90 heartbeats</p>
                   <WhenVisible
@@ -440,7 +392,7 @@ export default function MonitorsShow({
                 </div>
 
                 {/* Response Time + Distribution */}
-                <div className="border border-border rounded-lg">
+                <div className="rounded-lg border border-border">
                   <div className="flex items-center justify-between border-border border-b px-4 py-3">
                     <SectionLabel>
                       Response Time · {periodLabels[chartPeriod] ?? chartPeriod}
@@ -517,7 +469,7 @@ export default function MonitorsShow({
                                       if (!active || !payload?.length) return null
                                       const point = payload[0]
                                       return (
-                                        <div className="border border-border rounded-lg bg-secondary px-3 py-2 font-mono text-xs">
+                                        <div className="rounded-lg border border-border bg-secondary px-3 py-2 font-mono text-xs">
                                           <p className="text-muted-fg">
                                             {point?.payload?.time
                                               ? formatTime(
@@ -582,7 +534,7 @@ export default function MonitorsShow({
               <div className="space-y-4">
                 {/* SSL Certificate */}
                 {monitor.type === "http" && monitor.ssl_monitoring_enabled && (
-                  <div className="border border-border rounded-lg p-4">
+                  <div className="rounded-lg border border-border p-4">
                     <div className="flex items-center justify-between">
                       <SectionLabel>SSL Certificate</SectionLabel>
                       <Button
@@ -691,7 +643,7 @@ export default function MonitorsShow({
                 )}
 
                 {/* Recent Incidents */}
-                <div className="border border-border rounded-lg p-4">
+                <div className="rounded-lg border border-border p-4">
                   <SectionLabel>Incidents</SectionLabel>
                   <WhenVisible
                     data="incidents"
@@ -731,7 +683,7 @@ export default function MonitorsShow({
 
                 {/* Notification Channels */}
                 {monitor.notification_channels && monitor.notification_channels.length > 0 && (
-                  <div className="border border-border rounded-lg p-4">
+                  <div className="rounded-lg border border-border p-4">
                     <SectionLabel>Notification channels</SectionLabel>
                     <div className="mt-3 space-y-1.5">
                       {monitor.notification_channels.map((ch) => (
@@ -745,7 +697,7 @@ export default function MonitorsShow({
                 )}
 
                 {/* Live Log */}
-                <div className="border border-border rounded-lg p-4">
+                <div className="rounded-lg border border-border p-4">
                   <SectionLabel>Live log</SectionLabel>
                   <WhenVisible
                     data="heartbeats"
@@ -786,7 +738,7 @@ export default function MonitorsShow({
 
           {/* ── Heartbeats tab ── */}
           <TabPanel id="heartbeats" className="pt-4">
-            <div className="border border-border rounded-lg">
+            <div className="rounded-lg border border-border">
               <WhenVisible
                 fallback={<div className="m-4 h-64 animate-pulse rounded-sm bg-muted" />}
                 data="heartbeats"
@@ -883,7 +835,7 @@ export default function MonitorsShow({
 
           {/* ── Incidents tab ── */}
           <TabPanel id="incidents" className="pt-4">
-            <div className="border border-border rounded-lg p-4">
+            <div className="rounded-lg border border-border p-4">
               <WhenVisible
                 fallback={<div className="h-64 animate-pulse rounded-sm bg-muted" />}
                 data="incidents"
@@ -893,7 +845,7 @@ export default function MonitorsShow({
                     {incidents.map((incident) => (
                       <div
                         key={incident.id}
-                        className="flex items-center justify-between border border-border rounded-lg p-4"
+                        className="flex items-center justify-between rounded-lg border border-border p-4"
                       >
                         <div>
                           <p className="font-medium text-sm">{incident.cause ?? "Unknown cause"}</p>
@@ -928,7 +880,7 @@ export default function MonitorsShow({
           {/* ── SSL tab ── */}
           {monitor.type === "http" && monitor.ssl_monitoring_enabled && (
             <TabPanel id="ssl" className="pt-4">
-              <div className="border border-border rounded-lg p-4">
+              <div className="rounded-lg border border-border p-4">
                 <div className="mb-4 flex items-center justify-between">
                   <SectionLabel>SSL Certificate</SectionLabel>
                   <Button
@@ -958,7 +910,7 @@ export default function MonitorsShow({
                   {sslCertificate ? (
                     <div className="space-y-4">
                       <div className="grid gap-4 sm:grid-cols-2">
-                        <div className="border border-border rounded-lg p-4">
+                        <div className="rounded-lg border border-border p-4">
                           <p className="text-muted-fg text-sm">Status</p>
                           <p
                             className={`mt-1 font-semibold text-lg ${sslCertificate.is_valid ? "text-success" : "text-danger"}`}
@@ -966,7 +918,7 @@ export default function MonitorsShow({
                             {sslCertificate.is_valid ? "Valid" : "Invalid"}
                           </p>
                         </div>
-                        <div className="border border-border rounded-lg p-4">
+                        <div className="rounded-lg border border-border p-4">
                           <p className="text-muted-fg text-sm">Days Until Expiry</p>
                           <p
                             className={`mt-1 font-semibold text-lg ${sslExpiryColor(sslCertificate.days_until_expiry)}`}

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -206,16 +206,18 @@ export default function MonitorsShow({
           event.payload.heartbeat.response_time !== null &&
           (chartPeriod === "1h" || chartPeriod === "24h")
         ) {
+          const windowMs = chartPeriod === "1h" ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000
+          const newPoint = {
+            created_at: event.payload.heartbeat.created_at,
+            response_time: event.payload.heartbeat.response_time,
+            status: event.payload.heartbeat.status,
+          }
+          const newPointMs = new Date(newPoint.created_at).getTime()
           setChartData((prev) => {
             if (!prev) return prev
-            return [
-              ...prev,
-              {
-                created_at: event.payload.heartbeat.created_at,
-                response_time: event.payload.heartbeat.response_time,
-                status: event.payload.heartbeat.status,
-              },
-            ]
+            const cutoff = newPointMs - windowMs
+            const trimmed = prev.filter((p) => new Date(p.created_at).getTime() >= cutoff)
+            return [...trimmed, newPoint]
           })
         }
       } else if (event.type === "status") {
@@ -342,7 +344,7 @@ export default function MonitorsShow({
                   Avg Response · 24h
                 </p>
                 <p className="mt-1 font-medium text-2xl text-fg">
-                  {uptimeStats?.avg_response_24h
+                  {uptimeStats?.avg_response_24h != null
                     ? `${Math.round(uptimeStats.avg_response_24h)} ms`
                     : "—"}
                 </p>
@@ -352,7 +354,7 @@ export default function MonitorsShow({
                   Avg Response · 30d
                 </p>
                 <p className="mt-1 font-medium text-2xl text-fg">
-                  {uptimeStats?.avg_response_30d
+                  {uptimeStats?.avg_response_30d != null
                     ? `${Math.round(uptimeStats.avg_response_30d)} ms`
                     : "—"}
                 </p>
@@ -725,7 +727,9 @@ export default function MonitorsShow({
                             {hb.status.toUpperCase()}
                           </span>
                           <span className="truncate text-muted-fg">
-                            {hb.response_time ? `${hb.response_time}ms` : (hb.message ?? "—")}
+                            {hb.response_time != null
+                              ? `${hb.response_time}ms`
+                              : (hb.message ?? "—")}
                           </span>
                         </div>
                       ))}
@@ -772,7 +776,7 @@ export default function MonitorsShow({
                             </TableCell>
                             <TableCell>{hb.status_code ?? "—"}</TableCell>
                             <TableCell>
-                              {hb.response_time ? `${hb.response_time}ms` : "—"}
+                              {hb.response_time != null ? `${hb.response_time}ms` : "—"}
                             </TableCell>
                             <TableCell>
                               {new Date(hb.created_at).toLocaleString(undefined, {

--- a/resources/js/stores/__tests__/monitor-realtime.test.ts
+++ b/resources/js/stores/__tests__/monitor-realtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import {
   __resetForTests,
+  getCountsSnapshot,
   getSnapshot,
   handleChecking,
   handleHeartbeat,
@@ -213,4 +214,105 @@ describe("monitor-realtime store", () => {
       expect(getSnapshot().byId[1]?.status).toBe("up")
     })
   })
+
+  describe("getCountsSnapshot", () => {
+    it("returns zero counts for empty store", () => {
+      expect(getCountsSnapshot()).toEqual({
+        total: 0,
+        up: 0,
+        down: 0,
+        pending: 0,
+        paused: 0,
+      })
+    })
+
+    it("derives total/up/down/pending/paused from monitors array", () => {
+      hydrate([
+        makeMonitor({ id: 1, status: "up" }),
+        makeMonitor({ id: 2, status: "up" }),
+        makeMonitor({ id: 3, status: "down" }),
+        makeMonitor({ id: 4, status: "pending" }),
+        makeMonitor({ id: 5, status: "paused" }),
+        makeMonitor({ id: 6, status: "paused" }),
+      ])
+      expect(getCountsSnapshot()).toEqual({
+        total: 6,
+        up: 2,
+        down: 1,
+        pending: 1,
+        paused: 2,
+      })
+    })
+
+    it("matches filter().length after sequence of handleStatusChanged events", () => {
+      hydrate([
+        makeMonitor({ id: 1, status: "up" }),
+        makeMonitor({ id: 2, status: "up" }),
+        makeMonitor({ id: 3, status: "up" }),
+        makeMonitor({ id: 4, status: "paused" }),
+      ])
+
+      handleStatusChanged({ monitorId: 1, oldStatus: "up", newStatus: "down", message: null })
+      handleStatusChanged({ monitorId: 2, oldStatus: "up", newStatus: "down", message: null })
+      handleStatusChanged({ monitorId: 1, oldStatus: "down", newStatus: "up", message: null })
+      handleStatusChanged({ monitorId: 4, oldStatus: "paused", newStatus: "up", message: null })
+      handleStatusChanged({ monitorId: 2, oldStatus: "down", newStatus: "down", message: null })
+
+      const counts = getCountsSnapshot()
+      const monitors = getSnapshot().monitors
+      const expected = {
+        total: monitors.length,
+        up: monitors.filter((m) => m.status === "up").length,
+        down: monitors.filter((m) => m.status === "down").length,
+        pending: monitors.filter((m) => m.status === "pending").length,
+        paused: monitors.filter((m) => m.status === "paused").length,
+      }
+      expect(counts).toEqual(expected)
+    })
+
+    it("is idempotent — duplicate status events do not drift counts", () => {
+      hydrate([
+        makeMonitor({ id: 1, status: "up" }),
+        makeMonitor({ id: 2, status: "up" }),
+      ])
+
+      const fire = (): void => {
+        handleStatusChanged({ monitorId: 1, oldStatus: "up", newStatus: "down", message: null })
+      }
+      fire()
+      fire()
+      fire()
+
+      expect(getCountsSnapshot()).toEqual({
+        total: 2,
+        up: 1,
+        down: 1,
+        pending: 0,
+        paused: 0,
+      })
+    })
+
+    it("returns same reference when state unchanged (memoized)", () => {
+      hydrate([makeMonitor({ id: 1, status: "up" })])
+      const a = getCountsSnapshot()
+      const b = getCountsSnapshot()
+      expect(b).toBe(a)
+    })
+
+    it("recomputes after handleChecking flips monitor to pending", () => {
+      hydrate([
+        makeMonitor({ id: 1, status: "up" }),
+        makeMonitor({ id: 2, status: "down" }),
+      ])
+      handleChecking({ monitorId: 1 })
+      expect(getCountsSnapshot()).toEqual({
+        total: 2,
+        up: 0,
+        down: 1,
+        pending: 1,
+        paused: 0,
+      })
+    })
+  })
 })
+

--- a/resources/js/stores/__tests__/monitor-realtime.test.ts
+++ b/resources/js/stores/__tests__/monitor-realtime.test.ts
@@ -142,6 +142,31 @@ describe("monitor-realtime store", () => {
       expect(m1?.heartbeats?.[89].id).toBe(1000)
     })
 
+    it("sets last_checked_at from payload lastCheckedAt", () => {
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z" })])
+      handleHeartbeat({
+        monitorId: 1,
+        heartbeat: makeHeartbeat({ id: 42, created_at: "2026-04-28T00:30:00Z" }),
+        monitorStatus: "up",
+        lastCheckedAt: "2026-04-28T00:30:00Z",
+        uptimePercentage: 100,
+        averageResponseTime: 200,
+      })
+      expect(getSnapshot().byId[1]?.last_checked_at).toBe("2026-04-28T00:30:00Z")
+    })
+
+    it("preserves existing last_checked_at when payload omits lastCheckedAt", () => {
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z" })])
+      handleHeartbeat({
+        monitorId: 1,
+        heartbeat: makeHeartbeat({ id: 43, created_at: "2026-04-28T00:30:00Z" }),
+        monitorStatus: "up",
+        uptimePercentage: 100,
+        averageResponseTime: 200,
+      })
+      expect(getSnapshot().byId[1]?.last_checked_at).toBe("2026-04-28T00:00:00Z")
+    })
+
     it("ignores heartbeats for unknown monitor", () => {
       hydrate([makeMonitor({ id: 1 })])
       handleHeartbeat({

--- a/resources/js/stores/__tests__/monitor-realtime.test.ts
+++ b/resources/js/stores/__tests__/monitor-realtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import {
   __resetForTests,
+  clear,
   getCountsSnapshot,
   getSnapshot,
   handleChecking,
@@ -96,6 +97,29 @@ describe("monitor-realtime store", () => {
       hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T01:00:00Z", status: "down" })])
       expect(getSnapshot().byId[1]?.status).toBe("down")
     })
+
+    it("skips no-op hydrate — same payload yields same state ref", () => {
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z" })])
+      const before = getSnapshot()
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z" })])
+      expect(getSnapshot()).toBe(before)
+    })
+  })
+
+  describe("clear", () => {
+    it("empties the store when called with non-empty state", () => {
+      hydrate([makeMonitor({ id: 1 }), makeMonitor({ id: 2 })])
+      clear()
+      const snap = getSnapshot()
+      expect(snap.monitors).toHaveLength(0)
+      expect(snap.byId).toEqual({})
+    })
+
+    it("is a no-op when store is already empty (same state ref)", () => {
+      const before = getSnapshot()
+      clear()
+      expect(getSnapshot()).toBe(before)
+    })
   })
 
   describe("handleHeartbeat", () => {
@@ -126,8 +150,9 @@ describe("monitor-realtime store", () => {
     })
 
     it("caps heartbeat history at 90 entries", () => {
+      const baseMs = Date.parse("2026-04-28T00:00:00Z")
       const initial = Array.from({ length: 90 }, (_, i) =>
-        makeHeartbeat({ id: i + 1, created_at: `2026-04-28T00:${String(i).padStart(2, "0")}:00Z` }),
+        makeHeartbeat({ id: i + 1, created_at: new Date(baseMs + i * 60_000).toISOString() }),
       )
       hydrate([makeMonitor({ id: 1, heartbeats: initial })])
       handleHeartbeat({

--- a/resources/js/stores/__tests__/monitor-realtime.test.ts
+++ b/resources/js/stores/__tests__/monitor-realtime.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  __resetForTests,
+  getSnapshot,
+  handleChecking,
+  handleHeartbeat,
+  handleStatusChanged,
+  hydrate,
+} from "@/stores/monitor-realtime"
+import type { Heartbeat, Monitor } from "@/types/monitor"
+
+function makeMonitor(overrides: Partial<Monitor> = {}): Monitor {
+  return {
+    id: 1,
+    user_id: 1,
+    monitor_group_id: null,
+    name: "Example",
+    type: "http",
+    url: "https://example.com",
+    host: null,
+    port: null,
+    dns_record_type: null,
+    method: "GET",
+    body: null,
+    headers: null,
+    accepted_status_codes: null,
+    interval: 60,
+    timeout: 30,
+    retry_count: 0,
+    status: "up",
+    is_active: true,
+    push_token: null,
+    ssl_monitoring_enabled: false,
+    ssl_expiry_notification_days: null,
+    last_checked_at: "2026-04-28T00:00:00Z",
+    next_check_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    heartbeats: [],
+    uptime_percentage: 100,
+    average_response_time: 200,
+    ...overrides,
+  }
+}
+
+function makeHeartbeat(overrides: Partial<Heartbeat> = {}): Heartbeat {
+  return {
+    id: 1,
+    monitor_id: 1,
+    status: "up",
+    status_code: 200,
+    response_time: 150,
+    message: null,
+    created_at: "2026-04-28T00:01:00Z",
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  __resetForTests()
+})
+
+describe("monitor-realtime store", () => {
+  describe("hydrate", () => {
+    it("sets state from monitor array", () => {
+      const monitors = [makeMonitor({ id: 1 }), makeMonitor({ id: 2, name: "Another" })]
+      hydrate(monitors)
+      const snap = getSnapshot()
+      expect(snap.monitors).toHaveLength(2)
+      expect(snap.byId[1]?.name).toBe("Example")
+      expect(snap.byId[2]?.name).toBe("Another")
+    })
+
+    it("does not erase newer in-memory data on hydrate with stale snapshot", () => {
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z", status: "up" })])
+      handleStatusChanged({ monitorId: 1, oldStatus: "up", newStatus: "down", message: null })
+      handleHeartbeat({
+        monitorId: 1,
+        heartbeat: makeHeartbeat({ created_at: "2026-04-28T00:05:00Z", status: "down" }),
+        monitorStatus: "down",
+        lastCheckedAt: "2026-04-28T00:05:00Z",
+        uptimePercentage: 99,
+        averageResponseTime: 180,
+      })
+
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z", status: "up" })])
+
+      const snap = getSnapshot()
+      expect(snap.byId[1]?.status).toBe("down")
+      expect(snap.byId[1]?.last_checked_at).toBe("2026-04-28T00:05:00Z")
+    })
+
+    it("accepts newer hydration data over older in-memory data", () => {
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T00:00:00Z", status: "up" })])
+      hydrate([makeMonitor({ id: 1, last_checked_at: "2026-04-28T01:00:00Z", status: "down" })])
+      expect(getSnapshot().byId[1]?.status).toBe("down")
+    })
+  })
+
+  describe("handleHeartbeat", () => {
+    it("appends heartbeat and updates status, uptime, avg, last_checked_at on matching monitor only", () => {
+      hydrate([
+        makeMonitor({ id: 1, status: "up", uptime_percentage: 100, average_response_time: 200 }),
+        makeMonitor({ id: 2, name: "Other", status: "up" }),
+      ])
+      const hb = makeHeartbeat({ id: 99, created_at: "2026-04-28T00:10:00Z" })
+      handleHeartbeat({
+        monitorId: 1,
+        heartbeat: hb,
+        monitorStatus: "down",
+        lastCheckedAt: "2026-04-28T00:10:00Z",
+        uptimePercentage: 95,
+        averageResponseTime: 250,
+      })
+
+      const m1 = getSnapshot().byId[1]
+      const m2 = getSnapshot().byId[2]
+      expect(m1?.heartbeats?.[m1.heartbeats.length - 1]).toEqual(hb)
+      expect(m1?.status).toBe("down")
+      expect(m1?.uptime_percentage).toBe(95)
+      expect(m1?.average_response_time).toBe(250)
+      expect(m1?.last_checked_at).toBe("2026-04-28T00:10:00Z")
+      expect(m2?.status).toBe("up")
+      expect(m2?.heartbeats).toEqual([])
+    })
+
+    it("caps heartbeat history at 90 entries", () => {
+      const initial = Array.from({ length: 90 }, (_, i) =>
+        makeHeartbeat({ id: i + 1, created_at: `2026-04-28T00:${String(i).padStart(2, "0")}:00Z` }),
+      )
+      hydrate([makeMonitor({ id: 1, heartbeats: initial })])
+      handleHeartbeat({
+        monitorId: 1,
+        heartbeat: makeHeartbeat({ id: 1000, created_at: "2026-04-28T05:00:00Z" }),
+        monitorStatus: "up",
+        lastCheckedAt: "2026-04-28T05:00:00Z",
+        uptimePercentage: 100,
+        averageResponseTime: 150,
+      })
+      const m1 = getSnapshot().byId[1]
+      expect(m1?.heartbeats).toHaveLength(90)
+      expect(m1?.heartbeats?.[89].id).toBe(1000)
+    })
+
+    it("ignores heartbeats for unknown monitor", () => {
+      hydrate([makeMonitor({ id: 1 })])
+      handleHeartbeat({
+        monitorId: 999,
+        heartbeat: makeHeartbeat({ monitor_id: 999 }),
+        monitorStatus: "up",
+        lastCheckedAt: "2026-04-28T00:10:00Z",
+        uptimePercentage: 100,
+        averageResponseTime: 100,
+      })
+      expect(getSnapshot().byId[999]).toBeUndefined()
+      expect(getSnapshot().monitors).toHaveLength(1)
+    })
+  })
+
+  describe("handleStatusChanged", () => {
+    it("updates status on matching monitor", () => {
+      hydrate([makeMonitor({ id: 1, status: "up" })])
+      handleStatusChanged({ monitorId: 1, oldStatus: "up", newStatus: "down", message: null })
+      expect(getSnapshot().byId[1]?.status).toBe("down")
+    })
+
+    it("is idempotent — same event twice yields same state ref", () => {
+      hydrate([makeMonitor({ id: 1, status: "up" })])
+      handleStatusChanged({ monitorId: 1, oldStatus: "up", newStatus: "down", message: null })
+      const after1 = getSnapshot()
+      handleStatusChanged({ monitorId: 1, oldStatus: "up", newStatus: "down", message: null })
+      const after2 = getSnapshot()
+      expect(after2).toBe(after1)
+      expect(after2.byId[1]?.status).toBe("down")
+    })
+  })
+
+  describe("handleChecking", () => {
+    it("sets status to pending on matching monitor", () => {
+      hydrate([makeMonitor({ id: 1, status: "up" })])
+      handleChecking({ monitorId: 1 })
+      expect(getSnapshot().byId[1]?.status).toBe("pending")
+    })
+
+    it("ignores unknown monitor", () => {
+      hydrate([makeMonitor({ id: 1, status: "up" })])
+      handleChecking({ monitorId: 42 })
+      expect(getSnapshot().byId[1]?.status).toBe("up")
+    })
+  })
+})

--- a/resources/js/stores/monitor-realtime.ts
+++ b/resources/js/stores/monitor-realtime.ts
@@ -4,7 +4,6 @@ import type {
   Heartbeat,
   HeartbeatPayload,
   Monitor,
-  MonitorStatus,
   StatusChangedPayload,
 } from "@/types/monitor"
 
@@ -91,6 +90,27 @@ export function getSnapshot(): State {
   return state
 }
 
+function hasNewHeartbeats(
+  existing: Heartbeat[] | undefined,
+  incoming: Heartbeat[] | undefined,
+): boolean {
+  if (!incoming || incoming.length === 0) return false
+  const existingIds = new Set((existing ?? []).map((h) => h.id))
+  for (const hb of incoming) {
+    if (!existingIds.has(hb.id)) return true
+  }
+  return false
+}
+
+function monitorMetaDiffers(a: Monitor, b: Monitor): boolean {
+  return (
+    a.status !== b.status ||
+    a.last_checked_at !== b.last_checked_at ||
+    a.uptime_percentage !== b.uptime_percentage ||
+    a.average_response_time !== b.average_response_time
+  )
+}
+
 export function hydrate(monitors: Monitor[] | undefined | null): void {
   if (!monitors || monitors.length === 0) {
     return
@@ -106,6 +126,11 @@ export function hydrate(monitors: Monitor[] | undefined | null): void {
     }
     const incomingNewer = timestamp(incoming.last_checked_at) > timestamp(existing.last_checked_at)
     const base = incomingNewer ? incoming : existing
+    const newHeartbeats = hasNewHeartbeats(existing.heartbeats, incoming.heartbeats)
+    const baseChanged = base !== existing && monitorMetaDiffers(base, existing)
+    if (!baseChanged && !newHeartbeats) {
+      continue
+    }
     const merged: Monitor = {
       ...base,
       heartbeats: mergeHeartbeats(existing.heartbeats, incoming.heartbeats),
@@ -125,10 +150,15 @@ export function handleHeartbeat(payload: HeartbeatPayload): void {
   if (!existing) {
     return
   }
-  const heartbeats = mergeHeartbeats(existing.heartbeats, [payload.heartbeat])
+  const heartbeat: Heartbeat = {
+    ...payload.heartbeat,
+    monitor_id: payload.monitorId,
+    message: null,
+  }
+  const heartbeats = mergeHeartbeats(existing.heartbeats, [heartbeat])
   const updated: Monitor = {
     ...existing,
-    status: payload.monitorStatus as MonitorStatus,
+    status: payload.monitorStatus,
     heartbeats,
     uptime_percentage: payload.uptimePercentage,
     average_response_time: payload.averageResponseTime,
@@ -146,7 +176,7 @@ export function handleStatusChanged(payload: StatusChangedPayload): void {
   if (existing.status === payload.newStatus) {
     return
   }
-  const updated: Monitor = { ...existing, status: payload.newStatus as MonitorStatus }
+  const updated: Monitor = { ...existing, status: payload.newStatus }
   commit({ ...state.byId, [payload.monitorId]: updated })
 }
 
@@ -161,6 +191,13 @@ export function handleChecking(payload: CheckingPayload): void {
   }
   const updated: Monitor = { ...existing, status: "pending" }
   commit({ ...state.byId, [payload.monitorId]: updated })
+}
+
+export function clear(): void {
+  if (state.monitors.length === 0 && Object.keys(state.byId).length === 0) {
+    return
+  }
+  commit({})
 }
 
 export function __resetForTests(): void {

--- a/resources/js/stores/monitor-realtime.ts
+++ b/resources/js/stores/monitor-realtime.ts
@@ -117,8 +117,8 @@ export function hydrate(monitors: Monitor[] | undefined | null): void {
       changed = true
       continue
     }
-    const existingNewer = timestamp(existing.last_checked_at) > timestamp(incoming.last_checked_at)
-    const base = existingNewer ? existing : incoming
+    const incomingNewer = timestamp(incoming.last_checked_at) > timestamp(existing.last_checked_at)
+    const base = incomingNewer ? incoming : existing
     const merged: Monitor = {
       ...base,
       heartbeats: mergeHeartbeats(existing.heartbeats, incoming.heartbeats),

--- a/resources/js/stores/monitor-realtime.ts
+++ b/resources/js/stores/monitor-realtime.ts
@@ -1,0 +1,211 @@
+import { useEffect, useSyncExternalStore } from "react"
+import type { Heartbeat, Monitor, MonitorStatus } from "@/types/monitor"
+
+export interface HeartbeatPayload {
+  monitorId: number
+  heartbeat: Heartbeat
+  monitorStatus: string
+  lastCheckedAt?: string
+  uptimePercentage: number
+  averageResponseTime: number | null
+}
+
+export interface StatusChangedPayload {
+  monitorId: number
+  oldStatus: string
+  newStatus: string
+  message: string | null
+}
+
+export interface CheckingPayload {
+  monitorId: number
+}
+
+export interface MonitorCounts {
+  total: number
+  up: number
+  down: number
+  pending: number
+  paused: number
+}
+
+interface State {
+  monitors: Monitor[]
+  byId: Record<number, Monitor>
+}
+
+export type RealtimeEvent =
+  | { type: "heartbeat"; payload: HeartbeatPayload }
+  | { type: "status"; payload: StatusChangedPayload }
+  | { type: "checking"; payload: CheckingPayload }
+
+const HEARTBEAT_LIMIT = 90
+
+let state: State = { monitors: [], byId: {} }
+const listeners = new Set<() => void>()
+const eventListeners = new Set<(event: RealtimeEvent) => void>()
+
+function emit(): void {
+  for (const l of listeners) {
+    l()
+  }
+}
+
+function emitEvent(event: RealtimeEvent): void {
+  for (const l of eventListeners) {
+    l(event)
+  }
+}
+
+export function subscribeToEvents(listener: (event: RealtimeEvent) => void): () => void {
+  eventListeners.add(listener)
+  return () => {
+    eventListeners.delete(listener)
+  }
+}
+
+function commit(byId: Record<number, Monitor>): void {
+  state = { byId, monitors: Object.values(byId) }
+  emit()
+}
+
+function timestamp(value: string | null | undefined): number {
+  return value ? new Date(value).getTime() : 0
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function getSnapshot(): State {
+  return state
+}
+
+export function hydrate(monitors: Monitor[] | undefined | null): void {
+  if (!monitors || monitors.length === 0) {
+    return
+  }
+  const byId: Record<number, Monitor> = { ...state.byId }
+  let changed = false
+  for (const incoming of monitors) {
+    const existing = byId[incoming.id]
+    if (!existing) {
+      byId[incoming.id] = incoming
+      changed = true
+      continue
+    }
+    if (timestamp(existing.last_checked_at) > timestamp(incoming.last_checked_at)) {
+      continue
+    }
+    byId[incoming.id] = incoming
+    changed = true
+  }
+  if (!changed) {
+    return
+  }
+  commit(byId)
+}
+
+export function handleHeartbeat(payload: HeartbeatPayload): void {
+  emitEvent({ type: "heartbeat", payload })
+  const existing = state.byId[payload.monitorId]
+  if (!existing) {
+    return
+  }
+  const heartbeats = [...(existing.heartbeats ?? []), payload.heartbeat].slice(-HEARTBEAT_LIMIT)
+  const updated: Monitor = {
+    ...existing,
+    status: payload.monitorStatus as MonitorStatus,
+    heartbeats,
+    uptime_percentage: payload.uptimePercentage,
+    average_response_time: payload.averageResponseTime,
+    last_checked_at: payload.lastCheckedAt ?? existing.last_checked_at,
+  }
+  commit({ ...state.byId, [payload.monitorId]: updated })
+}
+
+export function handleStatusChanged(payload: StatusChangedPayload): void {
+  emitEvent({ type: "status", payload })
+  const existing = state.byId[payload.monitorId]
+  if (!existing) {
+    return
+  }
+  if (existing.status === payload.newStatus) {
+    return
+  }
+  const updated: Monitor = { ...existing, status: payload.newStatus as MonitorStatus }
+  commit({ ...state.byId, [payload.monitorId]: updated })
+}
+
+export function handleChecking(payload: CheckingPayload): void {
+  emitEvent({ type: "checking", payload })
+  const existing = state.byId[payload.monitorId]
+  if (!existing) {
+    return
+  }
+  if (existing.status === "pending") {
+    return
+  }
+  const updated: Monitor = { ...existing, status: "pending" }
+  commit({ ...state.byId, [payload.monitorId]: updated })
+}
+
+export function __resetForTests(): void {
+  state = { monitors: [], byId: {} }
+  listeners.clear()
+  eventListeners.clear()
+}
+
+function getMonitorsSnapshot(): Monitor[] {
+  return state.monitors
+}
+
+let cachedCountsState: State | null = null
+let cachedCounts: MonitorCounts = { total: 0, up: 0, down: 0, pending: 0, paused: 0 }
+
+function getCountsSnapshot(): MonitorCounts {
+  if (cachedCountsState === state) {
+    return cachedCounts
+  }
+  const counts: MonitorCounts = { total: 0, up: 0, down: 0, pending: 0, paused: 0 }
+  for (const m of state.monitors) {
+    counts.total++
+    if (m.status === "up") counts.up++
+    else if (m.status === "down") counts.down++
+    else if (m.status === "pending") counts.pending++
+    else if (m.status === "paused") counts.paused++
+  }
+  cachedCounts = counts
+  cachedCountsState = state
+  return counts
+}
+
+export function useMonitors(): Monitor[] {
+  return useSyncExternalStore(subscribe, getMonitorsSnapshot, getMonitorsSnapshot)
+}
+
+export function useMonitor(id: number): Monitor | undefined {
+  const getMonitor = (): Monitor | undefined => state.byId[id]
+  return useSyncExternalStore(subscribe, getMonitor, getMonitor)
+}
+
+export function useMonitorCounts(): MonitorCounts {
+  return useSyncExternalStore(subscribe, getCountsSnapshot, getCountsSnapshot)
+}
+
+export function useHydrateMonitors(monitors: Monitor[] | undefined | null): void {
+  useEffect(() => {
+    hydrate(monitors)
+  }, [monitors])
+}
+
+export function useHydrateMonitor(monitor: Monitor | undefined | null): void {
+  useEffect(() => {
+    if (monitor) {
+      hydrate([monitor])
+    }
+  }, [monitor])
+}

--- a/resources/js/stores/monitor-realtime.ts
+++ b/resources/js/stores/monitor-realtime.ts
@@ -1,5 +1,12 @@
 import { useEffect, useSyncExternalStore } from "react"
-import type { Heartbeat, Monitor, MonitorStatus } from "@/types/monitor"
+import type {
+  CheckingPayload,
+  Heartbeat,
+  HeartbeatPayload,
+  Monitor,
+  MonitorStatus,
+  StatusChangedPayload,
+} from "@/types/monitor"
 
 const HEARTBEAT_LIMIT = 90
 
@@ -21,26 +28,6 @@ function mergeHeartbeats(
     merged.push(hb)
   }
   return merged.slice(-HEARTBEAT_LIMIT)
-}
-
-export interface HeartbeatPayload {
-  monitorId: number
-  heartbeat: Heartbeat
-  monitorStatus: string
-  lastCheckedAt?: string
-  uptimePercentage: number
-  averageResponseTime: number | null
-}
-
-export interface StatusChangedPayload {
-  monitorId: number
-  oldStatus: string
-  newStatus: string
-  message: string | null
-}
-
-export interface CheckingPayload {
-  monitorId: number
 }
 
 export interface MonitorCounts {

--- a/resources/js/stores/monitor-realtime.ts
+++ b/resources/js/stores/monitor-realtime.ts
@@ -1,6 +1,28 @@
 import { useEffect, useSyncExternalStore } from "react"
 import type { Heartbeat, Monitor, MonitorStatus } from "@/types/monitor"
 
+const HEARTBEAT_LIMIT = 90
+
+function mergeHeartbeats(
+  existing: Heartbeat[] | undefined,
+  incoming: Heartbeat[] | undefined,
+): Heartbeat[] {
+  const a = existing ?? []
+  const b = incoming ?? []
+  if (a.length === 0) return b.slice(-HEARTBEAT_LIMIT)
+  if (b.length === 0) return a.slice(-HEARTBEAT_LIMIT)
+  const seen = new Set<number>()
+  const merged: Heartbeat[] = []
+  const all = [...a, ...b]
+  all.sort((x, y) => new Date(x.created_at).getTime() - new Date(y.created_at).getTime())
+  for (const hb of all) {
+    if (seen.has(hb.id)) continue
+    seen.add(hb.id)
+    merged.push(hb)
+  }
+  return merged.slice(-HEARTBEAT_LIMIT)
+}
+
 export interface HeartbeatPayload {
   monitorId: number
   heartbeat: Heartbeat
@@ -38,8 +60,6 @@ export type RealtimeEvent =
   | { type: "heartbeat"; payload: HeartbeatPayload }
   | { type: "status"; payload: StatusChangedPayload }
   | { type: "checking"; payload: CheckingPayload }
-
-const HEARTBEAT_LIMIT = 90
 
 let state: State = { monitors: [], byId: {} }
 const listeners = new Set<() => void>()
@@ -97,10 +117,13 @@ export function hydrate(monitors: Monitor[] | undefined | null): void {
       changed = true
       continue
     }
-    if (timestamp(existing.last_checked_at) > timestamp(incoming.last_checked_at)) {
-      continue
+    const existingNewer = timestamp(existing.last_checked_at) > timestamp(incoming.last_checked_at)
+    const base = existingNewer ? existing : incoming
+    const merged: Monitor = {
+      ...base,
+      heartbeats: mergeHeartbeats(existing.heartbeats, incoming.heartbeats),
     }
-    byId[incoming.id] = incoming
+    byId[incoming.id] = merged
     changed = true
   }
   if (!changed) {
@@ -115,7 +138,7 @@ export function handleHeartbeat(payload: HeartbeatPayload): void {
   if (!existing) {
     return
   }
-  const heartbeats = [...(existing.heartbeats ?? []), payload.heartbeat].slice(-HEARTBEAT_LIMIT)
+  const heartbeats = mergeHeartbeats(existing.heartbeats, [payload.heartbeat])
   const updated: Monitor = {
     ...existing,
     status: payload.monitorStatus as MonitorStatus,

--- a/resources/js/stores/monitor-realtime.ts
+++ b/resources/js/stores/monitor-realtime.ts
@@ -176,7 +176,7 @@ function getMonitorsSnapshot(): Monitor[] {
 let cachedCountsState: State | null = null
 let cachedCounts: MonitorCounts = { total: 0, up: 0, down: 0, pending: 0, paused: 0 }
 
-function getCountsSnapshot(): MonitorCounts {
+export function getCountsSnapshot(): MonitorCounts {
   if (cachedCountsState === state) {
     return cachedCounts
   }

--- a/resources/js/test/setup.ts
+++ b/resources/js/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest"

--- a/resources/js/types/monitor.ts
+++ b/resources/js/types/monitor.ts
@@ -184,10 +184,18 @@ export interface TeamMember {
     pivot: { role: TeamRole }
 }
 
+export interface RealtimeHeartbeat {
+    id: number
+    status: HeartbeatStatus
+    status_code: number | null
+    response_time: number | null
+    created_at: string
+}
+
 export interface HeartbeatPayload {
     monitorId: number
-    heartbeat: Heartbeat
-    monitorStatus: string
+    heartbeat: RealtimeHeartbeat
+    monitorStatus: MonitorStatus
     lastCheckedAt?: string | null
     uptimePercentage: number
     averageResponseTime: number | null
@@ -195,8 +203,8 @@ export interface HeartbeatPayload {
 
 export interface StatusChangedPayload {
     monitorId: number
-    oldStatus: string
-    newStatus: string
+    oldStatus: MonitorStatus
+    newStatus: MonitorStatus
     message: string | null
 }
 

--- a/resources/js/types/monitor.ts
+++ b/resources/js/types/monitor.ts
@@ -184,6 +184,26 @@ export interface TeamMember {
     pivot: { role: TeamRole }
 }
 
+export interface HeartbeatPayload {
+    monitorId: number
+    heartbeat: Heartbeat
+    monitorStatus: string
+    lastCheckedAt?: string | null
+    uptimePercentage: number
+    averageResponseTime: number | null
+}
+
+export interface StatusChangedPayload {
+    monitorId: number
+    oldStatus: string
+    newStatus: string
+    message: string | null
+}
+
+export interface CheckingPayload {
+    monitorId: number
+}
+
 export interface AuditLog {
     id: number
     team_id: number

--- a/tests/Feature/DashboardDataTest.php
+++ b/tests/Feature/DashboardDataTest.php
@@ -3,34 +3,34 @@
 use App\Models\Monitor;
 use App\Models\User;
 
-test('dashboard returns monitor counts', function () {
+test('dashboard deferred monitors include all team monitors with their status', function () {
     $user = User::factory()->create();
     Monitor::factory()->up()->create(['user_id' => $user->id]);
     Monitor::factory()->up()->create(['user_id' => $user->id]);
     Monitor::factory()->down()->create(['user_id' => $user->id]);
     Monitor::factory()->paused()->create(['user_id' => $user->id]);
 
-    $response = $this->actingAs($user)->get('/dashboard');
-
-    $response->assertOk()
+    $this->actingAs($user)->get('/dashboard')
+        ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->component('dashboard')
-            ->where('counts.total', 4)
-            ->where('counts.up', 2)
-            ->where('counts.down', 1)
-            ->where('counts.paused', 1)
+            ->loadDeferredProps('default', fn ($page) => $page
+                ->has('monitors', 4)
+                ->where('monitors', fn ($monitors) => collect($monitors)
+                    ->countBy('status')
+                    ->all() === ['up' => 2, 'down' => 1, 'paused' => 1])
+            )
         );
 });
 
-test('dashboard shows zero counts for user with no monitors', function () {
+test('dashboard renders for user with no monitors', function () {
     $user = User::factory()->create();
 
-    $response = $this->actingAs($user)->get('/dashboard');
-
-    $response->assertOk()
+    $this->actingAs($user)->get('/dashboard')
+        ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->component('dashboard')
-            ->where('counts.total', 0)
+            ->loadDeferredProps('default', fn ($page) => $page->has('monitors', 0))
         );
 });
 
@@ -41,10 +41,9 @@ test('dashboard only shows monitors for authenticated user', function () {
     Monitor::factory()->up()->count(3)->create(['user_id' => $user->id]);
     Monitor::factory()->up()->count(5)->create(['user_id' => $otherUser->id]);
 
-    $response = $this->actingAs($user)->get('/dashboard');
-
-    $response->assertOk()
+    $this->actingAs($user)->get('/dashboard')
+        ->assertOk()
         ->assertInertia(fn ($page) => $page
-            ->where('counts.total', 3)
+            ->loadDeferredProps('default', fn ($page) => $page->has('monitors', 3))
         );
 });

--- a/tests/Feature/HeartbeatOrderTest.php
+++ b/tests/Feature/HeartbeatOrderTest.php
@@ -97,3 +97,32 @@ test('HeartbeatRecorded broadcast payload exposes heartbeat created_at as ISO st
 
     expect($payload['heartbeat']['created_at'])->toBe($heartbeat->created_at->toISOString());
 });
+
+test('HeartbeatRecorded broadcast payload includes lastCheckedAt as ISO timestamp', function () {
+    $user = User::factory()->create();
+    $checkedAt = now()->subSeconds(10);
+    $monitor = Monitor::factory()->for($user)->create([
+        'last_checked_at' => $checkedAt,
+    ]);
+    $heartbeat = Heartbeat::factory()->for($monitor)->create();
+
+    $event = new HeartbeatRecorded($monitor->refresh(), $heartbeat->refresh());
+    $payload = $event->broadcastWith();
+
+    expect($payload)->toHaveKey('lastCheckedAt');
+    expect($payload['lastCheckedAt'])->toBe($monitor->last_checked_at->toISOString());
+});
+
+test('HeartbeatRecorded broadcast payload lastCheckedAt is null when monitor never checked', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'last_checked_at' => null,
+    ]);
+    $heartbeat = Heartbeat::factory()->for($monitor)->create();
+
+    $event = new HeartbeatRecorded($monitor->refresh(), $heartbeat->refresh());
+    $payload = $event->broadcastWith();
+
+    expect($payload)->toHaveKey('lastCheckedAt');
+    expect($payload['lastCheckedAt'])->toBeNull();
+});

--- a/tests/Feature/HeartbeatOrderTest.php
+++ b/tests/Feature/HeartbeatOrderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Events\HeartbeatRecorded;
+use App\Models\Heartbeat;
+use App\Models\Monitor;
+use App\Models\StatusPage;
+use App\Models\User;
+
+function makeMonitorWithSequencedHeartbeats(User $user, int $count = 5): Monitor
+{
+    $monitor = Monitor::factory()->for($user)->create();
+
+    for ($i = 0; $i < $count; $i++) {
+        Heartbeat::factory()->for($monitor)->create([
+            'created_at' => now()->subMinutes($count - $i),
+        ]);
+    }
+
+    return $monitor;
+}
+
+function assertAscByCreatedAt(array $heartbeats): void
+{
+    $timestamps = array_map(fn ($h) => $h['created_at'], $heartbeats);
+    $sorted = $timestamps;
+    sort($sorted);
+    expect($timestamps)->toBe($sorted);
+}
+
+test('dashboard payload returns heartbeats sorted oldest-first by created_at', function () {
+    $user = User::factory()->create();
+    makeMonitorWithSequencedHeartbeats($user, 5);
+
+    $response = $this->actingAs($user)
+        ->withHeaders(inertiaPartialHeaders('dashboard', 'monitors'))
+        ->get('/dashboard')
+        ->assertOk();
+
+    $monitors = $response->json('props.monitors');
+    expect($monitors)->not->toBeNull();
+    assertAscByCreatedAt($monitors[0]['heartbeats']);
+});
+
+test('monitors index payload returns heartbeats sorted oldest-first by created_at', function () {
+    $user = User::factory()->create();
+    makeMonitorWithSequencedHeartbeats($user, 5);
+
+    $response = $this->actingAs($user)
+        ->withHeaders(inertiaPartialHeaders('monitors/index', 'monitors'))
+        ->get('/monitors')
+        ->assertOk();
+
+    $monitors = $response->json('props.monitors');
+    expect($monitors)->not->toBeNull();
+    assertAscByCreatedAt($monitors[0]['heartbeats']);
+});
+
+test('paginated heartbeats payload on monitor show is sorted oldest-first by created_at', function () {
+    $user = User::factory()->create();
+    $monitor = makeMonitorWithSequencedHeartbeats($user, 5);
+
+    $response = $this->actingAs($user)
+        ->withHeaders(inertiaPartialHeaders('monitors/show', 'heartbeats'))
+        ->get("/monitors/{$monitor->id}")
+        ->assertOk();
+
+    $data = $response->json('props.heartbeats.data');
+    expect($data)->not->toBeNull();
+    assertAscByCreatedAt($data);
+});
+
+test('public status page payload returns heartbeats sorted oldest-first by created_at', function () {
+    $user = User::factory()->create();
+    $monitor = makeMonitorWithSequencedHeartbeats($user, 5);
+    $statusPage = StatusPage::factory()->for($user)->create([
+        'is_published' => true,
+    ]);
+    $statusPage->monitors()->attach($monitor);
+
+    $this->get("/status/{$statusPage->slug}")
+        ->assertOk()
+        ->assertInertia(function ($page) {
+            $monitors = $page->toArray()['props']['monitors'];
+            assertAscByCreatedAt($monitors[0]['heartbeats']);
+        });
+});
+
+test('HeartbeatRecorded broadcast payload exposes heartbeat created_at as ISO string', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create();
+    $heartbeat = Heartbeat::factory()->for($monitor)->create([
+        'created_at' => now()->subMinute(),
+    ]);
+
+    $event = new HeartbeatRecorded($monitor->refresh(), $heartbeat->refresh());
+    $payload = $event->broadcastWith();
+
+    expect($payload['heartbeat']['created_at'])->toBe($heartbeat->created_at->toISOString());
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import react from "@vitejs/plugin-react"
+import { resolve } from "node:path"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+    plugins: [react()],
+    resolve: {
+        alias: {
+            "@": resolve(__dirname, "resources/js"),
+        },
+    },
+    test: {
+        environment: "jsdom",
+        globals: true,
+        setupFiles: ["resources/js/test/setup.ts"],
+        include: ["resources/js/**/*.{test,spec}.{ts,tsx}"],
+    },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import react from "@vitejs/plugin-react"
-import { resolve } from "node:path"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vitest/config"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
     plugins: [react()],


### PR DESCRIPTION
## Summary
- Closes 6 PRDs in `docs/prds/` covering monitor UI realtime layer (heartbeat order, status bar consistency, stale `last_checked_at`, status counts drift, partial-reload state wipe, render storm).
- Centralizes WS state in shared store; eliminates 4 of 5 redundant `useEcho` subscribers.
- Memoizes `MonitorRow` + `MonitorCard`, trims concurrent `animate-ping` to alarm dots only, swaps `Math.random` ref for `useId()`.
- Adds Vitest + React Testing Library; 34 tests covering store, helpers, memo equality.

## PRD coverage
| PRD | Commits |
|-----|---------|
| 01 heartbeat order | `164c89e`, `2f91c29` |
| 02 status bar consistency | `d2b0fe3`, `2f91c29` |
| 03 stale last_checked_at | `9c59fc4` |
| 04 status counts drift | `b2f978a` |
| 05 partial reload wipes WS | `0699fbf`, `7c58874`, `f2a372f` |
| 06 render storm | `1b8e0fb` |

## Test plan
- [x] `npm run test:js` — 34/34 passing
- [x] `npx biome check --write` — clean
- [ ] Manual smoke: dashboard + monitors index under 20-event WS burst, verify no layout jumps
- [ ] Manual smoke: confirm `animate-ping` only on incident banner + LiveFeed indicator + down-state StatusDot
- [ ] Manual smoke: Inertia partial reload preserves heartbeat state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized realtime monitor updates for instant heartbeat, status and checking notifications
  * Expanded heartbeat history to 90 entries per monitor for richer trend views
  * Slow-response detection added to highlight degraded monitors

* **Bug Fixes**
  * Heartbeats consistently ordered oldest-first across dashboard, monitors list, detail pages, and public status

* **Style**
  * Increased UI corner radii for a smoother look

* **Tests**
  * Added Vitest-based JS test suite and many realtime/unit tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->