### PR TITLE
feat(dev): replace fake HTTP monitors with locally-spawned dev servers

### DIFF
--- a/app/Console/Commands/DevFakeServersCommand.php
+++ b/app/Console/Commands/DevFakeServersCommand.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+class DevFakeServersCommand extends Command
+{
+    protected $signature = 'dev:fake-servers {--stream : Stream child server output to STDERR}';
+
+    protected $description = 'Spawn a fleet of local fake HTTP servers (ports 9001-9020) for dev monitor targets.';
+
+    /**
+     * Profile registry — single source of truth shared with MonitorSeeder.
+     *
+     * Each entry keyed by port. Fields:
+     *   - kind: fast|slow|jitter|spike|down_500|unbound|flap|timeout
+     *   - name: monitor display name
+     *   - interval: monitor check interval (seconds)
+     *   - latency_min/latency_max: ms (fast/slow/jitter)
+     *   - spike_outlier_pct: 0-100 (spike)
+     *   - spike_outlier_ms: ms (spike)
+     *   - flap_down_pct: 0-100 (flap)
+     *   - sleep_seconds: float (timeout — exceeds monitor timeout of 10s)
+     *   - bind: false to skip spawning (unbound)
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function profileRegistry(): array
+    {
+        $registry = [];
+
+        foreach (range(9001, 9004) as $port) {
+            $registry[$port] = [
+                'kind' => 'fast',
+                'name' => "Fast API :{$port}",
+                'interval' => 30,
+                'latency_min' => 5,
+                'latency_max' => 50,
+                'bind' => true,
+            ];
+        }
+
+        foreach (range(9005, 9007) as $port) {
+            $registry[$port] = [
+                'kind' => 'slow',
+                'name' => "Slow API :{$port}",
+                'interval' => 60,
+                'latency_min' => 500,
+                'latency_max' => 1500,
+                'bind' => true,
+            ];
+        }
+
+        foreach (range(9008, 9011) as $port) {
+            $registry[$port] = [
+                'kind' => 'jitter',
+                'name' => "Jittery API :{$port}",
+                'interval' => 60,
+                'latency_min' => 10,
+                'latency_max' => 2000,
+                'bind' => true,
+            ];
+        }
+
+        foreach (range(9012, 9013) as $port) {
+            $registry[$port] = [
+                'kind' => 'spike',
+                'name' => "Spiky API :{$port}",
+                'interval' => 30,
+                'latency_min' => 5,
+                'latency_max' => 50,
+                'spike_outlier_pct' => 10,
+                'spike_outlier_ms' => 3000,
+                'bind' => true,
+            ];
+        }
+
+        foreach (range(9014, 9015) as $port) {
+            $registry[$port] = [
+                'kind' => 'down_500',
+                'name' => "Always-500 Service :{$port}",
+                'interval' => 60,
+                'bind' => true,
+            ];
+        }
+
+        foreach (range(9016, 9017) as $port) {
+            $registry[$port] = [
+                'kind' => 'unbound',
+                'name' => "Unbound Port :{$port}",
+                'interval' => 60,
+                'bind' => false,
+            ];
+        }
+
+        foreach (range(9018, 9019) as $port) {
+            $registry[$port] = [
+                'kind' => 'flap',
+                'name' => "Flapping Service :{$port}",
+                'interval' => 30,
+                'flap_down_pct' => 20,
+                'bind' => true,
+            ];
+        }
+
+        $registry[9020] = [
+            'kind' => 'timeout',
+            'name' => 'Timeout API :9020',
+            'interval' => 120,
+            'sleep_seconds' => 15,
+            'bind' => true,
+        ];
+
+        return $registry;
+    }
+
+    public function handle(): int
+    {
+        if (! app()->environment('local')) {
+            $this->warn('dev:fake-servers refuses to run outside the local environment.');
+
+            return self::FAILURE;
+        }
+
+        $router = base_path('bin/dev-fake-server-router.php');
+        if (! is_file($router)) {
+            $this->error("Router script not found: {$router}");
+
+            return self::FAILURE;
+        }
+
+        $stream = (bool) $this->option('stream');
+
+        /** @var array<int, Process> $processes */
+        $processes = [];
+
+        foreach (self::profileRegistry() as $port => $profile) {
+            if (empty($profile['bind'])) {
+                continue;
+            }
+
+            if ($this->isPortBound($port)) {
+                $this->error("Port {$port} is already in use. Free it and retry.");
+                $this->stopAll($processes);
+
+                return self::FAILURE;
+            }
+
+            $process = new Process(
+                [PHP_BINARY, '-S', "127.0.0.1:{$port}", $router],
+                base_path(),
+                ['FAKE_SERVER_PROFILE' => json_encode($profile)],
+            );
+            $process->setTimeout(null);
+            $process->start(function ($type, $buffer) use ($port, $stream) {
+                if ($stream) {
+                    fwrite(STDERR, "[fake:{$port}] {$buffer}");
+                }
+            });
+
+            $processes[$port] = $process;
+            $this->line("fake-server up on 127.0.0.1:{$port} ({$profile['kind']})");
+        }
+
+        $this->registerSignalHandlers($processes);
+
+        while (! empty($processes)) {
+            foreach ($processes as $port => $process) {
+                if (! $process->isRunning()) {
+                    $this->warn("fake-server on port {$port} exited (code ".($process->getExitCode() ?? 'null').'). Leaving dead.');
+                    unset($processes[$port]);
+
+                    continue;
+                }
+            }
+
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+
+            usleep(250_000);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function isPortBound(int $port): bool
+    {
+        $socket = @stream_socket_client("tcp://127.0.0.1:{$port}", $errno, $errstr, 0.2);
+        if ($socket) {
+            fclose($socket);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<int, Process>  $processes
+     */
+    private function registerSignalHandlers(array &$processes): void
+    {
+        if (! function_exists('pcntl_signal')) {
+            return;
+        }
+
+        $handler = function () use (&$processes) {
+            $this->stopAll($processes);
+            $processes = [];
+        };
+
+        pcntl_async_signals(true);
+        pcntl_signal(SIGINT, $handler);
+        pcntl_signal(SIGTERM, $handler);
+    }
+
+    /**
+     * @param  array<int, Process>  $processes
+     */
+    private function stopAll(array $processes): void
+    {
+        foreach ($processes as $process) {
+            if ($process->isRunning()) {
+                $process->stop(2);
+            }
+        }
+    }
+}

--- a/app/Console/Commands/DevFakeServersCommand.php
+++ b/app/Console/Commands/DevFakeServersCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Process;
 
 class DevFakeServersCommand extends Command
 {
-    protected $signature = 'dev:fake-servers {--stream : Stream child server output to STDERR}';
+    protected $signature = 'dev:fake-servers';
 
     protected $description = 'Spawn a fleet of local fake HTTP servers (ports 9001-9020) for dev monitor targets.';
 
@@ -100,6 +100,8 @@ class DevFakeServersCommand extends Command
                 'kind' => 'flap',
                 'name' => "Flapping Service :{$port}",
                 'interval' => 30,
+                'latency_min' => 30,
+                'latency_max' => 250,
                 'flap_down_pct' => 20,
                 'bind' => true,
             ];
@@ -131,7 +133,7 @@ class DevFakeServersCommand extends Command
             return self::FAILURE;
         }
 
-        $stream = (bool) $this->option('stream');
+        $stream = $this->output->isVerbose();
 
         /** @var array<int, Process> $processes */
         $processes = [];
@@ -154,11 +156,15 @@ class DevFakeServersCommand extends Command
                 ['FAKE_SERVER_PROFILE' => json_encode($profile)],
             );
             $process->setTimeout(null);
-            $process->start(function ($type, $buffer) use ($port, $stream) {
-                if ($stream) {
+
+            if ($stream) {
+                $process->start(function ($type, $buffer) use ($port) {
                     fwrite(STDERR, "[fake:{$port}] {$buffer}");
-                }
-            });
+                });
+            } else {
+                $process->disableOutput();
+                $process->start();
+            }
 
             $processes[$port] = $process;
             $this->line("fake-server up on 127.0.0.1:{$port} ({$profile['kind']})");

--- a/bin/dev-fake-server-router.php
+++ b/bin/dev-fake-server-router.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Dispatch script for `php -S` fake-server children.
+ * Reads FAKE_SERVER_PROFILE (JSON) from environment and responds per profile kind.
+ * No Laravel boot — pure PHP.
+ */
+declare(strict_types=1);
+
+$raw = getenv('FAKE_SERVER_PROFILE');
+$profile = $raw ? json_decode($raw, true) : null;
+
+if (! is_array($profile) || ! isset($profile['kind'])) {
+    http_response_code(500);
+    header('Content-Type: text/plain');
+    echo "fake-server: missing or invalid FAKE_SERVER_PROFILE\n";
+
+    return;
+}
+
+$kind = $profile['kind'];
+
+switch ($kind) {
+    case 'fast':
+    case 'slow':
+    case 'jitter':
+        $min = (int) ($profile['latency_min'] ?? 0);
+        $max = (int) ($profile['latency_max'] ?? $min);
+        $latencyMs = $max > $min ? mt_rand($min, $max) : $min;
+        usleep($latencyMs * 1000);
+        respondOk($kind, $latencyMs);
+        break;
+
+    case 'spike':
+        $outlierPct = (int) ($profile['spike_outlier_pct'] ?? 10);
+        $isOutlier = mt_rand(1, 100) <= $outlierPct;
+        if ($isOutlier) {
+            $latencyMs = (int) ($profile['spike_outlier_ms'] ?? 3000);
+        } else {
+            $min = (int) ($profile['latency_min'] ?? 5);
+            $max = (int) ($profile['latency_max'] ?? 50);
+            $latencyMs = $max > $min ? mt_rand($min, $max) : $min;
+        }
+        usleep($latencyMs * 1000);
+        respondOk($kind, $latencyMs);
+        break;
+
+    case 'flap':
+        $downPct = (int) ($profile['flap_down_pct'] ?? 20);
+        if (mt_rand(1, 100) <= $downPct) {
+            http_response_code(500);
+            header('Content-Type: text/plain');
+            echo "fake-server flap: simulated 500\n";
+        } else {
+            respondOk($kind, 0);
+        }
+        break;
+
+    case 'down_500':
+        http_response_code(500);
+        header('Content-Type: text/plain');
+        echo "fake-server: always 500\n";
+        break;
+
+    case 'timeout':
+        $sleep = (float) ($profile['sleep_seconds'] ?? 15);
+        usleep((int) ($sleep * 1_000_000));
+        respondOk($kind, (int) ($sleep * 1000));
+        break;
+
+    default:
+        http_response_code(500);
+        header('Content-Type: text/plain');
+        echo "fake-server: unknown kind '{$kind}'\n";
+}
+
+function respondOk(string $kind, int $latencyMs): void
+{
+    http_response_code(200);
+    header('Content-Type: application/json');
+    echo json_encode(['ok' => true, 'kind' => $kind, 'latency_ms' => $latencyMs]);
+}

--- a/bin/dev-fake-server-router.php
+++ b/bin/dev-fake-server-router.php
@@ -46,13 +46,17 @@ switch ($kind) {
         break;
 
     case 'flap':
+        $min = (int) ($profile['latency_min'] ?? 30);
+        $max = (int) ($profile['latency_max'] ?? 250);
+        $latencyMs = $max > $min ? mt_rand($min, $max) : $min;
+        usleep($latencyMs * 1000);
         $downPct = (int) ($profile['flap_down_pct'] ?? 20);
         if (mt_rand(1, 100) <= $downPct) {
             http_response_code(500);
             header('Content-Type: text/plain');
             echo "fake-server flap: simulated 500\n";
         } else {
-            respondOk($kind, 0);
+            respondOk($kind, $latencyMs);
         }
         break;
 

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#86efac,#fbbf24\" \"php artisan serve\" \"php artisan queue:listen --queue=monitors,ssl,notifications,default --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" \"php artisan schedule:work\" \"php artisan reverb:start\" --names=server,queue,logs,vite,scheduler,reverb"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#86efac,#fbbf24,#f5a524\" \"php artisan serve\" \"php artisan queue:listen --queue=monitors,ssl,notifications,default --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" \"php artisan schedule:work\" \"php artisan reverb:start\" \"php artisan dev:fake-servers\" --names=server,queue,logs,vite,scheduler,reverb,fakes"
         ]
     },
     "extra": {

--- a/database/seeders/MonitorSeeder.php
+++ b/database/seeders/MonitorSeeder.php
@@ -2,18 +2,22 @@
 
 namespace Database\Seeders;
 
-use App\Models\Heartbeat;
+use App\Console\Commands\DevFakeServersCommand;
 use App\Models\Incident;
 use App\Models\Monitor;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class MonitorSeeder extends Seeder
 {
     public function run(): void
     {
+        // Seeder builds tens of thousands of synthetic heartbeats; default CLI 128M OOMs.
+        ini_set('memory_limit', '512M');
+
         $user = User::where('email', 'test@example.com')->firstOrFail();
 
         $monitors = $this->definitions($user->id, $user->current_team_id);
@@ -25,8 +29,21 @@ class MonitorSeeder extends Seeder
 
             $monitor = Monitor::create($definition);
 
-            foreach ($heartbeats as $hb) {
-                (new Heartbeat)->forceFill(['monitor_id' => $monitor->id, ...$hb])->save();
+            if (! empty($heartbeats)) {
+                $rows = array_map(fn (array $hb) => [
+                    'monitor_id' => $monitor->id,
+                    'status' => $hb['status'],
+                    'status_code' => $hb['status_code'] ?? null,
+                    'response_time' => $hb['response_time'] ?? null,
+                    'message' => $hb['message'] ?? null,
+                    'created_at' => $hb['created_at'] instanceof Carbon
+                        ? $hb['created_at']->toDateTimeString()
+                        : $hb['created_at'],
+                ], $heartbeats);
+
+                foreach (array_chunk($rows, 500) as $chunk) {
+                    DB::table('heartbeats')->insert($chunk);
+                }
             }
 
             foreach ($incidents as $inc) {
@@ -34,9 +51,11 @@ class MonitorSeeder extends Seeder
             }
 
             if ($monitor->status === 'up' || $monitor->status === 'down') {
-                $latest = $monitor->heartbeats()->latest()->first();
-                if ($latest) {
-                    $monitor->update(['last_checked_at' => $latest->created_at]);
+                $latestCreatedAt = DB::table('heartbeats')
+                    ->where('monitor_id', $monitor->id)
+                    ->max('created_at');
+                if ($latestCreatedAt) {
+                    $monitor->update(['last_checked_at' => $latestCreatedAt]);
                 }
             }
         }
@@ -93,14 +112,84 @@ class MonitorSeeder extends Seeder
     }
 
     /**
+     * Generate heartbeats for a local fake-server profile. Pure helper — driven entirely
+     * by $profile so the runtime fleet and seeded history cannot drift.
+     *
+     * @param  array<string, mixed>  $profile
+     * @return array<int, array{status: string, status_code: int|null, response_time: int|null, message: string|null, created_at: Carbon}>
+     */
+    public static function localServerHistory(int $hours, int $intervalSeconds, array $profile): array
+    {
+        $records = [];
+        $now = now();
+        $current = $now->copy()->subHours($hours);
+        $kind = $profile['kind'] ?? 'fast';
+        $monitorTimeoutMs = 10_000;
+
+        while ($current->lessThanOrEqualTo($now)) {
+            $records[] = match ($kind) {
+                'fast', 'slow', 'jitter' => self::upRecord(
+                    rand((int) ($profile['latency_min'] ?? 5), (int) ($profile['latency_max'] ?? 50)),
+                    $current
+                ),
+                'spike' => self::upRecord(
+                    mt_rand(1, 100) <= (int) ($profile['spike_outlier_pct'] ?? 10)
+                        ? (int) ($profile['spike_outlier_ms'] ?? 3000)
+                        : rand((int) ($profile['latency_min'] ?? 5), (int) ($profile['latency_max'] ?? 50)),
+                    $current
+                ),
+                'flap' => mt_rand(1, 100) <= (int) ($profile['flap_down_pct'] ?? 20)
+                    ? self::downRecord(500, 'HTTP 500 Internal Server Error', $current)
+                    : self::upRecord(rand(5, 50), $current),
+                'down_500' => self::downRecord(500, 'HTTP 500 Internal Server Error', $current),
+                'unbound' => self::downRecord(null, 'Connection refused', $current),
+                'timeout' => self::downRecord(null, "Request exceeded timeout of {$monitorTimeoutMs}ms", $current),
+                default => self::upRecord(rand(5, 50), $current),
+            };
+
+            $current = $current->copy()->addSeconds($intervalSeconds);
+        }
+
+        return $records;
+    }
+
+    /**
+     * @return array{status: string, status_code: int, response_time: int, message: null, created_at: Carbon}
+     */
+    private static function upRecord(int $latencyMs, Carbon $at): array
+    {
+        return [
+            'status' => 'up',
+            'status_code' => 200,
+            'response_time' => $latencyMs,
+            'message' => null,
+            'created_at' => $at->copy(),
+        ];
+    }
+
+    /**
+     * @return array{status: string, status_code: int|null, response_time: null, message: string, created_at: Carbon}
+     */
+    private static function downRecord(?int $statusCode, string $message, Carbon $at): array
+    {
+        return [
+            'status' => 'down',
+            'status_code' => $statusCode,
+            'response_time' => null,
+            'message' => $message,
+            'created_at' => $at->copy(),
+        ];
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      */
     private function definitions(int $userId, int $teamId): array
     {
         $base = ['user_id' => $userId, 'team_id' => $teamId, 'is_active' => true, 'retry_count' => 1, 'timeout' => 10];
 
-        return [
-            // ── HTTP: UP ──────────────────────────────────────────────────────
+        $definitions = [
+            // ── HTTPS retained for SSL monitoring demos ──────────────────────
             [
                 ...$base,
                 'name' => 'GitHub API',
@@ -112,30 +201,6 @@ class MonitorSeeder extends Seeder
                 'status' => 'up',
                 'ssl_monitoring_enabled' => true,
                 'heartbeats' => $this->heartbeatHistory(24, 60),
-            ],
-            [
-                ...$base,
-                'name' => 'Stripe Dashboard',
-                'type' => 'http',
-                'url' => 'https://dashboard.stripe.com',
-                'method' => 'GET',
-                'interval' => 60,
-                'accepted_status_codes' => [200, 301, 302],
-                'status' => 'up',
-                'ssl_monitoring_enabled' => true,
-                'heartbeats' => $this->heartbeatHistory(24, 60),
-            ],
-            [
-                ...$base,
-                'name' => 'Cloudflare DNS',
-                'type' => 'http',
-                'url' => 'https://1.1.1.1',
-                'method' => 'GET',
-                'interval' => 30,
-                'accepted_status_codes' => [200, 301, 302, 403],
-                'status' => 'up',
-                'ssl_monitoring_enabled' => true,
-                'heartbeats' => $this->heartbeatHistory(24, 30),
             ],
             [
                 ...$base,
@@ -158,83 +223,42 @@ class MonitorSeeder extends Seeder
                     ],
                 ],
             ],
-            [
-                ...$base,
-                'name' => 'Vercel Edge Network',
-                'type' => 'http',
-                'url' => 'https://vercel.com',
-                'method' => 'HEAD',
-                'interval' => 120,
-                'accepted_status_codes' => [200, 301],
-                'status' => 'up',
-                'ssl_monitoring_enabled' => true,
-                'heartbeats' => $this->heartbeatHistory(24, 120),
-            ],
+        ];
 
-            // ── HTTP: DOWN ────────────────────────────────────────────────────
-            [
+        // ── Local fake-server fleet (driven by registry) ─────────────────────
+        $persistentDownKinds = ['down_500', 'unbound', 'timeout'];
+        $persistentDownCauses = [
+            'down_500' => 'HTTP 500 Internal Server Error',
+            'unbound' => 'Connection refused',
+            'timeout' => 'Request exceeded monitor timeout',
+        ];
+
+        foreach (DevFakeServersCommand::profileRegistry() as $port => $profile) {
+            $isPersistentDown = in_array($profile['kind'], $persistentDownKinds, true);
+
+            $definitions[] = [
                 ...$base,
-                'name' => 'Internal Admin Panel',
+                'name' => $profile['name'],
                 'type' => 'http',
-                'url' => 'https://admin.internal.dev',
+                'url' => "http://127.0.0.1:{$port}",
                 'method' => 'GET',
-                'interval' => 60,
+                'interval' => $profile['interval'],
                 'accepted_status_codes' => [200],
-                'status' => 'down',
+                'status' => $isPersistentDown ? 'down' : 'up',
                 'ssl_monitoring_enabled' => false,
-                'heartbeats' => $this->heartbeatHistory(24, 60, 'http', [
-                    ['from' => now()->subHours(3), 'to' => now()],
-                ]),
-                'incidents' => [
+                'heartbeats' => self::localServerHistory(24, $profile['interval'], $profile),
+                'incidents' => $isPersistentDown ? [
                     [
-                        'started_at' => now()->subHours(3),
+                        'started_at' => now()->subHours(24),
                         'resolved_at' => null,
-                        'cause' => 'Connection refused',
+                        'cause' => $persistentDownCauses[$profile['kind']],
                     ],
-                ],
-            ],
-            [
-                ...$base,
-                'name' => 'Legacy Auth Service',
-                'type' => 'http',
-                'url' => 'https://auth.legacy.example.com/health',
-                'method' => 'GET',
-                'interval' => 30,
-                'accepted_status_codes' => [200],
-                'status' => 'down',
-                'ssl_monitoring_enabled' => true,
-                'heartbeats' => $this->heartbeatHistory(24, 30, 'http', [
-                    ['from' => now()->subHours(6), 'to' => now()],
-                ]),
-                'incidents' => [
-                    [
-                        'started_at' => now()->subHours(14),
-                        'resolved_at' => now()->subHours(12),
-                        'cause' => 'HTTP 502 Bad Gateway',
-                    ],
-                    [
-                        'started_at' => now()->subHours(6),
-                        'resolved_at' => null,
-                        'cause' => 'HTTP 502 Bad Gateway',
-                    ],
-                ],
-            ],
+                ] : [],
+            ];
+        }
 
-            // ── HTTP: PAUSED ──────────────────────────────────────────────────
-            [
-                ...$base,
-                'name' => 'Staging Environment',
-                'type' => 'http',
-                'url' => 'https://staging.example.com',
-                'method' => 'GET',
-                'interval' => 300,
-                'accepted_status_codes' => [200],
-                'status' => 'paused',
-                'is_active' => false,
-                'ssl_monitoring_enabled' => false,
-                'heartbeats' => $this->heartbeatHistory(48, 300),
-            ],
-
+        // ── Synthetic non-HTTP monitors retained ─────────────────────────────
+        return array_merge($definitions, [
             // ── TCP: UP ───────────────────────────────────────────────────────
             [
                 ...$base,
@@ -436,6 +460,6 @@ class MonitorSeeder extends Seeder
                     ],
                 ],
             ],
-        ];
+        ]);
     }
 }

--- a/database/seeders/MonitorSeeder.php
+++ b/database/seeders/MonitorSeeder.php
@@ -140,7 +140,10 @@ class MonitorSeeder extends Seeder
                 ),
                 'flap' => mt_rand(1, 100) <= (int) ($profile['flap_down_pct'] ?? 20)
                     ? self::downRecord(500, 'HTTP 500 Internal Server Error', $current)
-                    : self::upRecord(rand(5, 50), $current),
+                    : self::upRecord(
+                        rand((int) ($profile['latency_min'] ?? 30), (int) ($profile['latency_max'] ?? 250)),
+                        $current
+                    ),
                 'down_500' => self::downRecord(500, 'HTTP 500 Internal Server Error', $current),
                 'unbound' => self::downRecord(null, 'Connection refused', $current),
                 'timeout' => self::downRecord(null, "Request exceeded timeout of {$monitorTimeoutMs}ms", $current),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
         </include>
     </source>
     <php>
+        <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/tests/Feature/DevFakeServersTest.php
+++ b/tests/Feature/DevFakeServersTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Console\Commands\DevFakeServersCommand;
+use Database\Seeders\MonitorSeeder;
+
+// --- profile registry ---
+
+test('profile registry covers ports 9001-9020', function () {
+    $registry = DevFakeServersCommand::profileRegistry();
+
+    expect(array_keys($registry))->toEqual(range(9001, 9020));
+});
+
+test('registry kinds are restricted to the documented set', function () {
+    $allowed = ['fast', 'slow', 'jitter', 'spike', 'down_500', 'unbound', 'flap', 'timeout'];
+
+    foreach (DevFakeServersCommand::profileRegistry() as $profile) {
+        expect($profile['kind'])->toBeIn($allowed);
+    }
+});
+
+test('unbound profiles are not bindable', function () {
+    foreach (DevFakeServersCommand::profileRegistry() as $profile) {
+        if ($profile['kind'] === 'unbound') {
+            expect($profile['bind'])->toBeFalse();
+        } else {
+            expect($profile['bind'])->toBeTrue();
+        }
+    }
+});
+
+// --- localServerHistory: record counts ---
+
+test('localServerHistory generates one record per interval over the window', function () {
+    $records = MonitorSeeder::localServerHistory(24, 60, ['kind' => 'fast', 'latency_min' => 5, 'latency_max' => 50]);
+
+    // 24h * 60 / 60s = 1440, plus one for the inclusive end ≈ 1441
+    expect(count($records))->toBeGreaterThanOrEqual(1440);
+    expect(count($records))->toBeLessThanOrEqual(1442);
+});
+
+// --- latency bounds per kind ---
+
+test('fast profile latencies stay inside declared band', function () {
+    $records = MonitorSeeder::localServerHistory(2, 30, ['kind' => 'fast', 'latency_min' => 5, 'latency_max' => 50]);
+
+    foreach ($records as $r) {
+        expect($r['status'])->toBe('up');
+        expect($r['response_time'])->toBeGreaterThanOrEqual(5);
+        expect($r['response_time'])->toBeLessThanOrEqual(50);
+    }
+});
+
+test('slow profile latencies stay inside declared band', function () {
+    $records = MonitorSeeder::localServerHistory(2, 60, ['kind' => 'slow', 'latency_min' => 500, 'latency_max' => 1500]);
+
+    foreach ($records as $r) {
+        expect($r['status'])->toBe('up');
+        expect($r['response_time'])->toBeGreaterThanOrEqual(500);
+        expect($r['response_time'])->toBeLessThanOrEqual(1500);
+    }
+});
+
+test('jitter profile latencies stay inside the wide band', function () {
+    $records = MonitorSeeder::localServerHistory(2, 60, ['kind' => 'jitter', 'latency_min' => 10, 'latency_max' => 2000]);
+
+    foreach ($records as $r) {
+        expect($r['response_time'])->toBeGreaterThanOrEqual(10);
+        expect($r['response_time'])->toBeLessThanOrEqual(2000);
+    }
+});
+
+// --- distribution per kind ---
+
+test('flap profile produces a status mix near the declared down ratio', function () {
+    $records = MonitorSeeder::localServerHistory(24, 30, ['kind' => 'flap', 'flap_down_pct' => 20]);
+
+    $down = collect($records)->where('status', 'down')->count();
+    $ratio = $down / count($records);
+
+    expect($ratio)->toBeGreaterThan(0.10);
+    expect($ratio)->toBeLessThan(0.30);
+});
+
+test('spike profile keeps most latencies fast and a tail above the spike threshold', function () {
+    $records = MonitorSeeder::localServerHistory(24, 30, [
+        'kind' => 'spike',
+        'latency_min' => 5,
+        'latency_max' => 50,
+        'spike_outlier_pct' => 10,
+        'spike_outlier_ms' => 3000,
+    ]);
+
+    $spikes = collect($records)->where('response_time', '>=', 3000)->count();
+    $ratio = $spikes / count($records);
+
+    expect($ratio)->toBeGreaterThan(0.04);
+    expect($ratio)->toBeLessThan(0.16);
+});
+
+// --- all-down kinds ---
+
+test('down_500 produces only 500 status_code down records', function () {
+    $records = MonitorSeeder::localServerHistory(2, 60, ['kind' => 'down_500']);
+
+    foreach ($records as $r) {
+        expect($r['status'])->toBe('down');
+        expect($r['status_code'])->toBe(500);
+        expect($r['response_time'])->toBeNull();
+    }
+});
+
+test('unbound produces only down records with null status_code', function () {
+    $records = MonitorSeeder::localServerHistory(2, 60, ['kind' => 'unbound']);
+
+    foreach ($records as $r) {
+        expect($r['status'])->toBe('down');
+        expect($r['status_code'])->toBeNull();
+        expect($r['message'])->toBe('Connection refused');
+    }
+});
+
+test('timeout produces only down records with null status_code', function () {
+    $records = MonitorSeeder::localServerHistory(2, 120, ['kind' => 'timeout']);
+
+    foreach ($records as $r) {
+        expect($r['status'])->toBe('down');
+        expect($r['status_code'])->toBeNull();
+        expect($r['message'])->toContain('timeout');
+    }
+});

--- a/tests/Feature/DevFakeServersTest.php
+++ b/tests/Feature/DevFakeServersTest.php
@@ -82,6 +82,38 @@ test('flap profile produces a status mix near the declared down ratio', function
     expect($ratio)->toBeLessThan(0.30);
 });
 
+test('flap UP records honor the configured latency band', function () {
+    $records = MonitorSeeder::localServerHistory(24, 30, [
+        'kind' => 'flap',
+        'flap_down_pct' => 20,
+        'latency_min' => 30,
+        'latency_max' => 250,
+    ]);
+
+    $upRecords = collect($records)->where('status', 'up');
+
+    expect($upRecords)->not->toBeEmpty();
+    foreach ($upRecords as $r) {
+        expect($r['response_time'])->toBeGreaterThanOrEqual(30);
+        expect($r['response_time'])->toBeLessThanOrEqual(250);
+    }
+});
+
+test('registry flap profile carries a realistic latency band', function () {
+    $registry = DevFakeServersCommand::profileRegistry();
+
+    foreach ($registry as $profile) {
+        if ($profile['kind'] !== 'flap') {
+            continue;
+        }
+        expect($profile)->toHaveKey('latency_min');
+        expect($profile)->toHaveKey('latency_max');
+        expect($profile['latency_min'])->toBeGreaterThanOrEqual(20);
+        expect($profile['latency_max'])->toBeLessThanOrEqual(500);
+        expect($profile['latency_max'])->toBeGreaterThan($profile['latency_min']);
+    }
+});
+
 test('spike profile keeps most latencies fast and a tail above the spike threshold', function () {
     $records = MonitorSeeder::localServerHistory(24, 30, [
         'kind' => 'spike',

--- a/tests/Feature/MonitorSeederTest.php
+++ b/tests/Feature/MonitorSeederTest.php
@@ -53,10 +53,11 @@ test('seeder retains the two HTTPS demo monitors for SSL coverage', function () 
     expect(Monitor::where('url', 'https://example.com')->where('ssl_monitoring_enabled', true)->exists())->toBeTrue();
 });
 
-test('seeder produces 20 local fake-server monitors', function () {
+test('seeder produces 20 local fake-server monitors and 35 total', function () {
     (new MonitorSeeder)->run();
 
     $local = Monitor::where('url', 'like', 'http://127.0.0.1:%')->count();
 
     expect($local)->toBe(20);
+    expect(Monitor::count())->toBe(35);
 });

--- a/tests/Feature/MonitorSeederTest.php
+++ b/tests/Feature/MonitorSeederTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Console\Commands\DevFakeServersCommand;
+use App\Models\Incident;
+use App\Models\Monitor;
+use App\Models\User;
+use Database\Seeders\MonitorSeeder;
+
+beforeEach(function () {
+    User::factory()->create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+    ]);
+});
+
+test('seeder registers one local monitor per registry port', function () {
+    (new MonitorSeeder)->run();
+
+    foreach (DevFakeServersCommand::profileRegistry() as $port => $profile) {
+        $monitor = Monitor::where('url', "http://127.0.0.1:{$port}")->first();
+
+        expect($monitor)->not->toBeNull();
+        expect($monitor->name)->toBe($profile['name']);
+        expect($monitor->interval)->toBe($profile['interval']);
+        expect($monitor->type)->toBe('http');
+        expect($monitor->method)->toBe('GET');
+    }
+});
+
+test('persistent-down profiles get one open incident; flap profiles get none', function () {
+    (new MonitorSeeder)->run();
+
+    $persistentDownKinds = ['down_500', 'unbound', 'timeout'];
+
+    foreach (DevFakeServersCommand::profileRegistry() as $port => $profile) {
+        $monitor = Monitor::where('url', "http://127.0.0.1:{$port}")->firstOrFail();
+        $openIncidents = Incident::where('monitor_id', $monitor->id)->whereNull('resolved_at')->count();
+
+        if (in_array($profile['kind'], $persistentDownKinds, true)) {
+            expect($openIncidents)->toBe(1);
+            expect($monitor->status)->toBe('down');
+        } elseif ($profile['kind'] === 'flap') {
+            expect($openIncidents)->toBe(0);
+            expect($monitor->status)->toBe('up');
+        }
+    }
+});
+
+test('seeder retains the two HTTPS demo monitors for SSL coverage', function () {
+    (new MonitorSeeder)->run();
+
+    expect(Monitor::where('url', 'https://api.github.com')->where('ssl_monitoring_enabled', true)->exists())->toBeTrue();
+    expect(Monitor::where('url', 'https://example.com')->where('ssl_monitoring_enabled', true)->exists())->toBeTrue();
+});
+
+test('seeder produces 20 local fake-server monitors', function () {
+    (new MonitorSeeder)->run();
+
+    $local = Monitor::where('url', 'like', 'http://127.0.0.1:%')->count();
+
+    expect($local)->toBe(20);
+});


### PR DESCRIPTION
Closes #13. Adds dev:fake-servers artisan command spawning 20 PHP HTTP servers on 127.0.0.1:9001-9020, each bound to a behavior profile (fast, slow, jitter, spike, flapping, always-500, timeout, unbound). MonitorSeeder consumes the same registry so seeded monitors target the live fleet and pre-seeded heartbeat history matches runtime behavior. Wires fleet into composer run dev. Bulk-inserts heartbeats to keep the seeder under the default CLI memory limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spawn a fleet of local fake HTTP servers (ports 9001–9020) that simulate latency, jitter, spikes, timeouts, flaps, and failures for development testing; optional streamed output when verbose.
  * Dev tooling now launches the fake-servers process as part of the local dev set.

* **Tests**
  * Added feature tests covering fake-server profiles and seeder-generated monitor histories and behaviors.

* **Chores**
  * Seeder rewritten to bulk-insert synthetic heartbeats and produce deterministic local-server histories.
  * Increased PHP memory limit to 512MB for seeding/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->