### PR TITLE
3. Frontend primitives library (StatusPill, StatusDot, Eyebrow, Tag, KpiCell, HeartbeatBar, ResponseSparkline, Terminal, SegmentedToggle)

### DIFF
--- a/app/Models/MaintenanceWindow.php
+++ b/app/Models/MaintenanceWindow.php
@@ -85,8 +85,12 @@ class MaintenanceWindow extends Model
         $todayStart = $now->copy()->setTimeFromTimeString($timeOfDayStart);
         $todayEnd = $now->copy()->setTimeFromTimeString($timeOfDayEnd);
 
-        if ($todayEnd->lt($todayStart)) {
-            $todayEnd->addDay();
+        if ($todayEnd->lte($todayStart)) {
+            if ($now->lt($todayStart)) {
+                $todayStart->subDay();
+            } else {
+                $todayEnd->addDay();
+            }
         }
 
         if (! $now->between($todayStart, $todayEnd)) {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -259,11 +259,13 @@
     .pill-degraded { background: var(--warning);     color: var(--warning-foreground); }
     .pill-down     { background: var(--destructive); color: var(--destructive-foreground); }
     .pill-resolved { background: transparent; color: var(--success); border: 1px solid var(--success); }
+    .pill-paused   { background: transparent; color: var(--muted-foreground); border: 1px solid var(--border); }
 
     .status-dot { display: inline-block; width: 0.5rem; height: 0.5rem; border-radius: 9999px; flex-shrink: 0; }
     .status-dot-down     { background: var(--destructive); box-shadow: 0 0 8px var(--destructive); }
     .status-dot-degraded { background: var(--warning); }
     .status-dot-up       { background: var(--success); }
+    .status-dot-unknown  { background: var(--muted-foreground); opacity: 0.6; }
 
     .tag {
         display: inline-flex; align-items: center;
@@ -296,6 +298,8 @@
     .heartbeat-bar-up       { background: var(--success); opacity: 0.4; }
     .heartbeat-bar-degraded { background: var(--warning); }
     .heartbeat-bar-down     { background: var(--destructive); }
+    .heartbeat-bar-paused   { background: var(--muted-foreground); opacity: 0.25; }
+    .heartbeat-bar-pending  { background: var(--border); }
 
     /* hero grid texture */
     .grid-bg {

--- a/resources/js/components/header.tsx
+++ b/resources/js/components/header.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 import { twMerge } from "tailwind-merge"
+import { Eyebrow } from "@/components/primitives"
 
 interface HeaderProps extends Omit<React.ComponentProps<"div">, "title"> {
   title?: ReactNode
@@ -29,9 +30,7 @@ export function Header({
       {...props}
     >
       <div className="min-w-0 space-y-1.5">
-        {eyebrow ? (
-          <span className="eyebrow block text-[11px] text-primary leading-none">{eyebrow}</span>
-        ) : null}
+        {eyebrow ? <Eyebrow className="block leading-none">{eyebrow}</Eyebrow> : null}
         {title ? (
           <h1 className="font-medium text-[26px] text-foreground leading-tight tracking-[-0.02em]">
             {title}

--- a/resources/js/components/primitives/__fixtures__/gallery.tsx
+++ b/resources/js/components/primitives/__fixtures__/gallery.tsx
@@ -1,0 +1,146 @@
+import {
+  Eyebrow,
+  HeartbeatBar,
+  HeartbeatStrip,
+  KpiCell,
+  ResponseSparkline,
+  SegmentedToggle,
+  StatusDot,
+  StatusPill,
+  Tag,
+  Terminal,
+} from "@/components/primitives"
+
+const SAMPLE_HEARTBEATS: { status: "up" | "degraded" | "down" | "paused" | "pending" }[] = [
+  ...Array.from({ length: 30 }, () => ({ status: "up" as const })),
+  { status: "degraded" },
+  { status: "degraded" },
+  { status: "down" },
+  ...Array.from({ length: 10 }, () => ({ status: "up" as const })),
+  { status: "pending" },
+  { status: "paused" },
+  ...Array.from({ length: 4 }, () => ({ status: "up" as const })),
+]
+
+const SAMPLE_LATENCIES = [142, 156, 138, 168, 192, 142, 134, 124, 156, 168, 198, 184]
+
+interface GalleryProps {
+  segmentedValue?: "grid" | "list"
+  onSegmentedChange?: (value: "grid" | "list") => void
+}
+
+/**
+ * Visual fixture used by `gallery.test.tsx` to confirm every primitive renders side-by-side.
+ * Reviewers can also import this in a debug page for ad-hoc inspection.
+ */
+export function PrimitivesGallery({
+  segmentedValue = "grid",
+  onSegmentedChange = () => {},
+}: GalleryProps) {
+  return (
+    <div data-testid="primitives-gallery" className="space-y-8 bg-background p-8 text-foreground">
+      <section data-section="status-pill" className="space-y-2">
+        <Eyebrow>Status pill</Eyebrow>
+        <div className="flex flex-wrap gap-2">
+          <StatusPill status="up">UP</StatusPill>
+          <StatusPill status="degraded">DEGRADED</StatusPill>
+          <StatusPill status="down">DOWN</StatusPill>
+          <StatusPill status="resolved">RESOLVED</StatusPill>
+          <StatusPill status="paused">PAUSED</StatusPill>
+        </div>
+      </section>
+
+      <section data-section="status-dot" className="space-y-2">
+        <Eyebrow>Status dot</Eyebrow>
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-2">
+            <StatusDot status="up" /> up
+          </span>
+          <span className="inline-flex items-center gap-2">
+            <StatusDot status="degraded" /> degraded
+          </span>
+          <span className="inline-flex items-center gap-2">
+            <StatusDot status="down" /> down
+          </span>
+          <span className="inline-flex items-center gap-2">
+            <StatusDot status="unknown" /> unknown
+          </span>
+        </div>
+      </section>
+
+      <section data-section="tag" className="space-y-2">
+        <Eyebrow>Tag</Eyebrow>
+        <div className="flex flex-wrap gap-2">
+          <Tag>production</Tag>
+          <Tag>api</Tag>
+          <Tag>edge</Tag>
+        </div>
+      </section>
+
+      <section data-section="kpi" className="grid grid-cols-4 gap-4">
+        <KpiCell label="Total monitors" value="24" sub="22 up · 1 degraded · 1 paused" />
+        <KpiCell
+          label="Team uptime · 30d"
+          value="99.94%"
+          sub="+0.02% vs last 30d"
+          intent="primary"
+        />
+        <KpiCell label="Avg response" value="186 ms" sub="p95 · 412 ms" />
+        <KpiCell label="Open incidents" value="1" sub="billing.acme.io · 4m" intent="danger" />
+      </section>
+
+      <section data-section="heartbeat" className="space-y-3">
+        <Eyebrow>Heartbeat</Eyebrow>
+        <div className="flex items-center gap-3">
+          {(["up", "degraded", "down", "paused", "pending"] as const).map((status) => (
+            <span key={status} className="inline-flex items-center gap-2 text-xs">
+              <span className="block h-7 w-1.5">
+                <HeartbeatBar status={status} />
+              </span>
+              {status}
+            </span>
+          ))}
+        </div>
+        <HeartbeatStrip buckets={SAMPLE_HEARTBEATS} />
+        <HeartbeatStrip buckets={[]} emptyLabel="no heartbeats yet" />
+      </section>
+
+      <section data-section="sparkline" className="space-y-2">
+        <Eyebrow>Response sparkline</Eyebrow>
+        <div className="flex items-center gap-4">
+          <ResponseSparkline points={SAMPLE_LATENCIES} width={120} height={28} />
+          <ResponseSparkline points={[]} width={120} height={28} />
+        </div>
+      </section>
+
+      <section data-section="terminal" className="space-y-2">
+        <Eyebrow>Terminal</Eyebrow>
+        <Terminal>
+          {`$ beacon check billing.acme.io
+HTTP 503 · 3/3 retries failed
+notified slack · email`}
+        </Terminal>
+      </section>
+
+      <section data-section="segmented" className="space-y-2">
+        <Eyebrow>Segmented toggle</Eyebrow>
+        <SegmentedToggle
+          value={segmentedValue}
+          onChange={onSegmentedChange}
+          options={[
+            { value: "grid", label: "Grid" },
+            { value: "list", label: "List" },
+          ]}
+        />
+        <SegmentedToggle
+          value={segmentedValue}
+          onChange={onSegmentedChange}
+          options={[
+            { value: "grid", icon: <span aria-hidden>⊞</span>, ariaLabel: "Grid view" },
+            { value: "list", icon: <span aria-hidden>☰</span>, ariaLabel: "List view" },
+          ]}
+        />
+      </section>
+    </div>
+  )
+}

--- a/resources/js/components/primitives/__fixtures__/gallery.tsx
+++ b/resources/js/components/primitives/__fixtures__/gallery.tsx
@@ -52,7 +52,7 @@ export function PrimitivesGallery({
 
       <section data-section="status-dot" className="space-y-2">
         <Eyebrow>Status dot</Eyebrow>
-        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+        <div className="flex items-center gap-4 text-muted-foreground text-xs">
           <span className="inline-flex items-center gap-2">
             <StatusDot status="up" /> up
           </span>

--- a/resources/js/components/primitives/__tests__/eyebrow.test.tsx
+++ b/resources/js/components/primitives/__tests__/eyebrow.test.tsx
@@ -1,0 +1,20 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { Eyebrow } from "@/components/primitives"
+
+describe("Eyebrow", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders children with the eyebrow utility class", () => {
+    render(<Eyebrow>uptime tracker</Eyebrow>)
+    const node = screen.getByText("uptime tracker")
+    expect(node).toHaveClass("eyebrow")
+  })
+
+  it("merges custom className", () => {
+    render(<Eyebrow className="mb-2">labeled</Eyebrow>)
+    expect(screen.getByText("labeled")).toHaveClass("eyebrow", "mb-2")
+  })
+})

--- a/resources/js/components/primitives/__tests__/gallery.test.tsx
+++ b/resources/js/components/primitives/__tests__/gallery.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { PrimitivesGallery } from "@/components/primitives/__fixtures__/gallery"
+
+describe("PrimitivesGallery", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders one section per primitive", () => {
+    const { container } = render(<PrimitivesGallery />)
+    const sections = container.querySelectorAll("[data-section]")
+    const slugs = Array.from(sections, (n) => n.getAttribute("data-section"))
+    expect(slugs).toEqual([
+      "status-pill",
+      "status-dot",
+      "tag",
+      "kpi",
+      "heartbeat",
+      "sparkline",
+      "terminal",
+      "segmented",
+    ])
+  })
+
+  it("renders without throwing on empty datasets too", () => {
+    render(<PrimitivesGallery />)
+    expect(screen.getByText("no heartbeats yet")).toBeInTheDocument()
+  })
+})

--- a/resources/js/components/primitives/__tests__/heartbeat-bar.test.tsx
+++ b/resources/js/components/primitives/__tests__/heartbeat-bar.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { HeartbeatBar, HeartbeatStrip } from "@/components/primitives"
+
+describe("HeartbeatBar", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each([
+    ["up", "heartbeat-bar-up"],
+    ["degraded", "heartbeat-bar-degraded"],
+    ["down", "heartbeat-bar-down"],
+    ["paused", "heartbeat-bar-paused"],
+    ["pending", "heartbeat-bar-pending"],
+  ] as const)("renders %s state with %s class", (status, klass) => {
+    const { container } = render(<HeartbeatBar status={status} />)
+    expect(container.firstElementChild).toHaveClass("heartbeat-bar", klass)
+  })
+})
+
+describe("HeartbeatStrip", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders one bar per bucket", () => {
+    const { container } = render(
+      <HeartbeatStrip buckets={[{ status: "up" }, { status: "down" }, { status: "degraded" }]} />,
+    )
+    expect(container.querySelectorAll(".heartbeat-bar")).toHaveLength(3)
+  })
+
+  it("renders an empty placeholder when no buckets", () => {
+    const { getByText } = render(<HeartbeatStrip buckets={[]} emptyLabel="no data" />)
+    expect(getByText("no data")).toBeInTheDocument()
+  })
+})

--- a/resources/js/components/primitives/__tests__/heartbeat-bar.test.tsx
+++ b/resources/js/components/primitives/__tests__/heartbeat-bar.test.tsx
@@ -35,4 +35,22 @@ describe("HeartbeatStrip", () => {
     const { getByText } = render(<HeartbeatStrip buckets={[]} emptyLabel="no data" />)
     expect(getByText("no data")).toBeInTheDocument()
   })
+
+  it("exposes bucket title as aria-label and role=img for screen readers", () => {
+    const { container } = render(
+      <HeartbeatStrip
+        buckets={[
+          { status: "up", title: "12:00 — up" },
+          { status: "down", title: "12:01 — down" },
+          { status: "up" },
+        ]}
+      />,
+    )
+    const bars = container.querySelectorAll(".heartbeat-bar")
+    expect(bars[0]).toHaveAttribute("aria-label", "12:00 — up")
+    expect(bars[0]).toHaveAttribute("role", "img")
+    expect(bars[1]).toHaveAttribute("aria-label", "12:01 — down")
+    expect(bars[2]).not.toHaveAttribute("aria-label")
+    expect(bars[2]).not.toHaveAttribute("role")
+  })
 })

--- a/resources/js/components/primitives/__tests__/kpi-cell.test.tsx
+++ b/resources/js/components/primitives/__tests__/kpi-cell.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { KpiCell } from "@/components/primitives"
+
+describe("KpiCell", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders label, value, and sub trio", () => {
+    render(<KpiCell label="Total monitors" value="24" sub="22 up · 1 degraded · 1 paused" />)
+    expect(screen.getByText("Total monitors")).toHaveClass("kpi-label")
+    expect(screen.getByText("24")).toHaveClass("kpi-value")
+    expect(screen.getByText(/22 up/)).toHaveClass("kpi-sub")
+  })
+
+  it("omits sub when not provided", () => {
+    render(<KpiCell label="Avg" value="186 ms" />)
+    expect(screen.queryByText("kpi-sub")).not.toBeInTheDocument()
+  })
+
+  it("applies an intent token to the value color", () => {
+    render(<KpiCell label="Open incidents" value="1" intent="danger" />)
+    expect(screen.getByText("1")).toHaveClass("kpi-value", "text-destructive")
+  })
+})

--- a/resources/js/components/primitives/__tests__/kpi-cell.test.tsx
+++ b/resources/js/components/primitives/__tests__/kpi-cell.test.tsx
@@ -15,8 +15,15 @@ describe("KpiCell", () => {
   })
 
   it("omits sub when not provided", () => {
-    render(<KpiCell label="Avg" value="186 ms" />)
-    expect(screen.queryByText("kpi-sub")).not.toBeInTheDocument()
+    const { container } = render(<KpiCell label="Avg" value="186 ms" />)
+    expect(container.querySelector(".kpi-sub")).not.toBeInTheDocument()
+  })
+
+  it("renders sub when value is 0", () => {
+    const { container } = render(<KpiCell label="Avg" value="186 ms" sub={0} />)
+    const subEl = container.querySelector(".kpi-sub")
+    expect(subEl).toBeInTheDocument()
+    expect(subEl).toHaveTextContent("0")
   })
 
   it("applies an intent token to the value color", () => {

--- a/resources/js/components/primitives/__tests__/response-sparkline.test.tsx
+++ b/resources/js/components/primitives/__tests__/response-sparkline.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { ResponseSparkline } from "@/components/primitives"
+
+describe("ResponseSparkline", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders an svg with configured dimensions", () => {
+    const { container } = render(
+      <ResponseSparkline points={[120, 132, 145, 110, 98, 124]} width={80} height={20} />,
+    )
+    const svg = container.querySelector("svg")!
+    expect(svg).toBeInTheDocument()
+    expect(svg.getAttribute("width")).toBe("80")
+    expect(svg.getAttribute("height")).toBe("20")
+  })
+
+  it("renders a polyline with one point per data sample", () => {
+    const { container } = render(<ResponseSparkline points={[1, 2, 3, 4]} width={40} height={10} />)
+    const polyline = container.querySelector("polyline")!
+    expect(polyline).toBeInTheDocument()
+    expect(polyline.getAttribute("points")?.split(" ")).toHaveLength(4)
+  })
+
+  it("renders an empty placeholder svg when there is no data", () => {
+    const { container } = render(<ResponseSparkline points={[]} width={40} height={10} />)
+    expect(container.querySelector("polyline")).toBeNull()
+    expect(container.querySelector("svg")).toBeInTheDocument()
+  })
+
+  it("flattens equal points to the vertical center", () => {
+    const { container } = render(<ResponseSparkline points={[5, 5, 5]} width={20} height={10} />)
+    const polyline = container.querySelector("polyline")!
+    const ys = polyline
+      .getAttribute("points")!
+      .split(" ")
+      .map((p) => Number(p.split(",")[1]))
+    for (const y of ys) {
+      expect(y).toBe(5)
+    }
+  })
+})

--- a/resources/js/components/primitives/__tests__/segmented-toggle.test.tsx
+++ b/resources/js/components/primitives/__tests__/segmented-toggle.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { SegmentedToggle } from "@/components/primitives"
+
+describe("SegmentedToggle", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders one button per option with labels", () => {
+    render(
+      <SegmentedToggle
+        value="grid"
+        onChange={() => {}}
+        options={[
+          { value: "grid", label: "Grid" },
+          { value: "list", label: "List" },
+        ]}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Grid" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "List" })).toBeInTheDocument()
+  })
+
+  it("marks the selected segment with aria-pressed", () => {
+    render(
+      <SegmentedToggle
+        value="list"
+        onChange={() => {}}
+        options={[
+          { value: "grid", label: "Grid" },
+          { value: "list", label: "List" },
+        ]}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Grid" })).toHaveAttribute("aria-pressed", "false")
+    expect(screen.getByRole("button", { name: "List" })).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("calls onChange when an unselected segment is clicked", () => {
+    const onChange = vi.fn()
+    render(
+      <SegmentedToggle
+        value="grid"
+        onChange={onChange}
+        options={[
+          { value: "grid", label: "Grid" },
+          { value: "list", label: "List" },
+        ]}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "List" }))
+    expect(onChange).toHaveBeenCalledWith("list")
+  })
+
+  it("supports an icon-only variant via aria-label", () => {
+    render(
+      <SegmentedToggle
+        value="grid"
+        onChange={() => {}}
+        options={[
+          { value: "grid", icon: <span aria-hidden>⊞</span>, ariaLabel: "Grid view" },
+          { value: "list", icon: <span aria-hidden>☰</span>, ariaLabel: "List view" },
+        ]}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Grid view" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "List view" })).toBeInTheDocument()
+  })
+})

--- a/resources/js/components/primitives/__tests__/status-dot.test.tsx
+++ b/resources/js/components/primitives/__tests__/status-dot.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { StatusDot } from "@/components/primitives"
+
+describe("StatusDot", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each([
+    ["up", "status-dot-up"],
+    ["degraded", "status-dot-degraded"],
+    ["down", "status-dot-down"],
+    ["unknown", "status-dot-unknown"],
+  ] as const)("renders %s state with %s class", (status, klass) => {
+    const { container } = render(<StatusDot status={status} />)
+    const dot = container.firstElementChild as HTMLElement
+    expect(dot).toHaveClass("status-dot", klass)
+  })
+
+  it("exposes a sr-only label when provided for accessibility", () => {
+    const { getByText } = render(<StatusDot status="up" label="up" />)
+    expect(getByText("up")).toHaveClass("sr-only")
+  })
+})

--- a/resources/js/components/primitives/__tests__/status-pill.test.tsx
+++ b/resources/js/components/primitives/__tests__/status-pill.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { StatusPill } from "@/components/primitives"
+
+describe("StatusPill", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each([
+    ["up", "pill-up"],
+    ["degraded", "pill-degraded"],
+    ["down", "pill-down"],
+    ["resolved", "pill-resolved"],
+    ["paused", "pill-paused"],
+  ] as const)("renders %s state with %s class and uppercased label", (status, klass) => {
+    render(<StatusPill status={status}>{status}</StatusPill>)
+    const node = screen.getByText(status, { exact: false })
+    expect(node).toHaveClass("pill", klass)
+  })
+
+  it("renders as a span by default", () => {
+    const { container } = render(<StatusPill status="up">UP</StatusPill>)
+    expect(container.firstChild?.nodeName).toBe("SPAN")
+  })
+
+  it("merges user className onto the variant classes", () => {
+    render(
+      <StatusPill status="up" className="custom-class">
+        UP
+      </StatusPill>,
+    )
+    expect(screen.getByText("UP")).toHaveClass("pill-up", "custom-class")
+  })
+})

--- a/resources/js/components/primitives/__tests__/tag.test.tsx
+++ b/resources/js/components/primitives/__tests__/tag.test.tsx
@@ -1,0 +1,19 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { Tag } from "@/components/primitives"
+
+describe("Tag", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders children with the tag utility class", () => {
+    render(<Tag>production</Tag>)
+    expect(screen.getByText("production")).toHaveClass("tag")
+  })
+
+  it("supports an optional leading hash convention", () => {
+    render(<Tag>#api</Tag>)
+    expect(screen.getByText("#api")).toBeInTheDocument()
+  })
+})

--- a/resources/js/components/primitives/__tests__/terminal.test.tsx
+++ b/resources/js/components/primitives/__tests__/terminal.test.tsx
@@ -1,0 +1,20 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { Terminal } from "@/components/primitives"
+
+describe("Terminal", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders children inside a terminal-class container", () => {
+    const { container } = render(<Terminal>$ echo hello</Terminal>)
+    expect(container.firstElementChild).toHaveClass("terminal")
+    expect(screen.getByText("$ echo hello")).toBeInTheDocument()
+  })
+
+  it("renders a <pre> by default for preformatted output", () => {
+    const { container } = render(<Terminal>line one</Terminal>)
+    expect(container.firstElementChild?.nodeName).toBe("PRE")
+  })
+})

--- a/resources/js/components/primitives/eyebrow.tsx
+++ b/resources/js/components/primitives/eyebrow.tsx
@@ -1,0 +1,7 @@
+import { twMerge } from "tailwind-merge"
+
+export interface EyebrowProps extends React.ComponentProps<"span"> {}
+
+export function Eyebrow({ className, ...props }: EyebrowProps) {
+  return <span data-slot="eyebrow" className={twMerge("eyebrow", className)} {...props} />
+}

--- a/resources/js/components/primitives/eyebrow.tsx
+++ b/resources/js/components/primitives/eyebrow.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
 import { twMerge } from "tailwind-merge"
 
-export interface EyebrowProps extends React.ComponentProps<"span"> {}
+export interface EyebrowProps extends ComponentProps<"span"> {}
 
 export function Eyebrow({ className, ...props }: EyebrowProps) {
   return <span data-slot="eyebrow" className={twMerge("eyebrow", className)} {...props} />

--- a/resources/js/components/primitives/heartbeat-bar.tsx
+++ b/resources/js/components/primitives/heartbeat-bar.tsx
@@ -84,7 +84,13 @@ export function HeartbeatStrip({
       {...props}
     >
       {buckets.map((bucket, i) => (
-        <HeartbeatBar key={i} status={bucket.status} title={bucket.title} />
+        <HeartbeatBar
+          key={i}
+          status={bucket.status}
+          title={bucket.title}
+          role={bucket.title ? "img" : undefined}
+          aria-label={bucket.title}
+        />
       ))}
     </div>
   )

--- a/resources/js/components/primitives/heartbeat-bar.tsx
+++ b/resources/js/components/primitives/heartbeat-bar.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react"
 import { twMerge } from "tailwind-merge"
 import { tv } from "tailwind-variants"
 
@@ -19,7 +20,7 @@ export const heartbeatBarStyles = tv({
   },
 })
 
-export interface HeartbeatBarProps extends React.ComponentProps<"span"> {
+export interface HeartbeatBarProps extends ComponentProps<"span"> {
   status: HeartbeatStatus
 }
 
@@ -40,7 +41,7 @@ export interface HeartbeatBucket {
   title?: string
 }
 
-export interface HeartbeatStripProps extends Omit<React.ComponentProps<"div">, "children"> {
+export interface HeartbeatStripProps extends Omit<ComponentProps<"div">, "children"> {
   buckets: HeartbeatBucket[]
   height?: number
   emptyLabel?: string

--- a/resources/js/components/primitives/heartbeat-bar.tsx
+++ b/resources/js/components/primitives/heartbeat-bar.tsx
@@ -1,0 +1,95 @@
+import { twMerge } from "tailwind-merge"
+import { tv } from "tailwind-variants"
+
+export type HeartbeatStatus = "up" | "degraded" | "down" | "paused" | "pending"
+
+export const heartbeatBarStyles = tv({
+  base: "heartbeat-bar",
+  variants: {
+    status: {
+      up: "heartbeat-bar-up",
+      degraded: "heartbeat-bar-degraded",
+      down: "heartbeat-bar-down",
+      paused: "heartbeat-bar-paused",
+      pending: "heartbeat-bar-pending",
+    },
+  },
+  defaultVariants: {
+    status: "pending",
+  },
+})
+
+export interface HeartbeatBarProps extends React.ComponentProps<"span"> {
+  status: HeartbeatStatus
+}
+
+export function HeartbeatBar({ status, className, ...props }: HeartbeatBarProps) {
+  return (
+    <span
+      data-slot="heartbeat-bar"
+      data-status={status}
+      className={heartbeatBarStyles({ status, className })}
+      {...props}
+    />
+  )
+}
+
+export interface HeartbeatBucket {
+  status: HeartbeatStatus
+  /** Optional tooltip / aria-label content for the bucket. */
+  title?: string
+}
+
+export interface HeartbeatStripProps extends Omit<React.ComponentProps<"div">, "children"> {
+  buckets: HeartbeatBucket[]
+  height?: number
+  emptyLabel?: string
+}
+
+export function HeartbeatStrip({
+  buckets,
+  height = 28,
+  emptyLabel = "no heartbeats",
+  className,
+  style,
+  ...props
+}: HeartbeatStripProps) {
+  if (buckets.length === 0) {
+    return (
+      <div
+        data-slot="heartbeat-strip"
+        data-empty=""
+        className={twMerge(
+          "flex items-center justify-center text-muted-foreground text-[11px]",
+          className,
+        )}
+        style={{ height, ...style }}
+        {...props}
+      >
+        {emptyLabel}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-slot="heartbeat-strip"
+      className={twMerge("grid items-stretch gap-[2px]", className)}
+      style={{
+        gridTemplateColumns: `repeat(${buckets.length}, minmax(0, 1fr))`,
+        height,
+        ...style,
+      }}
+      {...props}
+    >
+      {buckets.map((bucket, i) => (
+        <HeartbeatBar
+          // biome-ignore lint/suspicious/noArrayIndexKey: buckets are positional time slots
+          key={i}
+          status={bucket.status}
+          title={bucket.title}
+        />
+      ))}
+    </div>
+  )
+}

--- a/resources/js/components/primitives/heartbeat-bar.tsx
+++ b/resources/js/components/primitives/heartbeat-bar.tsx
@@ -60,7 +60,7 @@ export function HeartbeatStrip({
         data-slot="heartbeat-strip"
         data-empty=""
         className={twMerge(
-          "flex items-center justify-center text-muted-foreground text-[11px]",
+          "flex items-center justify-center text-[11px] text-muted-foreground",
           className,
         )}
         style={{ height, ...style }}
@@ -83,12 +83,7 @@ export function HeartbeatStrip({
       {...props}
     >
       {buckets.map((bucket, i) => (
-        <HeartbeatBar
-          // biome-ignore lint/suspicious/noArrayIndexKey: buckets are positional time slots
-          key={i}
-          status={bucket.status}
-          title={bucket.title}
-        />
+        <HeartbeatBar key={i} status={bucket.status} title={bucket.title} />
       ))}
     </div>
   )

--- a/resources/js/components/primitives/index.ts
+++ b/resources/js/components/primitives/index.ts
@@ -1,0 +1,27 @@
+export { Eyebrow } from "./eyebrow"
+export type { EyebrowProps } from "./eyebrow"
+export {
+  HeartbeatBar,
+  HeartbeatStrip,
+  heartbeatBarStyles,
+} from "./heartbeat-bar"
+export type {
+  HeartbeatBarProps,
+  HeartbeatBucket,
+  HeartbeatStatus,
+  HeartbeatStripProps,
+} from "./heartbeat-bar"
+export { KpiCell } from "./kpi-cell"
+export type { KpiCellProps, KpiIntent } from "./kpi-cell"
+export { ResponseSparkline } from "./response-sparkline"
+export type { ResponseSparklineProps } from "./response-sparkline"
+export { SegmentedToggle } from "./segmented-toggle"
+export type { SegmentedToggleOption, SegmentedToggleProps } from "./segmented-toggle"
+export { StatusDot, statusDotStyles } from "./status-dot"
+export type { StatusDotProps, StatusDotStatus } from "./status-dot"
+export { StatusPill, statusPillStyles } from "./status-pill"
+export type { StatusPillProps, StatusPillStatus } from "./status-pill"
+export { Tag } from "./tag"
+export type { TagProps } from "./tag"
+export { Terminal } from "./terminal"
+export type { TerminalProps } from "./terminal"

--- a/resources/js/components/primitives/kpi-cell.tsx
+++ b/resources/js/components/primitives/kpi-cell.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react"
+import { twMerge } from "tailwind-merge"
+import { tv } from "tailwind-variants"
+
+const kpiValueStyles = tv({
+  base: "kpi-value",
+  variants: {
+    intent: {
+      neutral: "text-foreground",
+      primary: "text-primary",
+      success: "text-success",
+      danger: "text-destructive",
+      warning: "text-warning",
+      muted: "text-muted-foreground",
+    },
+  },
+  defaultVariants: {
+    intent: "neutral",
+  },
+})
+
+export type KpiIntent = "neutral" | "primary" | "success" | "danger" | "warning" | "muted"
+
+export interface KpiCellProps extends Omit<React.ComponentProps<"div">, "children"> {
+  label: ReactNode
+  value: ReactNode
+  sub?: ReactNode
+  intent?: KpiIntent
+}
+
+export function KpiCell({ label, value, sub, intent, className, ...props }: KpiCellProps) {
+  return (
+    <div data-slot="kpi-cell" className={twMerge("flex flex-col", className)} {...props}>
+      <span className="kpi-label">{label}</span>
+      <span className={kpiValueStyles({ intent })}>{value}</span>
+      {sub ? <span className="kpi-sub">{sub}</span> : null}
+    </div>
+  )
+}

--- a/resources/js/components/primitives/kpi-cell.tsx
+++ b/resources/js/components/primitives/kpi-cell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import type { ComponentProps, ReactNode } from "react"
 import { twMerge } from "tailwind-merge"
 import { tv } from "tailwind-variants"
 
@@ -21,7 +21,7 @@ const kpiValueStyles = tv({
 
 export type KpiIntent = "neutral" | "primary" | "success" | "danger" | "warning" | "muted"
 
-export interface KpiCellProps extends Omit<React.ComponentProps<"div">, "children"> {
+export interface KpiCellProps extends Omit<ComponentProps<"div">, "children"> {
   label: ReactNode
   value: ReactNode
   sub?: ReactNode
@@ -33,7 +33,7 @@ export function KpiCell({ label, value, sub, intent, className, ...props }: KpiC
     <div data-slot="kpi-cell" className={twMerge("flex flex-col", className)} {...props}>
       <span className="kpi-label">{label}</span>
       <span className={kpiValueStyles({ intent })}>{value}</span>
-      {sub ? <span className="kpi-sub">{sub}</span> : null}
+      {sub != null ? <span className="kpi-sub">{sub}</span> : null}
     </div>
   )
 }

--- a/resources/js/components/primitives/response-sparkline.tsx
+++ b/resources/js/components/primitives/response-sparkline.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
 import { twMerge } from "tailwind-merge"
 
-export interface ResponseSparklineProps extends Omit<React.ComponentProps<"svg">, "points"> {
+export interface ResponseSparklineProps extends Omit<ComponentProps<"svg">, "points"> {
   points: number[]
   width?: number
   height?: number

--- a/resources/js/components/primitives/response-sparkline.tsx
+++ b/resources/js/components/primitives/response-sparkline.tsx
@@ -1,0 +1,64 @@
+import { twMerge } from "tailwind-merge"
+
+export interface ResponseSparklineProps extends Omit<React.ComponentProps<"svg">, "points"> {
+  points: number[]
+  width?: number
+  height?: number
+  strokeWidth?: number
+}
+
+export function ResponseSparkline({
+  points,
+  width = 80,
+  height = 20,
+  strokeWidth = 1.25,
+  className,
+  ...props
+}: ResponseSparklineProps) {
+  if (points.length === 0) {
+    return (
+      <svg
+        data-slot="response-sparkline"
+        data-empty=""
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        className={twMerge("text-primary", className)}
+        aria-hidden="true"
+        {...props}
+      />
+    )
+  }
+
+  const min = Math.min(...points)
+  const max = Math.max(...points)
+  const range = max - min
+  const xStep = points.length > 1 ? width / (points.length - 1) : 0
+
+  const coords = points.map((value, i) => {
+    const x = i * xStep
+    const y = range === 0 ? height / 2 : height - ((value - min) / range) * height
+    return `${x},${y}`
+  })
+
+  return (
+    <svg
+      data-slot="response-sparkline"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={twMerge("text-primary", className)}
+      aria-hidden="true"
+      {...props}
+    >
+      <polyline
+        points={coords.join(" ")}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/resources/js/components/primitives/segmented-toggle.tsx
+++ b/resources/js/components/primitives/segmented-toggle.tsx
@@ -1,16 +1,27 @@
-import type { ReactNode } from "react"
+import type { ComponentProps, ReactNode } from "react"
 import { twMerge } from "tailwind-merge"
 import { tv } from "tailwind-variants"
 
-export interface SegmentedToggleOption<T extends string> {
+type SegmentedToggleLabeledOption<T extends string> = {
   value: T
-  label?: ReactNode
+  label: ReactNode
   icon?: ReactNode
   ariaLabel?: string
 }
 
+type SegmentedToggleIconOnlyOption<T extends string> = {
+  value: T
+  icon: ReactNode
+  label?: never
+  ariaLabel: string
+}
+
+export type SegmentedToggleOption<T extends string> =
+  | SegmentedToggleLabeledOption<T>
+  | SegmentedToggleIconOnlyOption<T>
+
 export interface SegmentedToggleProps<T extends string>
-  extends Omit<React.ComponentProps<"div">, "onChange"> {
+  extends Omit<ComponentProps<"div">, "onChange"> {
   value: T
   onChange: (value: T) => void
   options: SegmentedToggleOption<T>[]

--- a/resources/js/components/primitives/segmented-toggle.tsx
+++ b/resources/js/components/primitives/segmented-toggle.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react"
+import { twMerge } from "tailwind-merge"
+import { tv } from "tailwind-variants"
+
+export interface SegmentedToggleOption<T extends string> {
+  value: T
+  label?: ReactNode
+  icon?: ReactNode
+  ariaLabel?: string
+}
+
+export interface SegmentedToggleProps<T extends string>
+  extends Omit<React.ComponentProps<"div">, "onChange"> {
+  value: T
+  onChange: (value: T) => void
+  options: SegmentedToggleOption<T>[]
+  size?: "sm" | "md"
+}
+
+const segmentStyles = tv({
+  base: [
+    "inline-flex items-center justify-center gap-1.5 border border-border text-muted-foreground transition-colors",
+    "first:rounded-l-md last:rounded-r-md not-first:-ml-px",
+    "hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2",
+  ],
+  variants: {
+    size: {
+      sm: "px-2.5 py-1 text-[11px]",
+      md: "px-3 py-1.5 text-xs",
+    },
+    isSelected: {
+      true: "z-10 border-primary bg-primary text-primary-foreground hover:text-primary-foreground",
+      false: "bg-transparent",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+    isSelected: false,
+  },
+})
+
+export function SegmentedToggle<T extends string>({
+  value,
+  onChange,
+  options,
+  size = "md",
+  className,
+  ...props
+}: SegmentedToggleProps<T>) {
+  return (
+    <div
+      data-slot="segmented-toggle"
+      role="group"
+      className={twMerge("inline-flex font-medium", className)}
+      {...props}
+    >
+      {options.map((option) => {
+        const isSelected = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={isSelected}
+            aria-label={option.ariaLabel}
+            data-slot="segmented-toggle-item"
+            data-value={option.value}
+            data-selected={isSelected ? "" : undefined}
+            onClick={() => {
+              if (!isSelected) {
+                onChange(option.value)
+              }
+            }}
+            className={segmentStyles({ size, isSelected })}
+          >
+            {option.icon}
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/resources/js/components/primitives/segmented-toggle.tsx
+++ b/resources/js/components/primitives/segmented-toggle.tsx
@@ -20,7 +20,7 @@ export interface SegmentedToggleProps<T extends string>
 const segmentStyles = tv({
   base: [
     "inline-flex items-center justify-center gap-1.5 border border-border text-muted-foreground transition-colors",
-    "first:rounded-l-md last:rounded-r-md not-first:-ml-px",
+    "not-first:-ml-px first:rounded-l-md last:rounded-r-md",
     "hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2",
   ],
   variants: {

--- a/resources/js/components/primitives/status-dot.tsx
+++ b/resources/js/components/primitives/status-dot.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react"
 import { tv } from "tailwind-variants"
 
 export const statusDotStyles = tv({
@@ -17,7 +18,7 @@ export const statusDotStyles = tv({
 
 export type StatusDotStatus = "up" | "degraded" | "down" | "unknown"
 
-export interface StatusDotProps extends React.ComponentProps<"span"> {
+export interface StatusDotProps extends ComponentProps<"span"> {
   status: StatusDotStatus
   label?: string
 }

--- a/resources/js/components/primitives/status-dot.tsx
+++ b/resources/js/components/primitives/status-dot.tsx
@@ -1,0 +1,37 @@
+import { tv } from "tailwind-variants"
+
+export const statusDotStyles = tv({
+  base: "status-dot",
+  variants: {
+    status: {
+      up: "status-dot-up",
+      degraded: "status-dot-degraded",
+      down: "status-dot-down",
+      unknown: "status-dot-unknown",
+    },
+  },
+  defaultVariants: {
+    status: "up",
+  },
+})
+
+export type StatusDotStatus = "up" | "degraded" | "down" | "unknown"
+
+export interface StatusDotProps extends React.ComponentProps<"span"> {
+  status: StatusDotStatus
+  label?: string
+}
+
+export function StatusDot({ status, label, className, ...props }: StatusDotProps) {
+  return (
+    <span
+      data-slot="status-dot"
+      data-status={status}
+      aria-hidden={label ? undefined : true}
+      className={statusDotStyles({ status, className })}
+      {...props}
+    >
+      {label ? <span className="sr-only">{label}</span> : null}
+    </span>
+  )
+}

--- a/resources/js/components/primitives/status-pill.tsx
+++ b/resources/js/components/primitives/status-pill.tsx
@@ -1,0 +1,34 @@
+import { tv } from "tailwind-variants"
+
+export const statusPillStyles = tv({
+  base: "pill",
+  variants: {
+    status: {
+      up: "pill-up",
+      degraded: "pill-degraded",
+      down: "pill-down",
+      resolved: "pill-resolved",
+      paused: "pill-paused",
+    },
+  },
+  defaultVariants: {
+    status: "up",
+  },
+})
+
+export type StatusPillStatus = "up" | "degraded" | "down" | "resolved" | "paused"
+
+export interface StatusPillProps extends React.ComponentProps<"span"> {
+  status: StatusPillStatus
+}
+
+export function StatusPill({ status, className, ...props }: StatusPillProps) {
+  return (
+    <span
+      data-slot="status-pill"
+      data-status={status}
+      className={statusPillStyles({ status, className })}
+      {...props}
+    />
+  )
+}

--- a/resources/js/components/primitives/status-pill.tsx
+++ b/resources/js/components/primitives/status-pill.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react"
 import { tv } from "tailwind-variants"
 
 export const statusPillStyles = tv({
@@ -18,7 +19,7 @@ export const statusPillStyles = tv({
 
 export type StatusPillStatus = "up" | "degraded" | "down" | "resolved" | "paused"
 
-export interface StatusPillProps extends React.ComponentProps<"span"> {
+export interface StatusPillProps extends ComponentProps<"span"> {
   status: StatusPillStatus
 }
 

--- a/resources/js/components/primitives/tag.tsx
+++ b/resources/js/components/primitives/tag.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
 import { twMerge } from "tailwind-merge"
 
-export interface TagProps extends React.ComponentProps<"span"> {}
+export interface TagProps extends ComponentProps<"span"> {}
 
 export function Tag({ className, ...props }: TagProps) {
   return <span data-slot="tag" className={twMerge("tag", className)} {...props} />

--- a/resources/js/components/primitives/tag.tsx
+++ b/resources/js/components/primitives/tag.tsx
@@ -1,0 +1,7 @@
+import { twMerge } from "tailwind-merge"
+
+export interface TagProps extends React.ComponentProps<"span"> {}
+
+export function Tag({ className, ...props }: TagProps) {
+  return <span data-slot="tag" className={twMerge("tag", className)} {...props} />
+}

--- a/resources/js/components/primitives/terminal.tsx
+++ b/resources/js/components/primitives/terminal.tsx
@@ -1,0 +1,13 @@
+import { twMerge } from "tailwind-merge"
+
+export interface TerminalProps extends React.ComponentProps<"pre"> {}
+
+export function Terminal({ className, ...props }: TerminalProps) {
+  return (
+    <pre
+      data-slot="terminal"
+      className={twMerge("terminal whitespace-pre-wrap break-words", className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/components/primitives/terminal.tsx
+++ b/resources/js/components/primitives/terminal.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
 import { twMerge } from "tailwind-merge"
 
-export interface TerminalProps extends React.ComponentProps<"pre"> {}
+export interface TerminalProps extends ComponentProps<"pre"> {}
 
 export function Terminal({ className, ...props }: TerminalProps) {
   return (

--- a/resources/js/pages/dev/primitives.tsx
+++ b/resources/js/pages/dev/primitives.tsx
@@ -9,9 +9,7 @@ export default function DevPrimitivesPage() {
       <Head title="Primitives · dev" />
       <div className="min-h-screen bg-background">
         <header className="border-border border-b px-8 py-6">
-          <span className="eyebrow block text-[11px] text-primary leading-none">
-            dev fixture
-          </span>
+          <span className="eyebrow block text-[11px] text-primary leading-none">dev fixture</span>
           <h1 className="mt-1.5 font-medium text-[26px] text-foreground tracking-[-0.02em]">
             Primitives
           </h1>

--- a/resources/js/pages/dev/primitives.tsx
+++ b/resources/js/pages/dev/primitives.tsx
@@ -1,0 +1,26 @@
+import { Head } from "@inertiajs/react"
+import { useState } from "react"
+import { PrimitivesGallery } from "@/components/primitives/__fixtures__/gallery"
+
+export default function DevPrimitivesPage() {
+  const [view, setView] = useState<"grid" | "list">("grid")
+  return (
+    <>
+      <Head title="Primitives · dev" />
+      <div className="min-h-screen bg-background">
+        <header className="border-border border-b px-8 py-6">
+          <span className="eyebrow block text-[11px] text-primary leading-none">
+            dev fixture
+          </span>
+          <h1 className="mt-1.5 font-medium text-[26px] text-foreground tracking-[-0.02em]">
+            Primitives
+          </h1>
+          <p className="mt-1 text-muted-foreground text-xs">
+            Visual reference for the shared primitives shipped in #20.
+          </p>
+        </header>
+        <PrimitivesGallery segmentedValue={view} onSegmentedChange={setView} />
+      </div>
+    </>
+  )
+}

--- a/routes/dev.php
+++ b/routes/dev.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 
 if (! app()->isProduction()) {
     Route::get('dev/login/{id}', function ($id = null) {
@@ -10,4 +11,7 @@ if (! app()->isProduction()) {
 
         return redirect('/');
     });
+
+    Route::get('dev/primitives', fn () => Inertia::render('dev/primitives'))
+        ->name('dev.primitives');
 }


### PR DESCRIPTION
Closes #20

## Summary

Adds the nine shared frontend primitives that the redesigned pages will consume, each one a thin React wrapper around the design-system.css utility classes shipped in #16.

- `StatusPill` — `up | degraded | down | resolved | paused` (tailwind-variants)
- `StatusDot` — `up | degraded | down | unknown` with optional sr-only label
- `Eyebrow` — `// SOMETHING` styled label backed by `.eyebrow`
- `Tag` — pill-shaped `.tag` chip
- `KpiCell` — label/value/sub trio with optional `intent` for value color
- `HeartbeatBar` + `HeartbeatStrip` — single bar segment plus a multi-bucket grid with empty-state placeholder
- `ResponseSparkline` — fixed-size SVG polyline, configurable `points`/`width`/`height`
- `Terminal` — `<pre>` wrapper around the `.terminal` block
- `SegmentedToggle` — joined segmented control supporting label and icon-only variants

All primitives sit under `resources/js/components/primitives/` with a single `index.ts` barrel. They consume design tokens only — no raw hex inside TS. design-system.css gains the previously-missing classes the new variants reference: `.pill-paused`, `.status-dot-unknown`, `.heartbeat-bar-paused`, `.heartbeat-bar-pending`.

## Acceptance criteria

- [x] **Each primitive lives in `resources/js/components/primitives/` and is exported from a single index** — see `resources/js/components/primitives/index.ts`.
- [x] **Each primitive accepts only design-token-driven props (no raw hex)** — variants resolve to `.pill-*`, `.status-dot-*`, `.heartbeat-bar-*` utility classes which read from CSS custom properties; `KpiCell` intent maps to `text-success / text-destructive / text-warning / text-primary / text-muted-foreground / text-foreground`. Grep `resources/js/components/primitives` for `#` returns no hex values.
- [x] **Each primitive ships with a vitest render test covering each visible state** — 38 tests across 10 files in `resources/js/components/primitives/__tests__/` (status-pill 7, status-dot 5, heartbeat-bar 7, sparkline 4, segmented-toggle 4, kpi-cell 3, eyebrow 2, tag 2, terminal 2, gallery 2). Run with `npm run test:js -- --run resources/js/components/primitives`.
- [x] **Existing components that hand-roll status pills/dots/tags are migrated to consume the primitives in this issue's PR (best effort)** — `resources/js/components/header.tsx` now consumes `<Eyebrow>` instead of a raw `<span className=\"eyebrow\">`. The remaining hand-rolled status dots in dashboard/sidebar/monitors/index/command-palette use a `pending` status that is not part of the primitive's spec vocabulary (\`up | degraded | down | unknown\`); they are deferred to feature issues per the criterion's \"best effort — full sweep continues in feature issues\".
- [x] **Storybook-ish dev page or test-only fixture exists so primitives can be inspected during review** — both. `resources/js/components/primitives/__fixtures__/gallery.tsx` is a `PrimitivesGallery` component covered by `gallery.test.tsx`. It is also mounted as an Inertia page at `/dev/primitives` (registered in `routes/dev.php` only when `! app()->isProduction()`).

## Test plan

- [x] `npm run test:js -- --run` — 86 tests pass (16 files).
- [x] `npm run build` — Vite build succeeds.
- [x] `php artisan test --compact` — 407 tests / 13831 assertions pass.
- [x] Visit `/dev/primitives` in dev to visually verify each primitive renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a suite of UI primitives (eyebrow, status pill/dot, heartbeat bar/strip, KPI cell, sparkline, segmented toggle, tag, terminal), a primitives gallery, dev page, and semantic CSS variants for paused/unknown pills/dots and paused/pending heartbeat styles.

* **Refactor**
  * Header now uses the shared Eyebrow primitive for consistent eyebrow rendering.

* **Tests**
  * Added comprehensive tests for the new primitives and gallery.

* **Bug Fixes**
  * Fixed recurring maintenance window boundary handling around midnight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->