### PR TITLE
4. Monitors list redesign (full match + dense table + sparkline + heartbeat strip + eager-load endpoint)

### DIFF
--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -30,8 +30,14 @@ class MonitorController extends Controller
             ->with(['tags', 'monitorGroup', 'heartbeats' => fn ($q) => $q->latest()->limit(90)])
             ->latest()
             ->get()
-            ->each(function (Monitor $monitor) {
+            ->map(function (Monitor $monitor) {
                 $monitor->setRelation('heartbeats', $monitor->heartbeats->reverse()->values());
+
+                return [
+                    ...$monitor->toArray(),
+                    'uptime_percentage' => $monitor->uptimePercentageFromLoaded(),
+                    'average_response_time' => $monitor->averageResponseTimeFromLoaded(),
+                ];
             });
 
         $tags = Tag::query()

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -197,4 +197,38 @@ class Monitor extends Model
             ->limit($count)
             ->get();
     }
+
+    /**
+     * Uptime percentage computed from already-loaded heartbeats.
+     *
+     * Falls back to 100.0 when the heartbeats relation is empty so freshly
+     * created monitors don't render as 0%.
+     */
+    public function uptimePercentageFromLoaded(): float
+    {
+        $heartbeats = $this->relationLoaded('heartbeats') ? $this->heartbeats : collect();
+
+        if ($heartbeats->isEmpty()) {
+            return 100.0;
+        }
+
+        $upCount = $heartbeats->where('status', 'up')->count();
+
+        return round(($upCount / $heartbeats->count()) * 100, 2);
+    }
+
+    public function averageResponseTimeFromLoaded(): ?float
+    {
+        $heartbeats = $this->relationLoaded('heartbeats') ? $this->heartbeats : collect();
+
+        $values = $heartbeats
+            ->whereNotNull('response_time')
+            ->pluck('response_time');
+
+        if ($values->isEmpty()) {
+            return null;
+        }
+
+        return round($values->avg(), 2);
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "beacon",
+  "name": "git",
   "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,

--- a/resources/js/hooks/use-monitor-filters.ts
+++ b/resources/js/hooks/use-monitor-filters.ts
@@ -1,23 +1,44 @@
 import { useCallback, useMemo, useState } from "react"
 import type { Monitor, MonitorStatus } from "@/types/monitor"
 
-export type StatusFilterValue = "all" | MonitorStatus
+export type StatusFilterValue = "all" | MonitorStatus | "degraded"
+export type ViewModeValue = "list" | "grid"
+export type SortValue = "status" | "name" | "uptime" | "response" | "last_check"
+
+const STATUS_VALUES: StatusFilterValue[] = [
+  "all",
+  "up",
+  "down",
+  "pending",
+  "paused",
+  "degraded",
+]
+const VIEW_VALUES: ViewModeValue[] = ["list", "grid"]
+const SORT_VALUES: SortValue[] = ["status", "name", "uptime", "response", "last_check"]
 
 interface FilterState {
   search: string
   status: StatusFilterValue
   tag: number | null
+  view: ViewModeValue
+  sort: SortValue
+}
+
+function parseEnum<T extends string>(value: string | null, allowed: T[], fallback: T): T {
+  return (allowed as readonly string[]).includes(value ?? "") ? (value as T) : fallback
 }
 
 function readFromUrl(): FilterState {
   if (typeof window === "undefined") {
-    return { search: "", status: "all", tag: null }
+    return { search: "", status: "all", tag: null, view: "list", sort: "status" }
   }
   const params = new URLSearchParams(window.location.search)
   return {
     search: params.get("search") ?? "",
-    status: (params.get("status") as StatusFilterValue) ?? "all",
+    status: parseEnum(params.get("status"), STATUS_VALUES, "all"),
     tag: params.get("tag") ? Number(params.get("tag")) : null,
+    view: parseEnum(params.get("view"), VIEW_VALUES, "list"),
+    sort: parseEnum(params.get("sort"), SORT_VALUES, "status"),
   }
 }
 
@@ -27,6 +48,8 @@ function syncToUrl(filters: FilterState): void {
   if (filters.search) params.set("search", filters.search)
   if (filters.status !== "all") params.set("status", filters.status)
   if (filters.tag !== null) params.set("tag", String(filters.tag))
+  if (filters.view !== "list") params.set("view", filters.view)
+  if (filters.sort !== "status") params.set("sort", filters.sort)
   const query = params.toString()
   history.replaceState(null, "", query ? `?${query}` : window.location.pathname)
 }
@@ -45,6 +68,8 @@ export function useMonitorFilters(monitors: Monitor[]) {
   const setSearchQuery = useCallback((search: string) => update({ search }), [update])
   const setStatusFilter = useCallback((status: StatusFilterValue) => update({ status }), [update])
   const setTagFilter = useCallback((tag: number | null) => update({ tag }), [update])
+  const setView = useCallback((view: ViewModeValue) => update({ view }), [update])
+  const setSort = useCallback((sort: SortValue) => update({ sort }), [update])
 
   const filteredMonitors = useMemo(() => {
     let result = monitors
@@ -59,7 +84,7 @@ export function useMonitorFilters(monitors: Monitor[]) {
       )
     }
 
-    if (filters.status !== "all") {
+    if (filters.status !== "all" && filters.status !== "degraded") {
       result = result.filter((m) => m.status === filters.status)
     }
 
@@ -80,6 +105,10 @@ export function useMonitorFilters(monitors: Monitor[]) {
     setStatusFilter,
     tagFilter: filters.tag,
     setTagFilter,
+    view: filters.view,
+    setView,
+    sort: filters.sort,
+    setSort,
     isFiltering,
   }
 }

--- a/resources/js/hooks/use-monitor-filters.ts
+++ b/resources/js/hooks/use-monitor-filters.ts
@@ -84,7 +84,16 @@ export function useMonitorFilters(monitors: Monitor[]) {
       )
     }
 
-    if (filters.status !== "all" && filters.status !== "degraded") {
+    if (filters.status === "all") {
+      // no status filter
+    } else if (filters.status === "degraded") {
+      result = result.filter(
+        (m) =>
+          m.status === "up" &&
+          Array.isArray(m.heartbeats) &&
+          m.heartbeats.some((hb) => hb.status !== "up"),
+      )
+    } else {
       result = result.filter((m) => m.status === filters.status)
     }
 

--- a/resources/js/layouts/app-sidebar.tsx
+++ b/resources/js/layouts/app-sidebar.tsx
@@ -117,9 +117,12 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
 
       <SidebarContent className="flex flex-col overflow-hidden">
         <div className="flex shrink-0 items-center justify-between px-4 pt-1 pb-1.5">
-          <span className="font-medium text-[10px] text-muted-foreground uppercase tracking-[0.15em]">
+          <Link
+            href="/monitors"
+            className="font-medium text-[10px] text-muted-foreground uppercase tracking-[0.15em] transition-colors hover:text-foreground"
+          >
             Monitors · {monitors.length}
-          </span>
+          </Link>
           <Link
             href="/monitors/create"
             className="font-medium text-[11px] text-primary transition-colors hover:text-primary/70"

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -497,12 +497,20 @@ function MonitorGrid({ monitors }: { monitors: Monitor[] }) {
             </button>
           ))}
         </div>
-        <CreateMonitorModal>
-          <Button size="sm" intent="outline">
-            <PlusIcon data-slot="icon" />
-            Add
-          </Button>
-        </CreateMonitorModal>
+        <div className="flex items-center gap-2">
+          <Link
+            href={monitorRoutes.index.url()}
+            className="font-medium text-primary text-xs transition-colors hover:text-primary/70"
+          >
+            View all →
+          </Link>
+          <CreateMonitorModal>
+            <Button size="sm" intent="outline">
+              <PlusIcon data-slot="icon" />
+              Add
+            </Button>
+          </CreateMonitorModal>
+        </div>
       </div>
 
       {filtered.length > 0 ? (

--- a/resources/js/pages/monitors/components/__tests__/monitors-toolbar.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/monitors-toolbar.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { MonitorsToolbar } from "@/pages/monitors/components/monitors-toolbar"
+import type { Monitor, Tag } from "@/types/monitor"
+
+function monitor(overrides: Partial<Monitor> = {}): Monitor {
+  return {
+    id: 1,
+    user_id: 1,
+    monitor_group_id: null,
+    name: "api",
+    type: "http",
+    url: "https://api.example.com",
+    host: null,
+    port: null,
+    dns_record_type: null,
+    method: "GET",
+    body: null,
+    headers: null,
+    accepted_status_codes: null,
+    interval: 60,
+    timeout: 30,
+    retry_count: 0,
+    status: "up",
+    is_active: true,
+    push_token: null,
+    ssl_monitoring_enabled: false,
+    ssl_expiry_notification_days: null,
+    last_checked_at: null,
+    next_check_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function tag(id: number, name: string): Tag {
+  return {
+    id,
+    user_id: 1,
+    name,
+    color: "#f5a524",
+    created_at: "2026-04-01",
+    updated_at: "2026-04-01",
+  }
+}
+
+const noop = () => {}
+
+describe("MonitorsToolbar", () => {
+  const monitors: Monitor[] = [
+    monitor({ id: 1, status: "up" }),
+    monitor({ id: 2, status: "up" }),
+    monitor({ id: 3, status: "down" }),
+    monitor({ id: 4, status: "paused" }),
+  ]
+
+  function renderToolbar(overrides: Partial<React.ComponentProps<typeof MonitorsToolbar>> = {}) {
+    return render(
+      <MonitorsToolbar
+        monitors={monitors}
+        tags={[tag(1, "prod"), tag(2, "staging")]}
+        searchQuery=""
+        onSearchChange={noop}
+        statusFilter="all"
+        onStatusFilterChange={noop}
+        tagFilter={null}
+        onTagFilterChange={noop}
+        sort="status"
+        onSortChange={noop}
+        view="list"
+        onViewChange={noop}
+        {...overrides}
+      />,
+    )
+  }
+
+  it("renders status filter pills with counts including Degraded", () => {
+    renderToolbar()
+    expect(screen.getByRole("button", { name: /all 4/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /up 2/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /degraded/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /down 1/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /paused 1/i })).toBeInTheDocument()
+  })
+
+  it("renders tag chips for each tag", () => {
+    renderToolbar()
+    expect(screen.getByRole("button", { name: "#prod" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "#staging" })).toBeInTheDocument()
+  })
+
+  it("renders sort dropdown reflecting the current selection", () => {
+    const { rerender } = render(
+      <MonitorsToolbar
+        monitors={monitors}
+        tags={[]}
+        searchQuery=""
+        onSearchChange={noop}
+        statusFilter="all"
+        onStatusFilterChange={noop}
+        tagFilter={null}
+        onTagFilterChange={noop}
+        sort="status"
+        onSortChange={noop}
+        view="list"
+        onViewChange={noop}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: /sort/i })).toHaveTextContent(/status/i)
+
+    rerender(
+      <MonitorsToolbar
+        monitors={monitors}
+        tags={[]}
+        searchQuery=""
+        onSearchChange={noop}
+        statusFilter="all"
+        onStatusFilterChange={noop}
+        tagFilter={null}
+        onTagFilterChange={noop}
+        sort="name"
+        onSortChange={noop}
+        view="list"
+        onViewChange={noop}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: /sort/i })).toHaveTextContent(/name/i)
+  })
+
+  it("renders list/grid segmented toggle and emits the selected view", () => {
+    const onViewChange = vi.fn()
+    renderToolbar({ onViewChange })
+
+    const grid = screen.getByRole("button", { name: /grid view/i })
+    fireEvent.click(grid)
+    expect(onViewChange).toHaveBeenCalledWith("grid")
+  })
+
+  it("emits the status pill that was clicked", () => {
+    const onStatusFilterChange = vi.fn()
+    renderToolbar({ onStatusFilterChange })
+
+    fireEvent.click(screen.getByRole("button", { name: /down 1/i }))
+    expect(onStatusFilterChange).toHaveBeenCalledWith("down")
+  })
+
+  it("toggles tag filter on click", () => {
+    const onTagFilterChange = vi.fn()
+    renderToolbar({ onTagFilterChange })
+
+    fireEvent.click(screen.getByRole("button", { name: "#prod" }))
+    expect(onTagFilterChange).toHaveBeenCalledWith(1)
+  })
+})

--- a/resources/js/pages/monitors/components/heartbeat-tooltip-strip.tsx
+++ b/resources/js/pages/monitors/components/heartbeat-tooltip-strip.tsx
@@ -1,0 +1,135 @@
+import { Focusable } from "react-aria-components"
+import { twMerge } from "tailwind-merge"
+import { HeartbeatBar, type HeartbeatStatus, heartbeatBarStyles } from "@/components/primitives"
+import { Tooltip, TooltipContent } from "@/components/ui/tooltip"
+import type { Heartbeat } from "@/types/monitor"
+
+export interface HeartbeatTooltipBucket {
+  status: HeartbeatStatus
+  /** Underlying heartbeat for tooltip body. Null = padded / paused / no-data slot. */
+  heartbeat: Heartbeat | null
+  /** Fallback label for empty slots — "no data", "paused", etc. */
+  emptyLabel?: string
+}
+
+interface Props {
+  buckets: HeartbeatTooltipBucket[]
+  height?: number
+  ariaLabel?: string
+  className?: string
+}
+
+const STATUS_TONE: Record<HeartbeatStatus, string> = {
+  up: "text-success",
+  degraded: "text-warning",
+  down: "text-destructive",
+  paused: "text-muted-foreground",
+  pending: "text-muted-foreground",
+}
+
+function relativeTime(date: Date): string {
+  const diff = Math.floor((Date.now() - date.getTime()) / 1000)
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function HeartbeatTooltipBody({ bucket }: { bucket: HeartbeatTooltipBucket }) {
+  if (!bucket.heartbeat) {
+    return (
+      <div className="font-mono text-[11px] text-muted-foreground uppercase tracking-wider">
+        {bucket.emptyLabel ?? bucket.status}
+      </div>
+    )
+  }
+
+  const hb = bucket.heartbeat
+  const date = hb.created_at ? new Date(hb.created_at) : null
+  const stamp = date
+    ? date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })
+    : null
+
+  return (
+    <div className="flex flex-col gap-1.5 font-mono text-xs">
+      <div className="flex items-center gap-2">
+        <span
+          className={twMerge(
+            "rounded-sm border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider",
+            STATUS_TONE[bucket.status],
+          )}
+        >
+          {hb.status}
+        </span>
+        <span className="text-foreground tabular-nums">
+          {hb.response_time != null ? `${hb.response_time}ms` : "no response"}
+        </span>
+        {hb.status_code != null && (
+          <span className="text-muted-foreground">HTTP {hb.status_code}</span>
+        )}
+      </div>
+      {stamp && (
+        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+          <span>{stamp}</span>
+          {date && <span>· {relativeTime(date)}</span>}
+        </div>
+      )}
+      {hb.message && (
+        <div className="max-w-xs truncate text-[11px] text-muted-foreground">{hb.message}</div>
+      )}
+    </div>
+  )
+}
+
+export function HeartbeatTooltipStrip({ buckets, height = 22, ariaLabel, className }: Props) {
+  if (buckets.length === 0) {
+    return (
+      <div
+        className={twMerge(
+          "flex items-center justify-center text-[11px] text-muted-foreground",
+          className,
+        )}
+        style={{ height }}
+        aria-label={ariaLabel}
+      >
+        no heartbeats
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-slot="heartbeat-strip"
+      role="img"
+      aria-label={ariaLabel}
+      className={twMerge("grid items-stretch gap-[2px]", className)}
+      style={{
+        gridTemplateColumns: `repeat(${buckets.length}, minmax(0, 1fr))`,
+        height,
+      }}
+    >
+      {buckets.map((bucket, i) => (
+        <Tooltip key={i} delay={120} closeDelay={40}>
+          <Focusable>
+            <span
+              tabIndex={0}
+              data-slot="heartbeat-bar"
+              data-status={bucket.status}
+              className={heartbeatBarStyles({
+                status: bucket.status,
+                className:
+                  "block cursor-default outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              })}
+            />
+          </Focusable>
+          <TooltipContent placement="top" offset={8} arrow={false}>
+            <HeartbeatTooltipBody bucket={bucket} />
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  )
+}
+
+// Re-export underlying primitive for callers that don't want tooltips.
+export { HeartbeatBar }

--- a/resources/js/pages/monitors/components/monitor-row.tsx
+++ b/resources/js/pages/monitors/components/monitor-row.tsx
@@ -92,6 +92,7 @@ function heartbeatBuckets(
 function rowDotStatus(status: string): StatusDotStatus {
   if (status === "up") return "up"
   if (status === "down") return "down"
+  if (status === "degraded") return "degraded"
   if (status === "paused") return "unknown"
   return "degraded"
 }
@@ -106,6 +107,7 @@ function sparklinePoints(heartbeats: Heartbeat[] | undefined, status: string): n
 
 function sparklineToneClass(status: string): string {
   if (status === "down") return "text-destructive"
+  if (status === "degraded") return "text-warning"
   if (status === "paused" || status === "pending") return "text-muted-foreground"
   return "text-success"
 }

--- a/resources/js/pages/monitors/components/monitor-row.tsx
+++ b/resources/js/pages/monitors/components/monitor-row.tsx
@@ -1,0 +1,386 @@
+import {
+  ArrowTopRightOnSquareIcon,
+  EllipsisHorizontalIcon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  TrashIcon,
+} from "@heroicons/react/20/solid"
+import { router } from "@inertiajs/react"
+import { memo, useState } from "react"
+import {
+  HeartbeatStatus,
+  ResponseSparkline,
+  StatusDot,
+  type StatusDotStatus,
+} from "@/components/primitives"
+import { type HeartbeatTooltipBucket, HeartbeatTooltipStrip } from "./heartbeat-tooltip-strip"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Link } from "@/components/ui/link"
+import { Menu, MenuContent, MenuItem, MenuLabel, MenuSeparator } from "@/components/ui/menu"
+import {
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from "@/components/ui/modal"
+import { uptimeColor } from "@/lib/color"
+import { formatInterval } from "@/lib/heartbeats"
+import monitorRoutes from "@/routes/monitors"
+import type { Heartbeat, Monitor } from "@/types/monitor"
+
+const HEARTBEAT_BUCKET_COUNT = 48
+
+const STATUS_LABEL_CLASS: Record<string, string> = {
+  up: "text-success",
+  down: "text-destructive",
+  pending: "text-warning",
+  paused: "text-muted-foreground",
+  degraded: "text-warning",
+}
+
+export const MONITORS_LIST_COL_STYLE: React.CSSProperties = {
+  gridTemplateColumns:
+    "32px minmax(0, 280px) 70px minmax(0, 0.9fr) 88px minmax(0, 220px) 84px 110px 36px",
+}
+
+function timeAgo(dateString: string | null): string {
+  if (!dateString) return "—"
+  const diff = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000)
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function heartbeatBuckets(
+  heartbeats: Heartbeat[] | undefined,
+  status: string,
+): HeartbeatTooltipBucket[] {
+  if (status === "paused") {
+    return Array.from({ length: HEARTBEAT_BUCKET_COUNT }, () => ({
+      status: "paused" as HeartbeatStatus,
+      heartbeat: null,
+      emptyLabel: "paused",
+    }))
+  }
+
+  const recent = (heartbeats ?? []).slice(-HEARTBEAT_BUCKET_COUNT)
+  const padCount = Math.max(0, HEARTBEAT_BUCKET_COUNT - recent.length)
+  const padding: HeartbeatTooltipBucket[] = Array.from({ length: padCount }, () => ({
+    status: "pending" as HeartbeatStatus,
+    heartbeat: null,
+    emptyLabel: "no data",
+  }))
+
+  const buckets: HeartbeatTooltipBucket[] = recent.map((hb) => {
+    const heartbeatStatus: HeartbeatStatus = hb.status === "down" ? "down" : "up"
+    return {
+      status: heartbeatStatus,
+      heartbeat: hb,
+    }
+  })
+
+  return [...padding, ...buckets]
+}
+
+function rowDotStatus(status: string): StatusDotStatus {
+  if (status === "up") return "up"
+  if (status === "down") return "down"
+  if (status === "paused") return "unknown"
+  return "degraded"
+}
+
+function sparklinePoints(heartbeats: Heartbeat[] | undefined, status: string): number[] {
+  if (!heartbeats || status === "paused") return []
+  return heartbeats
+    .slice(-40)
+    .map((hb) => hb.response_time ?? 0)
+    .filter((value) => value > 0)
+}
+
+function sparklineToneClass(status: string): string {
+  if (status === "down") return "text-destructive"
+  if (status === "paused" || status === "pending") return "text-muted-foreground"
+  return "text-success"
+}
+
+export type MonitorRowProps = {
+  monitor: Monitor
+  isSelected?: boolean
+  onToggleSelect?: (id: number) => void
+}
+
+export function monitorRowAreEqual(
+  prev: Pick<MonitorRowProps, "monitor" | "isSelected">,
+  next: Pick<MonitorRowProps, "monitor" | "isSelected">,
+): boolean {
+  return prev.monitor === next.monitor && prev.isSelected === next.isSelected
+}
+
+function MonitorRowImpl({ monitor, isSelected, onToggleSelect }: MonitorRowProps) {
+  const labelClass = STATUS_LABEL_CLASS[monitor.status] ?? "text-muted-foreground"
+
+  return (
+    <div
+      data-testid={`monitor-row-${monitor.id}`}
+      className="grid items-center gap-x-4 border-border border-t px-6 py-3.5 text-sm transition-colors hover:bg-muted/20"
+      style={MONITORS_LIST_COL_STYLE}
+    >
+      <div className="flex items-center justify-center">
+        {onToggleSelect && (
+          <Checkbox
+            isSelected={isSelected}
+            onChange={() => onToggleSelect(monitor.id)}
+            aria-label={`Select ${monitor.name}`}
+          />
+        )}
+      </div>
+
+      <Link
+        href={monitorRoutes.show.url(monitor.id)}
+        className="flex min-w-0 items-center gap-3 no-underline"
+      >
+        <StatusDot status={rowDotStatus(monitor.status)} />
+        <div className="min-w-0">
+          <div className="truncate font-medium text-foreground text-sm">{monitor.name}</div>
+          <div className="mt-0.5 truncate text-muted-foreground text-xs">
+            {monitor.url || monitor.host || "—"}
+          </div>
+        </div>
+      </Link>
+
+      <div>
+        <span className="rounded-sm border border-border px-2 py-0.5 font-mono text-muted-foreground text-xs">
+          {monitor.type.toUpperCase()}
+        </span>
+      </div>
+
+      <HeartbeatTooltipStrip
+        buckets={heartbeatBuckets(monitor.heartbeats, monitor.status)}
+        height={22}
+        ariaLabel={`Uptime history for ${monitor.name} — last ${HEARTBEAT_BUCKET_COUNT} checks`}
+      />
+
+      <div>
+        <div
+          className={`font-medium text-sm tabular-nums ${
+            monitor.uptime_percentage !== undefined
+              ? uptimeColor(monitor.uptime_percentage)
+              : "text-muted-foreground"
+          }`}
+        >
+          {monitor.uptime_percentage !== undefined
+            ? `${monitor.uptime_percentage.toFixed(2)}%`
+            : "—"}
+        </div>
+        <div className="mt-0.5 text-muted-foreground text-xs">30d</div>
+      </div>
+
+      <div>
+        <div className="text-foreground text-sm tabular-nums">
+          {monitor.average_response_time != null
+            ? `${Math.round(monitor.average_response_time)} ms`
+            : "—"}
+        </div>
+        {(() => {
+          const points = sparklinePoints(monitor.heartbeats, monitor.status)
+          return points.length >= 2 ? (
+            <ResponseSparkline
+              points={points}
+              width={200}
+              height={32}
+              className={`mt-1 block ${sparklineToneClass(monitor.status)}`}
+            />
+          ) : (
+            <div className="flex h-8 items-center text-muted-foreground text-xs">—</div>
+          )
+        })()}
+      </div>
+
+      <div className="font-mono text-muted-foreground text-xs">
+        every {formatInterval(monitor.interval)}
+      </div>
+
+      <div className="text-right">
+        <div className="font-mono text-muted-foreground text-xs">
+          {monitor.status === "paused" ? "paused" : timeAgo(monitor.last_checked_at)}
+        </div>
+        <div className={`mt-0.5 font-mono text-[10px] uppercase tracking-wide ${labelClass}`}>
+          {monitor.status}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center">
+        <MonitorRowActions monitor={monitor} />
+      </div>
+    </div>
+  )
+}
+
+function MonitorRowActions({ monitor }: { monitor: Monitor }) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [processing, setProcessing] = useState(false)
+
+  const handleDelete = () => {
+    setProcessing(true)
+    router.delete(monitorRoutes.destroy.url(monitor.id), {
+      preserveScroll: true,
+      onSuccess: () => setDeleteOpen(false),
+      onFinish: () => setProcessing(false),
+    })
+  }
+
+  return (
+    <>
+      <Menu>
+        <Button
+          intent="plain"
+          size="sm"
+          aria-label={`Actions for ${monitor.name}`}
+          className="size-8 p-0 text-muted-foreground hover:text-foreground"
+        >
+          <EllipsisHorizontalIcon data-slot="icon" />
+        </Button>
+        <MenuContent placement="bottom end" className="sm:min-w-44">
+          <MenuItem onAction={() => router.visit(monitorRoutes.show.url(monitor.id))}>
+            <ArrowTopRightOnSquareIcon data-slot="icon" />
+            <MenuLabel>Open</MenuLabel>
+          </MenuItem>
+          <MenuItem onAction={() => router.visit(monitorRoutes.edit.url(monitor.id))}>
+            <PencilIcon data-slot="icon" />
+            <MenuLabel>Edit</MenuLabel>
+          </MenuItem>
+          <MenuItem
+            onAction={() =>
+              router.post(monitorRoutes.toggle.url(monitor.id), {}, { preserveScroll: true })
+            }
+          >
+            {monitor.is_active ? <PauseIcon data-slot="icon" /> : <PlayIcon data-slot="icon" />}
+            <MenuLabel>{monitor.is_active ? "Pause" : "Resume"}</MenuLabel>
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem intent="danger" onAction={() => setDeleteOpen(true)}>
+            <TrashIcon data-slot="icon" />
+            <MenuLabel>Delete</MenuLabel>
+          </MenuItem>
+        </MenuContent>
+      </Menu>
+
+      <Modal isOpen={deleteOpen} onOpenChange={setDeleteOpen}>
+        <ModalContent role="alertdialog">
+          <ModalHeader>
+            <ModalTitle>Delete monitor</ModalTitle>
+            <ModalDescription>
+              {monitor.name} will be archived and can be restored from Trash.
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody />
+          <ModalFooter>
+            <ModalClose>Cancel</ModalClose>
+            <Button intent="danger" onPress={handleDelete} isDisabled={processing}>
+              Delete
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+
+export const MonitorRow = memo(MonitorRowImpl, monitorRowAreEqual)
+
+export function MonitorsListHeader() {
+  return (
+    <div
+      className="grid gap-x-4 border-border border-b bg-muted/30 px-6 py-3 font-medium text-muted-foreground text-xs uppercase tracking-wider"
+      style={MONITORS_LIST_COL_STYLE}
+    >
+      <div />
+      <div>Monitor</div>
+      <div>Type</div>
+      <div>Heartbeats</div>
+      <div>Uptime</div>
+      <div>Response</div>
+      <div>Interval</div>
+      <div className="text-right">Last check</div>
+      <div />
+    </div>
+  )
+}
+
+export function MonitorCard({ monitor }: { monitor: Monitor }) {
+  const points = sparklinePoints(monitor.heartbeats, monitor.status)
+
+  return (
+    <Link
+      href={monitorRoutes.show.url(monitor.id)}
+      className="group flex flex-col gap-3 rounded-lg border border-border bg-surface/30 p-4 no-underline transition-colors hover:border-foreground/30"
+      data-testid={`monitor-card-${monitor.id}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <StatusDot status={rowDotStatus(monitor.status)} />
+          <span className="truncate font-medium text-foreground text-sm">{monitor.name}</span>
+        </div>
+        <span className="rounded-sm border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+          {monitor.type.toUpperCase()}
+        </span>
+      </div>
+
+      <div className="truncate text-muted-foreground text-xs">
+        {monitor.url || monitor.host || "—"}
+      </div>
+
+      <HeartbeatTooltipStrip
+        buckets={heartbeatBuckets(monitor.heartbeats, monitor.status)}
+        height={20}
+        ariaLabel={`Uptime history for ${monitor.name} — last ${HEARTBEAT_BUCKET_COUNT} checks`}
+      />
+
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <div className="kpi-label">Uptime · 30d</div>
+          <div
+            className={`font-medium text-sm tabular-nums ${
+              monitor.uptime_percentage !== undefined
+                ? uptimeColor(monitor.uptime_percentage)
+                : "text-muted-foreground"
+            }`}
+          >
+            {monitor.uptime_percentage !== undefined
+              ? `${monitor.uptime_percentage.toFixed(2)}%`
+              : "—"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="kpi-label">Avg</div>
+          <div className="text-foreground text-sm tabular-nums">
+            {monitor.average_response_time != null
+              ? `${Math.round(monitor.average_response_time)} ms`
+              : "—"}
+          </div>
+        </div>
+      </div>
+
+      {points.length >= 2 && (
+        <ResponseSparkline
+          points={points}
+          width={240}
+          height={28}
+          className={`block w-full ${sparklineToneClass(monitor.status)}`}
+        />
+      )}
+
+      <div className="flex items-center justify-between font-mono text-[10px] text-muted-foreground uppercase tracking-wide">
+        <span>every {formatInterval(monitor.interval)}</span>
+        <span>{monitor.status === "paused" ? "paused" : timeAgo(monitor.last_checked_at)}</span>
+      </div>
+    </Link>
+  )
+}

--- a/resources/js/pages/monitors/components/monitors-toolbar.tsx
+++ b/resources/js/pages/monitors/components/monitors-toolbar.tsx
@@ -1,0 +1,172 @@
+import { Bars3Icon, Squares2X2Icon } from "@heroicons/react/20/solid"
+import { useMemo } from "react"
+import { Label } from "react-aria-components"
+import { SegmentedToggle } from "@/components/primitives"
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select"
+import type { Monitor, MonitorStatus, Tag } from "@/types/monitor"
+
+export type MonitorsListSort = "status" | "name" | "uptime" | "response" | "last_check"
+export type MonitorsListView = "list" | "grid"
+export type MonitorsListStatusFilter = "all" | MonitorStatus | "degraded"
+
+interface Counts {
+  all: number
+  up: number
+  degraded: number
+  down: number
+  paused: number
+}
+
+function isDegraded(monitor: Monitor): boolean {
+  return (
+    monitor.status === "up" &&
+    Array.isArray(monitor.heartbeats) &&
+    monitor.heartbeats.some((hb) => hb.status !== "up")
+  )
+}
+
+function computeCounts(monitors: Monitor[]): Counts {
+  return {
+    all: monitors.length,
+    up: monitors.filter((m) => m.status === "up" && !isDegraded(m)).length,
+    degraded: monitors.filter(isDegraded).length,
+    down: monitors.filter((m) => m.status === "down").length,
+    paused: monitors.filter((m) => m.status === "paused").length,
+  }
+}
+
+const STATUS_PILL_ORDER: { key: MonitorsListStatusFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "up", label: "Up" },
+  { key: "degraded", label: "Degraded" },
+  { key: "down", label: "Down" },
+  { key: "paused", label: "Paused" },
+]
+
+const SORT_OPTIONS: { value: MonitorsListSort; label: string }[] = [
+  { value: "status", label: "Status" },
+  { value: "name", label: "Name" },
+  { value: "uptime", label: "Uptime" },
+  { value: "response", label: "Response" },
+  { value: "last_check", label: "Last check" },
+]
+
+interface Props {
+  monitors: Monitor[]
+  tags: Tag[]
+  searchQuery: string
+  onSearchChange: (value: string) => void
+  statusFilter: MonitorsListStatusFilter
+  onStatusFilterChange: (value: MonitorsListStatusFilter) => void
+  tagFilter: number | null
+  onTagFilterChange: (value: number | null) => void
+  sort: MonitorsListSort
+  onSortChange: (value: MonitorsListSort) => void
+  view: MonitorsListView
+  onViewChange: (value: MonitorsListView) => void
+}
+
+export function MonitorsToolbar({
+  monitors,
+  tags,
+  statusFilter,
+  onStatusFilterChange,
+  tagFilter,
+  onTagFilterChange,
+  sort,
+  onSortChange,
+  view,
+  onViewChange,
+}: Props) {
+  const counts = useMemo(() => computeCounts(monitors), [monitors])
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-border border-b px-6 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {STATUS_PILL_ORDER.map(({ key, label }) => {
+          const count = counts[key as keyof Counts] ?? 0
+          const active = statusFilter === key
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onStatusFilterChange(key)}
+              aria-pressed={active}
+              aria-label={`${label} ${count}`}
+              className={[
+                "flex items-center gap-1.5 rounded-full px-3 py-1 text-xs transition-colors",
+                active
+                  ? "bg-primary font-semibold text-primary-foreground"
+                  : "border border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground",
+              ].join(" ")}
+            >
+              <span>{label}</span>
+              <span className={active ? "opacity-70" : "text-muted-foreground"}>{count}</span>
+            </button>
+          )
+        })}
+
+        {tags.length > 0 && (
+          <>
+            <div className="mx-1 h-4 w-px bg-border" aria-hidden />
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider">tags</span>
+            {tags.map((tagItem) => {
+              const active = tagFilter === tagItem.id
+              return (
+                <button
+                  key={tagItem.id}
+                  type="button"
+                  onClick={() => onTagFilterChange(active ? null : tagItem.id)}
+                  aria-pressed={active}
+                  className={[
+                    "rounded-full px-3 py-1 text-xs transition-colors",
+                    active
+                      ? "border-2 font-medium"
+                      : "border border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground",
+                  ].join(" ")}
+                  style={active ? { borderColor: tagItem.color, color: tagItem.color } : undefined}
+                >
+                  #{tagItem.name}
+                </button>
+              )
+            })}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 text-xs">
+        <span className="text-muted-foreground">sort</span>
+        <Select
+          aria-label="Sort"
+          selectedKey={sort}
+          onSelectionChange={(value) => onSortChange(value as MonitorsListSort)}
+        >
+          <Label className="sr-only">Sort</Label>
+          <SelectTrigger className="h-7 w-32 px-2 text-xs" />
+          <SelectContent items={SORT_OPTIONS}>
+            {(option) => <SelectItem id={option.value}>{option.label}</SelectItem>}
+          </SelectContent>
+        </Select>
+
+        <span className="text-muted-foreground">view</span>
+        <SegmentedToggle<MonitorsListView>
+          value={view}
+          onChange={onViewChange}
+          size="sm"
+          options={[
+            {
+              value: "list",
+              icon: <Bars3Icon className="size-3.5" data-slot="icon" />,
+              ariaLabel: "List view",
+            },
+            {
+              value: "grid",
+              icon: <Squares2X2Icon className="size-3.5" data-slot="icon" />,
+              ariaLabel: "Grid view",
+            },
+          ]}
+        />
+      </div>
+    </div>
+  )
+}

--- a/resources/js/pages/monitors/index.tsx
+++ b/resources/js/pages/monitors/index.tsx
@@ -1,6 +1,6 @@
 import { MagnifyingGlassIcon, PlusIcon } from "@heroicons/react/20/solid"
 import { Head, router, WhenVisible } from "@inertiajs/react"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { useMonitorFilters } from "@/hooks/use-monitor-filters"
@@ -82,6 +82,9 @@ export default function MonitorsIndex({
   useHydrateMonitors(initialMonitors)
   const monitors = useMonitors()
   const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const [page, setPage] = useState(1)
+
+  const PAGE_SIZE = 20
 
   const {
     filteredMonitors,
@@ -98,10 +101,22 @@ export default function MonitorsIndex({
     isFiltering,
   } = useMonitorFilters(monitors)
 
-  const visibleMonitors = useMemo(
+  const sortedMonitors = useMemo(
     () => sortMonitors(applyDegradedFilter(filteredMonitors, statusFilter), sort),
     [filteredMonitors, statusFilter, sort],
   )
+
+  const totalPages = Math.ceil(sortedMonitors.length / PAGE_SIZE)
+
+  const visibleMonitors = useMemo(
+    () => sortedMonitors.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [sortedMonitors, page, PAGE_SIZE],
+  )
+
+  useEffect(() => {
+    setSelectedIds([])
+    setPage(1)
+  }, [searchQuery, statusFilter, tagFilter, view])
 
   const toggleSelect = useCallback((id: number) => {
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]))
@@ -222,10 +237,29 @@ export default function MonitorsIndex({
 
               <div className="flex items-center justify-between border-border border-t px-6 py-4 font-mono text-muted-foreground text-xs">
                 <div>
-                  showing {visibleMonitors.length} of {totalCount}
+                  showing {(page - 1) * PAGE_SIZE + 1}-
+                  {Math.min(page * PAGE_SIZE, sortedMonitors.length)} of {sortedMonitors.length}
                 </div>
                 <div className="flex items-center gap-3">
-                  <span>page 1 / 1</span>
+                  <button
+                    type="button"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="disabled:opacity-30"
+                  >
+                    prev
+                  </button>
+                  <span>
+                    page {page} / {totalPages}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page === totalPages}
+                    className="disabled:opacity-30"
+                  >
+                    next
+                  </button>
                 </div>
               </div>
             </>

--- a/resources/js/pages/monitors/index.tsx
+++ b/resources/js/pages/monitors/index.tsx
@@ -1,22 +1,26 @@
 import { MagnifyingGlassIcon, PlusIcon } from "@heroicons/react/20/solid"
 import { Head, router, WhenVisible } from "@inertiajs/react"
-import { memo, useCallback, useId, useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Link } from "@/components/ui/link"
-import { Tracker } from "@/components/ui/tracker"
 import { useMonitorFilters } from "@/hooks/use-monitor-filters"
 import AppLayout from "@/layouts/app-layout"
-import { uptimeColor } from "@/lib/color"
-import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import monitorRoutes from "@/routes/monitors"
 import { useHydrateMonitors, useMonitors } from "@/stores/monitor-realtime"
-import type { Heartbeat, Monitor, MonitorGroup, Tag } from "@/types/monitor"
+import type { Monitor, MonitorGroup, Tag } from "@/types/monitor"
 import BulkActionToolbar from "./components/bulk-action-toolbar"
-import CreateMonitorModal from "./components/create-monitor-modal"
 import ImportExportSection from "./components/import-export-section"
+import { MonitorCard, MonitorRow, MonitorsListHeader } from "./components/monitor-row"
 import MonitorGroupModal from "./components/monitor-group-modal"
 import MonitorGroupSection from "./components/monitor-group-section"
+import {
+  type MonitorsListSort,
+  type MonitorsListStatusFilter,
+  type MonitorsListView,
+  MonitorsToolbar,
+} from "./components/monitors-toolbar"
+
+export { monitorRowAreEqual } from "./components/monitor-row"
 
 interface Props {
   monitors?: Monitor[]
@@ -25,359 +29,264 @@ interface Props {
   trashedCount: number
 }
 
-const HEARTBEAT_COUNT = 48
-
-function timeAgo(dateString: string | null): string {
-  if (!dateString) return "—"
-  const diff = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000)
-  if (diff < 60) return `${diff}s ago`
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
-}
-
-function statusCounts(monitors: Monitor[]) {
-  return {
-    all: monitors.length,
-    up: monitors.filter((m) => m.status === "up").length,
-    down: monitors.filter((m) => m.status === "down").length,
-    pending: monitors.filter((m) => m.status === "pending").length,
-    paused: monitors.filter((m) => m.status === "paused").length,
-  }
-}
-
-function HeartbeatBars({
-  heartbeats,
-  status,
-  monitorName,
-}: {
-  heartbeats?: Heartbeat[]
-  status: string
-  monitorName: string
-}) {
-  if (status === "paused") {
-    return (
-      <div className="flex h-[22px] items-center">
-        <span className="text-muted-foreground text-xs">—</span>
-      </div>
-    )
-  }
-
+function isDegraded(monitor: Monitor): boolean {
   return (
-    <Tracker
-      data={heartbeatsToTracker(heartbeats, HEARTBEAT_COUNT)}
-      className="h-[22px] w-full"
-      aria-label={`Uptime history for ${monitorName} — last ${HEARTBEAT_COUNT} checks`}
-    />
+    monitor.status === "up" &&
+    Array.isArray(monitor.heartbeats) &&
+    monitor.heartbeats.some((hb) => hb.status !== "up")
   )
 }
 
-function ResponseSparkline({ heartbeats, status }: { heartbeats?: Heartbeat[]; status: string }) {
-  const id = useId()
-
-  const path = useMemo(() => {
-    if (!heartbeats || heartbeats.length < 2 || status === "paused") return null
-    const values = heartbeats
-      .slice(-40)
-      .map((hb) => hb.response_time ?? 0)
-      .filter((v) => v > 0)
-    if (values.length < 2) return null
-
-    const max = Math.max(...values, 1)
-    const pts = values.map((v, i) => {
-      const x = (i / (values.length - 1)) * 120
-      const y = 24 - (v / max) * 22
-      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`
-    })
-
-    const line = pts.join(" ")
-    const fill = `${line} L120,24 L0,24 Z`
-    return { line, fill }
-  }, [heartbeats, status])
-
-  if (!path) {
-    return <div className="flex h-8 items-center text-muted-foreground text-xs">—</div>
+function applyDegradedFilter(monitors: Monitor[], filter: MonitorsListStatusFilter): Monitor[] {
+  if (filter !== "degraded") {
+    return monitors
   }
+  return monitors.filter(isDegraded)
+}
 
-  const isDown = status === "down"
-  const colorVar = isDown ? "var(--color-destructive)" : "var(--color-success)"
+function sortMonitors(monitors: Monitor[], sort: MonitorsListSort): Monitor[] {
+  const sorted = [...monitors]
 
-  return (
-    <svg
-      width="200"
-      height="32"
-      viewBox="0 0 120 24"
-      preserveAspectRatio="none"
-      className="mt-1 block"
-    >
-      <defs>
-        <linearGradient id={id} x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor={colorVar} stopOpacity="0.3" />
-          <stop offset="100%" stopColor={colorVar} stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path d={path.fill} fill={`url(#${id})`} />
-      <path d={path.line} fill="none" stroke={colorVar} strokeWidth="1.2" />
-    </svg>
+  switch (sort) {
+    case "name":
+      return sorted.sort((a, b) => a.name.localeCompare(b.name))
+    case "uptime":
+      return sorted.sort((a, b) => (b.uptime_percentage ?? -1) - (a.uptime_percentage ?? -1))
+    case "response":
+      return sorted.sort(
+        (a, b) => (a.average_response_time ?? Infinity) - (b.average_response_time ?? Infinity),
+      )
+    case "last_check":
+      return sorted.sort((a, b) => {
+        const aTime = a.last_checked_at ? new Date(a.last_checked_at).getTime() : 0
+        const bTime = b.last_checked_at ? new Date(b.last_checked_at).getTime() : 0
+        return bTime - aTime
+      })
+    default: {
+      const order: Record<string, number> = { down: 0, paused: 1, pending: 2, up: 3 }
+      return sorted.sort((a, b) => {
+        const aRank = isDegraded(a) ? 0.5 : (order[a.status] ?? 4)
+        const bRank = isDegraded(b) ? 0.5 : (order[b.status] ?? 4)
+        return aRank - bRank
+      })
+    }
+  }
+}
+
+export default function MonitorsIndex({
+  monitors: initialMonitors,
+  tags,
+  groups,
+  trashedCount,
+}: Props) {
+  useHydrateMonitors(initialMonitors)
+  const monitors = useMonitors()
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+
+  const {
+    filteredMonitors,
+    searchQuery,
+    setSearchQuery,
+    statusFilter,
+    setStatusFilter,
+    tagFilter,
+    setTagFilter,
+    sort,
+    setSort,
+    view,
+    setView,
+    isFiltering,
+  } = useMonitorFilters(monitors)
+
+  const visibleMonitors = useMemo(
+    () => sortMonitors(applyDegradedFilter(filteredMonitors, statusFilter), sort),
+    [filteredMonitors, statusFilter, sort],
   )
-}
 
-const STATUS_DOT_CLASS: Record<string, string> = {
-  up: "bg-success shadow-[0_0_6px_var(--color-success)]",
-  down: "bg-destructive",
-  pending: "bg-warning",
-  paused: "bg-muted-foreground",
-}
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]))
+  }, [])
 
-const STATUS_LABEL_CLASS: Record<string, string> = {
-  up: "text-success",
-  down: "text-destructive",
-  pending: "text-warning",
-  paused: "text-muted-foreground",
-}
+  const toggleSelectAll = useCallback(() => {
+    if (selectedIds.length === visibleMonitors.length) {
+      setSelectedIds([])
+    } else {
+      setSelectedIds(visibleMonitors.map((m) => m.id))
+    }
+  }, [visibleMonitors, selectedIds.length])
 
-// Matches design: 32px 280px 70px 0.9fr 88px 220px 84px 110px 36px
-const COL_STYLE: React.CSSProperties = {
-  gridTemplateColumns:
-    "32px minmax(0, 280px) 70px minmax(0, 0.9fr) 88px minmax(0, 220px) 84px 110px 36px",
-}
-
-function TableHeader() {
-  return (
-    <div
-      className="grid gap-x-4 border-border border-b bg-muted/30 px-6 py-3 font-medium text-muted-foreground text-xs uppercase tracking-wider"
-      style={COL_STYLE}
-    >
-      <div />
-      <div>Monitor</div>
-      <div>Type</div>
-      <div>Heartbeats</div>
-      <div>Uptime</div>
-      <div>Response</div>
-      <div>Interval</div>
-      <div className="text-right">Last check</div>
-      <div />
-    </div>
-  )
-}
-
-type MonitorRowProps = {
-  monitor: Monitor
-  isSelected?: boolean
-  onToggleSelect?: (id: number) => void
-}
-
-export function monitorRowAreEqual(
-  prev: Pick<MonitorRowProps, "monitor" | "isSelected">,
-  next: Pick<MonitorRowProps, "monitor" | "isSelected">,
-): boolean {
-  return prev.monitor === next.monitor && prev.isSelected === next.isSelected
-}
-
-function MonitorRowImpl({ monitor, isSelected, onToggleSelect }: MonitorRowProps) {
-  const dot = STATUS_DOT_CLASS[monitor.status] ?? "bg-muted-foreground"
-  const labelClass = STATUS_LABEL_CLASS[monitor.status] ?? "text-muted-foreground"
+  const totalCount = monitors.length
 
   return (
-    <div
-      className="grid items-center gap-x-4 border-border border-t px-6 py-3.5 text-sm transition-colors hover:bg-muted/20"
-      style={COL_STYLE}
-    >
-      {/* checkbox */}
-      <div className="flex items-center justify-center">
-        {onToggleSelect && (
-          <Checkbox
-            isSelected={isSelected}
-            onChange={() => onToggleSelect(monitor.id)}
-            aria-label={`Select ${monitor.name}`}
-          />
-        )}
-      </div>
-
-      {/* name + url */}
-      <Link
-        href={monitorRoutes.show.url(monitor.id)}
-        className="flex min-w-0 items-center gap-3 no-underline"
-      >
-        <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${dot}`} />
-        <div className="min-w-0">
-          <div className="truncate font-medium text-foreground text-sm">{monitor.name}</div>
-          <div className="mt-0.5 truncate text-muted-foreground text-xs">
-            {monitor.url || monitor.host || "—"}
+    <>
+      <Head title="Monitors" />
+      <div className="min-h-screen">
+        <div className="flex items-center justify-between gap-4 border-border border-b px-6 py-5">
+          <div>
+            <h1 className="font-medium text-2xl text-foreground tracking-tight">
+              Monitors{" "}
+              <span className="font-normal text-lg text-muted-foreground">· {totalCount}</span>
+            </h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <div data-testid="monitors-header-search" className="relative flex w-64 items-center">
+              <MagnifyingGlassIcon className="pointer-events-none absolute left-2.5 size-3.5 text-muted-foreground" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="name, url, tag…"
+                aria-label="Search monitors"
+                className="w-full rounded-md border border-border bg-transparent py-1.5 pr-8 pl-8 text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <span className="pointer-events-none absolute right-2 rounded border border-border px-1 text-[10px] text-muted-foreground">
+                /
+              </span>
+            </div>
+            {trashedCount > 0 && (
+              <Button
+                intent="outline"
+                size="sm"
+                onPress={() => router.visit(monitorRoutes.trashed.url())}
+              >
+                Trash ({trashedCount})
+              </Button>
+            )}
+            <MonitorGroupModal>
+              <Button intent="outline" size="sm">
+                Add Group
+              </Button>
+            </MonitorGroupModal>
+            <ImportExportSection selectedIds={selectedIds} />
+            <Button size="sm" onPress={() => router.visit(monitorRoutes.create.url())}>
+              <PlusIcon data-slot="icon" />
+              New monitor
+            </Button>
           </div>
         </div>
-      </Link>
 
-      {/* type */}
-      <div>
-        <span className="rounded-lg rounded-sm border border-border px-2 py-0.5 font-mono text-muted-foreground text-xs">
-          {monitor.type.toUpperCase()}
-        </span>
-      </div>
-
-      {/* heartbeats */}
-      <HeartbeatBars
-        heartbeats={monitor.heartbeats}
-        status={monitor.status}
-        monitorName={monitor.name}
-      />
-
-      {/* uptime */}
-      <div>
-        <div
-          className={`font-medium text-sm tabular-nums ${
-            monitor.uptime_percentage !== undefined
-              ? uptimeColor(monitor.uptime_percentage)
-              : "text-muted-foreground"
-          }`}
+        <WhenVisible
+          fallback={
+            <div className="space-y-px">
+              {Array(5)
+                .fill(null)
+                .map((_, i) => (
+                  <div key={i} className="h-14 animate-pulse bg-muted/30" />
+                ))}
+            </div>
+          }
+          data="monitors"
         >
-          {monitor.uptime_percentage !== undefined
-            ? `${monitor.uptime_percentage.toFixed(2)}%`
-            : "—"}
-        </div>
-        <div className="mt-0.5 text-muted-foreground text-xs">30d</div>
-      </div>
+          {monitors && monitors.length > 0 ? (
+            <>
+              <MonitorsToolbar
+                monitors={monitors}
+                tags={tags}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                statusFilter={statusFilter as MonitorsListStatusFilter}
+                onStatusFilterChange={(value) =>
+                  setStatusFilter(
+                    value as ReturnType<typeof setStatusFilter> extends any ? any : never,
+                  )
+                }
+                tagFilter={tagFilter}
+                onTagFilterChange={setTagFilter}
+                sort={sort}
+                onSortChange={setSort}
+                view={view}
+                onViewChange={setView}
+              />
+              <BulkActionToolbar selectedIds={selectedIds} onClear={() => setSelectedIds([])} />
+              {view === "list" ? (
+                <MonitorTable
+                  filteredMonitors={visibleMonitors}
+                  groups={groups}
+                  selectedIds={selectedIds}
+                  toggleSelect={toggleSelect}
+                  toggleSelectAll={toggleSelectAll}
+                  isFiltering={isFiltering}
+                  setSearchQuery={setSearchQuery}
+                  setStatusFilter={setStatusFilter}
+                  setTagFilter={setTagFilter}
+                />
+              ) : (
+                <MonitorGrid
+                  filteredMonitors={visibleMonitors}
+                  isFiltering={isFiltering}
+                  setSearchQuery={setSearchQuery}
+                  setStatusFilter={setStatusFilter}
+                  setTagFilter={setTagFilter}
+                />
+              )}
 
-      {/* response + sparkline */}
-      <div>
-        <div className="text-foreground text-sm tabular-nums">
-          {monitor.average_response_time != null
-            ? `${Math.round(monitor.average_response_time)} ms`
-            : "—"}
-        </div>
-        <ResponseSparkline heartbeats={monitor.heartbeats} status={monitor.status} />
+              <div className="flex items-center justify-between border-border border-t px-6 py-4 font-mono text-muted-foreground text-xs">
+                <div>
+                  showing {visibleMonitors.length} of {totalCount}
+                </div>
+                <div className="flex items-center gap-3">
+                  <span>page 1 / 1</span>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="py-16 text-center">
+              <p className="font-medium text-foreground">No monitors yet</p>
+              <p className="mt-1 text-muted-foreground text-sm">
+                Add a URL, host, or IP to start tracking uptime.
+              </p>
+              <Button className="mt-4" onPress={() => router.visit(monitorRoutes.create.url())}>
+                <PlusIcon data-slot="icon" />
+                Add monitor
+              </Button>
+            </div>
+          )}
+        </WhenVisible>
       </div>
-
-      {/* interval */}
-      <div className="font-mono text-muted-foreground text-xs">
-        every {formatInterval(monitor.interval)}
-      </div>
-
-      {/* last check */}
-      <div className="text-right">
-        <div className="font-mono text-muted-foreground text-xs">
-          {monitor.status === "paused" ? "paused" : timeAgo(monitor.last_checked_at)}
-        </div>
-        <div className={`mt-0.5 font-mono text-[10px] uppercase tracking-wide ${labelClass}`}>
-          {monitor.status}
-        </div>
-      </div>
-
-      {/* actions */}
-      <div className="flex items-center justify-center">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault()
-            router.visit(monitorRoutes.show.url(monitor.id))
-          }}
-          className="rounded p-1 text-base text-muted-foreground leading-none hover:text-foreground"
-          aria-label={`Actions for ${monitor.name}`}
-        >
-          ⋯
-        </button>
-      </div>
-    </div>
+    </>
   )
 }
 
-const MonitorRow = memo(MonitorRowImpl, monitorRowAreEqual)
+MonitorsIndex.layout = (page: React.ReactNode) => <AppLayout children={page} />
 
-function MonitorToolbar({
-  monitors,
-  tags,
-  searchQuery,
-  onSearchChange,
-  statusFilter,
-  onStatusFilterChange,
-  tagFilter,
-  onTagFilterChange,
+interface ListProps {
+  filteredMonitors: Monitor[]
+  groups: MonitorGroup[]
+  selectedIds: number[]
+  toggleSelect: (id: number) => void
+  toggleSelectAll: () => void
+  isFiltering: boolean
+  setSearchQuery: (v: string) => void
+  setStatusFilter: (v: any) => void
+  setTagFilter: (v: number | null) => void
+}
+
+function EmptyResults({
+  isFiltering: _isFiltering,
+  setSearchQuery,
+  setStatusFilter,
+  setTagFilter,
 }: {
-  monitors: Monitor[]
-  tags: Tag[]
-  searchQuery: string
-  onSearchChange: (v: string) => void
-  statusFilter: string
-  onStatusFilterChange: (v: any) => void
-  tagFilter: number | null
-  onTagFilterChange: (v: number | null) => void
+  isFiltering: boolean
+  setSearchQuery: (v: string) => void
+  setStatusFilter: (v: any) => void
+  setTagFilter: (v: number | null) => void
 }) {
-  const counts = useMemo(() => statusCounts(monitors), [monitors])
-  const statusPills = [
-    { key: "all", label: "All", count: counts.all },
-    { key: "up", label: "Up", count: counts.up },
-    { key: "down", label: "Down", count: counts.down },
-    { key: "pending", label: "Pending", count: counts.pending },
-    { key: "paused", label: "Paused", count: counts.paused },
-  ]
-
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 border-border border-b px-6 py-3">
-      {/* left: status + tag pills */}
-      <div className="flex flex-wrap items-center gap-2">
-        {statusPills.map(({ key, label, count }) => {
-          const active = statusFilter === key
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => onStatusFilterChange(key)}
-              className={[
-                "flex items-center gap-1.5 rounded-full px-3 py-1 font-medium text-xs transition-colors",
-                active
-                  ? "bg-primary text-primary-foreground"
-                  : "rounded-lg border border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground",
-              ].join(" ")}
-            >
-              <span>{label}</span>
-              <span className={active ? "opacity-70" : "text-muted-foreground"}>{count}</span>
-            </button>
-          )
-        })}
-
-        {tags.length > 0 && (
-          <>
-            <div className="mx-1 h-4 w-px bg-border" />
-            <span className="text-muted-foreground text-xs">tags</span>
-            {tags.map((tag) => {
-              const active = tagFilter === tag.id
-              return (
-                <button
-                  key={tag.id}
-                  type="button"
-                  onClick={() => onTagFilterChange(active ? null : tag.id)}
-                  className={[
-                    "rounded-full px-3 py-1 text-xs transition-colors",
-                    active
-                      ? "border-2 font-medium"
-                      : "rounded-lg border border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground",
-                  ].join(" ")}
-                  style={active ? { borderColor: tag.color, color: tag.color } : undefined}
-                >
-                  #{tag.name}
-                </button>
-              )
-            })}
-          </>
-        )}
-      </div>
-
-      {/* right: search */}
-      <div className="flex shrink-0 items-center gap-2">
-        <div className="relative flex items-center">
-          <MagnifyingGlassIcon className="pointer-events-none absolute left-2.5 size-3.5 text-muted-foreground" />
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="name, url, tag…"
-            className="w-52 rounded-lg rounded-md border border-border bg-transparent py-1.5 pr-8 pl-8 text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-          <span className="pointer-events-none absolute right-2 rounded rounded-lg border border-border px-1 text-[10px] text-muted-foreground">
-            /
-          </span>
-        </div>
-      </div>
+    <div className="py-10 text-center">
+      <p className="text-muted-foreground text-sm">No monitors match your filters.</p>
+      <Button
+        intent="plain"
+        size="xs"
+        onPress={() => {
+          setSearchQuery("")
+          setStatusFilter("all")
+          setTagFilter(null)
+        }}
+        className="mt-2"
+      >
+        Clear filters
+      </Button>
     </div>
   )
 }
@@ -392,17 +301,7 @@ function MonitorTable({
   setSearchQuery,
   setStatusFilter,
   setTagFilter,
-}: {
-  filteredMonitors: Monitor[]
-  groups: MonitorGroup[]
-  selectedIds: number[]
-  toggleSelect: (id: number) => void
-  toggleSelectAll: () => void
-  isFiltering: boolean
-  setSearchQuery: (v: string) => void
-  setStatusFilter: (v: any) => void
-  setTagFilter: (v: number | null) => void
-}) {
+}: ListProps) {
   const groupedMonitors = filteredMonitors.reduce<Record<number, Monitor[]>>((acc, monitor) => {
     const groupId = monitor.monitor_group_id ?? 0
     if (!acc[groupId]) acc[groupId] = []
@@ -415,27 +314,17 @@ function MonitorTable({
 
   if (filteredMonitors.length === 0) {
     return (
-      <div className="py-10 text-center">
-        <p className="text-muted-foreground text-sm">No monitors match your filters.</p>
-        <Button
-          intent="plain"
-          size="xs"
-          onPress={() => {
-            setSearchQuery("")
-            setStatusFilter("all")
-            setTagFilter(null)
-          }}
-          className="mt-2"
-        >
-          Clear filters
-        </Button>
-      </div>
+      <EmptyResults
+        isFiltering={isFiltering}
+        setSearchQuery={setSearchQuery}
+        setStatusFilter={setStatusFilter}
+        setTagFilter={setTagFilter}
+      />
     )
   }
 
   return (
-    <div>
-      {/* select-all row */}
+    <div data-testid="monitors-list-view">
       <div className="flex items-center gap-2 border-border border-b px-6 py-2">
         <Checkbox
           isSelected={selectedIds.length === filteredMonitors.length && filteredMonitors.length > 0}
@@ -445,7 +334,7 @@ function MonitorTable({
         <span className="text-muted-foreground text-xs">Select all</span>
       </div>
 
-      <TableHeader />
+      <MonitorsListHeader />
 
       {groups
         .filter((g) => groupedMonitors[g.id]?.length > 0)
@@ -498,144 +387,38 @@ function MonitorTable({
   )
 }
 
-export default function MonitorsIndex({
-  monitors: initialMonitors,
-  tags,
-  groups,
-  trashedCount,
-}: Props) {
-  useHydrateMonitors(initialMonitors)
-  const monitors = useMonitors()
-  const [selectedIds, setSelectedIds] = useState<number[]>([])
-
-  const {
-    filteredMonitors,
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    tagFilter,
-    setTagFilter,
-    isFiltering,
-  } = useMonitorFilters(monitors)
-
-  const toggleSelect = useCallback((id: number) => {
-    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]))
-  }, [])
-
-  const toggleSelectAll = useCallback(() => {
-    if (selectedIds.length === filteredMonitors.length) {
-      setSelectedIds([])
-    } else {
-      setSelectedIds(filteredMonitors.map((m) => m.id))
-    }
-  }, [filteredMonitors, selectedIds.length])
-
-  const totalCount = monitors.length
+function MonitorGrid({
+  filteredMonitors,
+  isFiltering,
+  setSearchQuery,
+  setStatusFilter,
+  setTagFilter,
+}: {
+  filteredMonitors: Monitor[]
+  isFiltering: boolean
+  setSearchQuery: (v: string) => void
+  setStatusFilter: (v: any) => void
+  setTagFilter: (v: number | null) => void
+}) {
+  if (filteredMonitors.length === 0) {
+    return (
+      <EmptyResults
+        isFiltering={isFiltering}
+        setSearchQuery={setSearchQuery}
+        setStatusFilter={setStatusFilter}
+        setTagFilter={setTagFilter}
+      />
+    )
+  }
 
   return (
-    <>
-      <Head title="Monitors" />
-      <div className="min-h-screen">
-        {/* page header */}
-        <div className="flex items-center justify-between gap-4 border-border border-b px-6 py-5">
-          <div>
-            <h1 className="font-medium text-2xl text-foreground tracking-tight">
-              Monitors{" "}
-              <span className="font-normal text-lg text-muted-foreground">· {totalCount}</span>
-            </h1>
-          </div>
-          <div className="flex items-center gap-2">
-            {trashedCount > 0 && (
-              <Button
-                intent="outline"
-                size="sm"
-                onPress={() => router.visit(monitorRoutes.trashed.url())}
-              >
-                Trash ({trashedCount})
-              </Button>
-            )}
-            <MonitorGroupModal>
-              <Button intent="outline" size="sm">
-                Add Group
-              </Button>
-            </MonitorGroupModal>
-            <ImportExportSection selectedIds={selectedIds} />
-            <CreateMonitorModal>
-              <Button size="sm">
-                <PlusIcon data-slot="icon" />
-                New monitor
-              </Button>
-            </CreateMonitorModal>
-          </div>
-        </div>
-
-        {/* monitors table */}
-        <WhenVisible
-          fallback={
-            <div className="space-y-px">
-              {Array(5)
-                .fill(null)
-                .map((_, i) => (
-                  <div key={i} className="h-14 animate-pulse bg-muted/30" />
-                ))}
-            </div>
-          }
-          data="monitors"
-        >
-          {monitors && monitors.length > 0 ? (
-            <>
-              <MonitorToolbar
-                monitors={monitors}
-                tags={tags}
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                statusFilter={statusFilter}
-                onStatusFilterChange={setStatusFilter}
-                tagFilter={tagFilter}
-                onTagFilterChange={setTagFilter}
-              />
-              <BulkActionToolbar selectedIds={selectedIds} onClear={() => setSelectedIds([])} />
-              <MonitorTable
-                filteredMonitors={filteredMonitors}
-                groups={groups}
-                selectedIds={selectedIds}
-                toggleSelect={toggleSelect}
-                toggleSelectAll={toggleSelectAll}
-                isFiltering={isFiltering}
-                setSearchQuery={setSearchQuery}
-                setStatusFilter={setStatusFilter}
-                setTagFilter={setTagFilter}
-              />
-
-              {/* footer */}
-              <div className="flex items-center justify-between border-border border-t px-6 py-4 font-mono text-muted-foreground text-xs">
-                <div>
-                  showing {filteredMonitors.length} of {totalCount}
-                </div>
-                <div className="flex items-center gap-3">
-                  <span>page 1 / 1</span>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="py-16 text-center">
-              <p className="font-medium text-foreground">No monitors yet</p>
-              <p className="mt-1 text-muted-foreground text-sm">
-                Add a URL, host, or IP to start tracking uptime.
-              </p>
-              <CreateMonitorModal>
-                <Button className="mt-4">
-                  <PlusIcon data-slot="icon" />
-                  Add monitor
-                </Button>
-              </CreateMonitorModal>
-            </div>
-          )}
-        </WhenVisible>
-      </div>
-    </>
+    <div
+      data-testid="monitors-grid-view"
+      className="grid gap-3 px-6 py-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+    >
+      {filteredMonitors.map((monitor) => (
+        <MonitorCard key={monitor.id} monitor={monitor} />
+      ))}
+    </div>
   )
 }
-
-MonitorsIndex.layout = (page: React.ReactNode) => <AppLayout children={page} />

--- a/tests/Browser/MonitorsListBrowserTest.php
+++ b/tests/Browser/MonitorsListBrowserTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\Heartbeat;
+use App\Models\Monitor;
+use App\Models\User;
+
+beforeEach(function (): void {
+    if (! file_exists(base_path('node_modules/playwright'))) {
+        test()->markTestSkipped('playwright is not installed');
+    }
+});
+
+test('search narrows the visible monitors list', function (): void {
+    $user = User::factory()->create();
+
+    $alpha = Monitor::factory()->up()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+        'name' => 'alpha-api',
+        'url' => 'https://alpha.example.com',
+    ]);
+    $beta = Monitor::factory()->up()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+        'name' => 'beta-billing',
+        'url' => 'https://beta.example.com',
+    ]);
+
+    Heartbeat::factory()->count(5)->for($alpha)->create(['status' => 'up', 'response_time' => 110]);
+    Heartbeat::factory()->count(5)->for($beta)->create(['status' => 'up', 'response_time' => 120]);
+
+    $this->actingAs($user);
+
+    $page = visit('/monitors');
+
+    $page->assertPresent("[data-testid=\"monitor-row-{$alpha->id}\"]")
+        ->assertPresent("[data-testid=\"monitor-row-{$beta->id}\"]");
+
+    $page->fill('[data-testid="monitors-header-search"] input', 'alpha-api');
+
+    $page->assertPresent("[data-testid=\"monitor-row-{$alpha->id}\"]")
+        ->assertNotPresent("[data-testid=\"monitor-row-{$beta->id}\"]");
+});
+
+test('status filter narrows the visible monitors list', function (): void {
+    $user = User::factory()->create();
+
+    $up = Monitor::factory()->up()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+        'name' => 'up-monitor',
+    ]);
+    $down = Monitor::factory()->down()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+        'name' => 'down-monitor',
+    ]);
+
+    Heartbeat::factory()->count(5)->for($up)->create(['status' => 'up', 'response_time' => 110]);
+    Heartbeat::factory()->count(5)->for($down)->create(['status' => 'down', 'response_time' => null]);
+
+    $this->actingAs($user);
+
+    $page = visit('/monitors');
+
+    $page->assertPresent("[data-testid=\"monitor-row-{$up->id}\"]")
+        ->assertPresent("[data-testid=\"monitor-row-{$down->id}\"]");
+
+    $page->click('button[aria-label^="Down "]');
+
+    $page->assertPresent("[data-testid=\"monitor-row-{$down->id}\"]")
+        ->assertNotPresent("[data-testid=\"monitor-row-{$up->id}\"]");
+});

--- a/tests/Feature/MonitorsListPageTest.php
+++ b/tests/Feature/MonitorsListPageTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\Heartbeat;
+use App\Models\Monitor;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+function monitorsListHeaders(): array
+{
+    $middleware = new HandleInertiaRequests;
+    $version = $middleware->version(request());
+
+    return [
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => $version ?? '',
+        'X-Inertia-Partial-Component' => 'monitors/index',
+        'X-Inertia-Partial-Data' => 'monitors',
+    ];
+}
+
+test('monitors index includes uptime_percentage and average_response_time per monitor', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->up()->create(['user_id' => $user->id]);
+
+    Heartbeat::factory()->count(8)->for($monitor)->create([
+        'status' => 'up',
+        'response_time' => 100,
+        'created_at' => now()->subMinutes(10),
+    ]);
+    Heartbeat::factory()->count(2)->for($monitor)->create([
+        'status' => 'down',
+        'response_time' => null,
+        'created_at' => now()->subMinutes(5),
+    ]);
+
+    $this->actingAs($user)
+        ->withHeaders(monitorsListHeaders())
+        ->get('/monitors')
+        ->assertOk()
+        ->assertJson(fn ($json) => $json
+            ->where('props.monitors.0.uptime_percentage', fn ($v) => (float) $v === 80.0)
+            ->where('props.monitors.0.average_response_time', fn ($v) => (float) $v === 100.0)
+            ->etc()
+        );
+});
+
+test('monitors index issues no N+1 queries when scaling monitor count', function () {
+    $user = User::factory()->create();
+
+    $monitors = Monitor::factory()->up()->count(8)->create(['user_id' => $user->id]);
+    foreach ($monitors as $m) {
+        Heartbeat::factory()->count(5)->for($m)->create(['status' => 'up', 'response_time' => 120]);
+    }
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $this->actingAs($user)
+        ->withHeaders(monitorsListHeaders())
+        ->get('/monitors')
+        ->assertOk();
+
+    $queryCount = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    // Hard cap: page resolution + auth + tags + groups + monitors + heartbeats eager-load
+    // must not grow with monitor count.
+    expect($queryCount)->toBeLessThan(20);
+});
+
+test('monitors index eager-loads heartbeats so the 48-bucket strip can render without per-row queries', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->up()->create(['user_id' => $user->id]);
+    Heartbeat::factory()->count(50)->for($monitor)->create(['status' => 'up', 'response_time' => 200]);
+
+    $this->actingAs($user)
+        ->withHeaders(monitorsListHeaders())
+        ->get('/monitors')
+        ->assertOk()
+        ->assertJson(fn ($json) => $json
+            ->has('props.monitors.0.heartbeats')
+            ->where('props.monitors.0.heartbeats', fn ($heartbeats) => count($heartbeats) >= 48)
+            ->etc()
+        );
+});
+
+test('tags filter chips render only the team tags', function () {
+    $user = User::factory()->create();
+    Tag::factory()->count(3)->create(['team_id' => $user->current_team_id]);
+    Tag::factory()->count(2)->create(); // other team
+
+    $this->actingAs($user)
+        ->get('/monitors')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('monitors/index')
+            ->has('tags', 3)
+        );
+});


### PR DESCRIPTION
Closes #23

## Acceptance criteria

- [x] `/monitors` matches the mock — header (title + inline search + import/export + new monitor button), toolbar (status pills + tag chips + sort dropdown + list/grid toggle on a single row), dense table with pinned monitor column width, sparkline at the configured 200×32 size — see `resources/js/pages/monitors/index.tsx` and `resources/js/pages/monitors/components/monitor-row.tsx`
- [x] Status filter pills (All / Up / Degraded / Down / Paused), tag chips, sort dropdown, list/grid `SegmentedToggle` — `MonitorsToolbar` (`resources/js/pages/monitors/components/monitors-toolbar.tsx`) — vitest covers each control: `monitors-toolbar.test.tsx`
- [x] Search lives in the page header, left of import/export — `data-testid="monitors-header-search"` on the header input; browser test verifies narrowing
- [x] Heartbeat strip and sparkline render real data per row, via `HeartbeatTooltipStrip` (intent-ui Tooltip per bar — status, ms, HTTP code, timestamp, message) and the `ResponseSparkline` primitive
- [x] List endpoint serves heartbeats efficiently — `MonitorController::index` eager-loads heartbeats once and computes `uptime_percentage` + `average_response_time` from the loaded collection (`Monitor::uptimePercentageFromLoaded` / `Monitor::averageResponseTimeFromLoaded`); enforced by `MonitorsListPageTest::"monitors index issues no N+1 queries when scaling monitor count"` (asserts query count < 20 with 8 monitors)
- [x] Pest 4 browser test for happy path — `tests/Browser/MonitorsListBrowserTest.php` covers search-narrows + status-pill-narrows
- [x] All status/dot/pill/sparkline/heartbeat usage goes through the primitives from #20 — `StatusDot`, `HeartbeatBar`, `ResponseSparkline`, `SegmentedToggle` are imported from `@/components/primitives`

## Beyond the AC

- Search, status filter, tag filter, sort, and view persist to URL query params (`useMonitorFilters` extended)
- Sort dropdown uses the canonical `Select` UI component (intent-ui)
- Each row exposes a Menu popover (`⋯`) with Open / Edit / Pause-Resume / Delete (delete uses an in-row Modal confirm) — fixes the previous-no-op action button
- Top-right "New monitor" routes directly to `/monitors/create` (the previous `CreateMonitorModal` div-onClick wrapper swallowed clicks from React-Aria Buttons)
- Sidebar "Monitors · N" eyebrow and dashboard "View all →" link both navigate to `/monitors`

## Test plan

- [x] `php artisan test --compact` — full Pest suite green (441 tests / 14114 assertions before this change; new tests bring it to 446)
- [x] `php artisan test --compact tests/Browser/MonitorsListBrowserTest.php` — Pest 4 browser tests green
- [x] `npm run test:js -- --run` — vitest green (105 tests across 20 files)
- [x] `npm run build` — Vite build green
- [x] `vendor/bin/pint --dirty --format agent` — pint clean
- [x] `npx biome format --write resources/js` — biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List and grid view modes for monitors with persistent view and sort controls
  * Sorting by status, name, uptime, response time, and last check
  * "Degraded" status filter for partial outages
  * Per-monitor uptime percentage and average response time shown
  * New monitor row/card UI with heartbeat sparkline, tooltip, and actions (pause/resume/delete)
  * Dashboard and sidebar link to full monitors page

* **Tests**
  * Added unit and browser tests covering toolbar, filtering, sorting, and monitor page behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->