### PR TITLE
Local dev: Sail stack (Postgres + Mailpit) + dashboard pgsql fix

### DIFF
--- a/.env.example.sail
+++ b/.env.example.sail
@@ -1,0 +1,95 @@
+APP_NAME=Beacon
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_TIMEZONE=UTC
+APP_URL=http://localhost
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+APP_FAKER_LOCALE=en_US
+
+APP_MAINTENANCE_DRIVER=file
+# APP_MAINTENANCE_STORE=database
+
+BCRYPT_ROUNDS=12
+
+LOG_CHANNEL=stack
+LOG_STACK=single
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+# --- Sail / Postgres ---
+DB_CONNECTION=pgsql
+DB_HOST=pgsql
+DB_PORT=5432
+DB_DATABASE=laravel
+DB_USERNAME=sail
+DB_PASSWORD=password
+# Host port forwarded by the pgsql container
+FORWARD_DB_PORT=5432
+
+SESSION_DRIVER=database
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_DOMAIN=null
+
+BROADCAST_CONNECTION=reverb
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=database
+
+CACHE_STORE=database
+CACHE_PREFIX=
+
+MEMCACHED_HOST=memcached
+
+REDIS_CLIENT=phpredis
+REDIS_HOST=redis
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+# --- Mailpit (sail) ---
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_NAME="${APP_NAME}"
+FORWARD_MAILPIT_PORT=1025
+FORWARD_MAILPIT_DASHBOARD_PORT=8025
+
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=us-east-1
+AWS_BUCKET=
+AWS_USE_PATH_STYLE_ENDPOINT=false
+
+VITE_APP_NAME="${APP_NAME}"
+VITE_PORT=5173
+
+# --- Reverb (websockets) ---
+REVERB_APP_ID=
+REVERB_APP_KEY=
+REVERB_APP_SECRET=
+REVERB_HOST=localhost
+REVERB_PORT=8080
+REVERB_SCHEME=http
+
+VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
+VITE_REVERB_HOST="${REVERB_HOST}"
+VITE_REVERB_PORT="${REVERB_PORT}"
+VITE_REVERB_SCHEME="${REVERB_SCHEME}"
+
+# --- Sail compose ---
+# Tell `docker compose` (and the `sail` alias) which file to use for local dev.
+COMPOSE_FILE=docker-compose.sail.yml
+# Match host UID/GID so volume mounts aren't owned by root.
+WWWUSER=1000
+WWWGROUP=1000
+
+# Host port forwarded by the laravel.test container.
+APP_PORT=80
+SAIL_XDEBUG_MODE=off

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,13 @@ Wayfinder generates TypeScript functions for Laravel routes. Import from `@/acti
 
 </laravel-boost-guidelines>
 
+## Local Development
+
+- **Primary path: Laravel Sail.** The local dev stack lives in `docker-compose.sail.yml` (Postgres + Mailpit + the `laravel.test` PHP container). Bootstrap with `./bin/build_sail.sh` (use `--fresh` to reset the DB). Day-to-day: `sail up -d`, `sail artisan ...`, `sail npm run dev`, `sail test`. The `sail` shell alias is expected.
+- The repo's `docker-compose.yml` is the **production** stack (uses the published `ghcr.io/pingbeacon/beacon:latest` image) — do not edit it for local-dev convenience.
+- `.env` should set `COMPOSE_FILE=docker-compose.sail.yml` so `docker compose` (and Sail) target the dev file by default. `.env.example.sail` is the canonical template.
+- Tests run against SQLite in-memory (see `phpunit.xml`), but the dev DB is **Postgres**. Postgres is stricter than SQLite — avoid double-quoted string literals in raw SQL (use `?` bindings or single quotes).
+
 ## Design Context
 
 ### Users

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -27,7 +27,7 @@ class DashboardController extends Controller
             $stats30d = Heartbeat::query()
                 ->whereIn('monitor_id', $activeMonitorIds)
                 ->where('created_at', '>=', now()->subHours(720))
-                ->selectRaw('COUNT(*) as total, SUM(CASE WHEN status = "up" THEN 1 ELSE 0 END) as up_count')
+                ->selectRaw('COUNT(*) as total, SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as up_count', ['up'])
                 ->first();
 
             if ($stats30d && $stats30d->total > 0) {

--- a/bin/build_sail.sh
+++ b/bin/build_sail.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Bootstrap the Sail-based local dev stack.
+#   - Copies .env.example.sail → .env (if missing)
+#   - Generates APP_KEY (if missing)
+#   - Builds the laravel.test image
+#   - Brings up pgsql + mailpit + laravel.test
+#   - Installs composer + npm deps inside the container
+#   - Runs migrations
+set -e
+
+cd "$(dirname "$0")/.."
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}[✓]${NC} $1"; }
+fail() { echo -e "${RED}[✗]${NC} $1"; exit 1; }
+info() { echo -e "${YELLOW}[…]${NC} $1"; }
+
+# --- Flags ---
+FRESH=0
+for arg in "$@"; do
+    case "$arg" in
+        --fresh) FRESH=1 ;;
+        -h|--help)
+            cat <<EOF
+Usage: bin/build_sail.sh [--fresh]
+
+  --fresh   Drop + recreate all tables (migrate:fresh --seed). DESTRUCTIVE.
+            Default: idempotent migrate --seed (preserves existing data).
+EOF
+            exit 0
+            ;;
+        *) fail "Unknown arg: $arg (try --help)" ;;
+    esac
+done
+
+SAIL_FILE="docker-compose.sail.yml"
+SAIL_TEMPLATE=".env.example.sail"
+
+[ -f "$SAIL_FILE" ] || fail "$SAIL_FILE missing. Run from repo root."
+[ -f "$SAIL_TEMPLATE" ] || fail "$SAIL_TEMPLATE missing."
+
+# --- Setup .env ---
+if [ ! -f .env ]; then
+    info "Creating .env from $SAIL_TEMPLATE..."
+    cp "$SAIL_TEMPLATE" .env
+    ok ".env created"
+else
+    ok ".env exists"
+    if ! grep -q "^COMPOSE_FILE=" .env; then
+        echo "" >> .env
+        echo "COMPOSE_FILE=$SAIL_FILE" >> .env
+        ok "Appended COMPOSE_FILE=$SAIL_FILE"
+    fi
+    if ! grep -q "^WWWUSER=" .env; then
+        echo "WWWUSER=$(id -u)" >> .env
+        echo "WWWGROUP=$(id -g)" >> .env
+        ok "Appended WWWUSER/WWWGROUP"
+    fi
+fi
+
+# --- Composer deps (host) so vendor/laravel/sail exists ---
+if [ ! -f vendor/bin/sail ]; then
+    info "Installing composer deps on host (one-time, needed to bootstrap sail image)..."
+    if command -v composer >/dev/null 2>&1; then
+        composer install --no-interaction --prefer-dist
+    else
+        docker run --rm -v "$(pwd):/app" -w /app composer:2 install --no-interaction --prefer-dist
+    fi
+    ok "Composer deps installed"
+fi
+
+SAIL="vendor/bin/sail"
+
+# --- Build image ---
+info "Building Sail image..."
+$SAIL build
+ok "Image built"
+
+# --- Start services ---
+info "Starting services..."
+$SAIL up -d
+ok "Services started"
+
+# --- APP_KEY ---
+if grep -q "^APP_KEY=$" .env || grep -q "^APP_KEY=base64:$" .env; then
+    info "Generating APP_KEY..."
+    $SAIL artisan key:generate --force
+    ok "APP_KEY set"
+fi
+
+# --- Wait for pgsql ---
+info "Waiting for pgsql healthcheck..."
+attempt=0
+max=24
+until $SAIL ps pgsql 2>/dev/null | grep -q "healthy"; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge "$max" ]; then
+        fail "pgsql not healthy in time. Logs:\n$($SAIL logs --tail=30 pgsql)"
+    fi
+    sleep 5
+done
+ok "pgsql healthy"
+
+# --- Migrate + seed ---
+if [ "$FRESH" = "1" ]; then
+    info "Running migrate:fresh --seed (drops + recreates all tables)..."
+    $SAIL artisan migrate:fresh --seed --force
+    ok "Schema reset + seeders applied"
+else
+    info "Running migrate --seed (idempotent, preserves data)..."
+    $SAIL artisan migrate --seed --force
+    ok "Migrations + seeders applied"
+fi
+
+# --- npm deps + build ---
+if [ -f package.json ]; then
+    info "Installing npm deps..."
+    $SAIL npm install
+    ok "npm deps installed"
+fi
+
+# --- Summary ---
+echo ""
+ok "Sail stack ready."
+echo ""
+$SAIL ps
+echo ""
+echo "  Run dev server: sail npm run dev   (then visit http://localhost)"
+echo "  Mailpit UI:     http://localhost:8025"
+echo "  Logs:           sail logs -f"
+echo "  Teardown:       sail down -v"
+echo ""

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "laravel/boost": "^2.0",
         "laravel/pail": "^1.2",
         "laravel/pint": "^1.13",
-        "laravel/sail": "^1.26",
+        "laravel/sail": "^1.58",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
         "pestphp/pest": "^4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac713f2332ea6d81bb3b9d9ca72a3d8e",
+    "content-hash": "c88aef973778f749378084aac8635d31",
     "packages": [
         {
             "name": "brick/math",
@@ -9380,16 +9380,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.53.0",
+            "version": "v1.58.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "e340eaa2bea9b99192570c48ed837155dbf24fbb"
+                "reference": "2e5e968138ca52ed87d712449697a8364d73b466"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/e340eaa2bea9b99192570c48ed837155dbf24fbb",
-                "reference": "e340eaa2bea9b99192570c48ed837155dbf24fbb",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/2e5e968138ca52ed87d712449697a8364d73b466",
+                "reference": "2e5e968138ca52ed87d712449697a8364d73b466",
                 "shasum": ""
             },
             "require": {
@@ -9439,7 +9439,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-02-06T12:16:02+00:00"
+            "time": "2026-04-27T13:38:34+00:00"
         },
         {
             "name": "league/uri-components",

--- a/docker-compose.sail.yml
+++ b/docker-compose.sail.yml
@@ -14,7 +14,6 @@ services:
         ports:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
-            - '${REVERB_PORT:-8080}:8080'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
@@ -28,6 +27,54 @@ services:
         depends_on:
             - pgsql
             - mailpit
+    queue:
+        image: sail-8.4/app
+        command:
+            - php
+            - artisan
+            - 'queue:work'
+            - '--queue=monitors,ssl,notifications,default'
+            - '--tries=1'
+            - '--sleep=3'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            REVERB_HOST: reverb
+            REVERB_PORT: '8080'
+            REVERB_SCHEME: http
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            laravel.test:
+                condition: service_started
+            pgsql:
+                condition: service_healthy
+        restart: unless-stopped
+    reverb:
+        image: sail-8.4/app
+        command:
+            - php
+            - artisan
+            - 'reverb:start'
+            - '--host=0.0.0.0'
+            - '--port=8080'
+        ports:
+            - '${REVERB_PORT:-8080}:8080'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            laravel.test:
+                condition: service_started
+            pgsql:
+                condition: service_healthy
+        restart: unless-stopped
     pgsql:
         image: 'postgres:18-alpine'
         ports:

--- a/docker-compose.sail.yml
+++ b/docker-compose.sail.yml
@@ -1,0 +1,68 @@
+# Local development stack via Laravel Sail.
+# Activate by setting `COMPOSE_FILE=docker-compose.sail.yml` in `.env`.
+# Production stack lives in docker-compose.yml.
+services:
+    laravel.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.4
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.4/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+            - '${REVERB_PORT:-8080}:8080'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            IGNITION_LOCAL_SITES_PATH: '${PWD}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - pgsql
+            - mailpit
+    pgsql:
+        image: 'postgres:18-alpine'
+        ports:
+            - '${FORWARD_DB_PORT:-5432}:5432'
+        environment:
+            PGPASSWORD: '${DB_PASSWORD:-secret}'
+            POSTGRES_DB: '${DB_DATABASE}'
+            POSTGRES_USER: '${DB_USERNAME}'
+            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
+        volumes:
+            - 'sail-pgsql:/var/lib/postgresql'
+            - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - pg_isready
+                - '-q'
+                - '-d'
+                - '${DB_DATABASE}'
+                - '-U'
+                - '${DB_USERNAME}'
+            retries: 3
+            timeout: 5s
+    mailpit:
+        image: 'axllent/mailpit:latest'
+        ports:
+            - '${FORWARD_MAILPIT_PORT:-1025}:1025'
+            - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
+        networks:
+            - sail
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sail-pgsql:
+        driver: local

--- a/docker-compose.sail.yml
+++ b/docker-compose.sail.yml
@@ -75,6 +75,28 @@ services:
             pgsql:
                 condition: service_healthy
         restart: unless-stopped
+    scheduler:
+        image: sail-8.4/app
+        command:
+            - php
+            - artisan
+            - 'schedule:work'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            REVERB_HOST: reverb
+            REVERB_PORT: '8080'
+            REVERB_SCHEME: http
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            laravel.test:
+                condition: service_started
+            pgsql:
+                condition: service_healthy
+        restart: unless-stopped
     pgsql:
         image: 'postgres:18-alpine'
         ports:

--- a/tests/Feature/DashboardDataTest.php
+++ b/tests/Feature/DashboardDataTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\Heartbeat;
 use App\Models\Incident;
 use App\Models\Monitor;
 use App\Models\User;
@@ -100,6 +101,26 @@ test('has_incidents_24h is false for resolved incident outside 24h window', func
         ->assertJson(fn ($json) => $json
             ->where('props.monitors.0.has_incidents_24h', false)
             ->etc()
+        );
+});
+
+test('team_uptime_30d aggregates heartbeats across active monitors', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->up()->create(['user_id' => $user->id]);
+
+    Heartbeat::factory()->up()->count(8)->create([
+        'monitor_id' => $monitor->id,
+        'created_at' => now()->subHours(1),
+    ]);
+    Heartbeat::factory()->down()->count(2)->create([
+        'monitor_id' => $monitor->id,
+        'created_at' => now()->subHours(1),
+    ]);
+
+    $this->actingAs($user)->get('/dashboard')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('team_uptime_30d', 80)
         );
 });
 


### PR DESCRIPTION
Closes #45

## Summary

- Adds Laravel Sail as the primary local-dev path: `docker-compose.sail.yml` (Postgres 18 + Mailpit + `laravel.test` PHP 8.4) on a dedicated `sail` network. Production `docker-compose.yml` is untouched, so `install.sh` / README / `test_build.sh` keep working.
- Adds `.env.example.sail` (Sail-flavored env template — `DB_HOST=pgsql`, `MAIL_HOST=mailpit`, `COMPOSE_FILE`, `WWWUSER`/`WWWGROUP`) and `bin/build_sail.sh` (bootstrap: build, up, key:generate, wait pgsql healthy, `migrate --seed`, `npm install`). `--fresh` flag opts into destructive `migrate:fresh --seed`; default is idempotent.
- Fixes a Postgres-only bug in `DashboardController` exposed by switching the dev DB to pg: `selectRaw('... CASE WHEN status = "up" ...')` — Postgres reads `"up"` as an identifier, not a string. Now uses `?` parameter binding (matches the existing pattern in `Monitor::averageResponseTime`). Regression test covers the `team_uptime_30d` aggregate.
- CLAUDE.md documents Sail as the primary local-dev path and warns about double-quoted SQL string literals.

## Test plan

- [x] `vendor/bin/sail artisan test --compact --filter=DashboardDataTest` → 7 passed
- [x] `/dashboard` loads against Postgres without `column "up" does not exist`
- [x] Both compose files validate (`docker compose -f <file> config --quiet`)
- [x] `vendor/bin/pint --dirty --format agent` clean
- [ ] Verify production `docker-compose.yml` stack still boots (`./test_build.sh`) on a clean host
- [ ] Fresh-clone smoke: `./bin/build_sail.sh` → `sail artisan test`

## Out of scope (follow-ups)

Running the full `sail artisan test` surfaced 5 pre-existing failures unrelated to this PR — they are environmental issues that only appear inside the Sail container and should be addressed separately:

- `MonitoringEngineTest > ping checker returns up for localhost` — `iputils-ping` likely missing in the sail-8.4 PHP image (or icmp behavior differs in container).
- 4 browser tests — `Playwright is outdated` in the container; needs `sail npm install playwright@latest && sail npx playwright install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)