### PR TITLE
fix(dev): bootstrap Playwright Chromium in build_sail.sh

### DIFF
--- a/bin/build_sail.sh
+++ b/bin/build_sail.sh
@@ -123,6 +123,17 @@ if [ -f package.json ]; then
     ok "npm deps installed"
 fi
 
+# --- Playwright browsers (Pest browser tests) ---
+if [ -f node_modules/.bin/playwright ]; then
+    if [ ! -d node_modules/playwright-core/.local-browsers ]; then
+        info "Installing Playwright Chromium (one-time, ~120MB)..."
+        $SAIL exec -T laravel.test bash -c 'PLAYWRIGHT_BROWSERS_PATH=0 npx playwright install chromium --force'
+        ok "Playwright Chromium installed"
+    else
+        ok "Playwright browsers already present"
+    fi
+fi
+
 # --- Summary ---
 echo ""
 ok "Sail stack ready."


### PR DESCRIPTION
Follow-up to #46 — the playwright bootstrap step raced the merge and never landed on main.

## Summary

- Adds a one-time Playwright Chromium install step to `bin/build_sail.sh` after `npm install`.
- Browsers are placed at `node_modules/playwright-core/.local-browsers/` (project-local because the sail Dockerfile sets `PLAYWRIGHT_BROWSERS_PATH=0`), so they persist via the bind mount.
- Subsequent runs short-circuit when the directory already exists.
- Uses `--force` because Playwright's normal `install chromium` silently no-ops when it sees a stale cache marker (observed during initial bootstrap).

## Why this matters

Without this, Pest 4 browser tests inside the Sail container all fail with `PlaywrightOutdatedException` even though the npm package is up-to-date — the message is misleading; the actual problem is missing browser binaries.

## Test plan

- [x] `sail artisan test --filter=AppShellTest` → green (was failing pre-fix)
- [x] Full suite: 474 passed / 1 failed; the remaining failure is `PingChecker` (tracked in #47, separate concern)
- [x] Re-running `bin/build_sail.sh` skips the install when browsers are already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build bootstrap process with automated browser dependency management. The initialization script now intelligently detects Playwright requirements and automatically installs necessary Chromium browser binaries when needed, with informative status reporting. This streamlines development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->