### PR TITLE
14. Notification deliveries log (schema + dispatcher logging + log UI + fired-today counts)

### DIFF
--- a/app/Http/Controllers/FiredTodayDeliveriesController.php
+++ b/app/Http/Controllers/FiredTodayDeliveriesController.php
@@ -12,6 +12,10 @@ class FiredTodayDeliveriesController extends Controller
     {
         $teamId = $request->user()->current_team_id;
 
+        if ($teamId === null) {
+            return response()->json([]);
+        }
+
         $rows = NotificationDelivery::query()
             ->selectRaw('channel_id, count(*) as count')
             ->where('team_id', $teamId)

--- a/app/Http/Controllers/FiredTodayDeliveriesController.php
+++ b/app/Http/Controllers/FiredTodayDeliveriesController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationDelivery;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class FiredTodayDeliveriesController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $teamId = $request->user()->current_team_id;
+
+        $rows = NotificationDelivery::query()
+            ->selectRaw('channel_id, count(*) as count')
+            ->where('team_id', $teamId)
+            ->where('dispatched_at', '>=', now()->startOfDay())
+            ->groupBy('channel_id')
+            ->orderBy('channel_id')
+            ->get()
+            ->map(fn ($row) => [
+                'channel_id' => (int) $row->channel_id,
+                'count' => (int) $row->count,
+            ]);
+
+        return response()->json($rows);
+    }
+}

--- a/app/Http/Controllers/MonitorNotificationDeliveryController.php
+++ b/app/Http/Controllers/MonitorNotificationDeliveryController.php
@@ -2,19 +2,19 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\MonitorNotificationDeliveryIndexRequest;
 use App\Http\Resources\NotificationDeliveryResource;
 use App\Models\Monitor;
 use App\Models\NotificationDelivery;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class MonitorNotificationDeliveryController extends Controller
 {
-    public function index(Request $request, Monitor $monitor): AnonymousResourceCollection
+    public function index(MonitorNotificationDeliveryIndexRequest $request, Monitor $monitor): AnonymousResourceCollection
     {
         $this->authorize('view', $monitor);
 
-        $status = $request->query('status', 'all');
+        $status = $request->validated('status', 'all');
 
         $query = NotificationDelivery::query()
             ->with(['channel:id,name,type', 'incident:id,started_at,resolved_at'])

--- a/app/Http/Controllers/MonitorNotificationDeliveryController.php
+++ b/app/Http/Controllers/MonitorNotificationDeliveryController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\NotificationDeliveryResource;
+use App\Models\Monitor;
+use App\Models\NotificationDelivery;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class MonitorNotificationDeliveryController extends Controller
+{
+    public function index(Request $request, Monitor $monitor): AnonymousResourceCollection
+    {
+        $this->authorize('view', $monitor);
+
+        $status = $request->query('status', 'all');
+
+        $query = NotificationDelivery::query()
+            ->with(['channel:id,name,type', 'incident:id,started_at,resolved_at'])
+            ->where('team_id', $monitor->team_id)
+            ->where('monitor_id', $monitor->id)
+            ->orderByDesc('dispatched_at');
+
+        if (in_array($status, ['delivered', 'failed'], true)) {
+            $query->where('status', $status);
+        }
+
+        $paginator = $query->paginate(20)->withQueryString();
+
+        return NotificationDeliveryResource::collection($paginator);
+    }
+}

--- a/app/Http/Requests/MonitorNotificationDeliveryIndexRequest.php
+++ b/app/Http/Requests/MonitorNotificationDeliveryIndexRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class MonitorNotificationDeliveryIndexRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['nullable', 'string', 'in:all,delivered,failed'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'status.in' => 'The status filter must be all, delivered, or failed.',
+        ];
+    }
+}

--- a/app/Http/Resources/NotificationDeliveryResource.php
+++ b/app/Http/Resources/NotificationDeliveryResource.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\NotificationDelivery;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin NotificationDelivery
+ */
+class NotificationDeliveryResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'channel_id' => $this->channel_id,
+            'channel' => $this->whenLoaded('channel', fn () => [
+                'id' => $this->channel->id,
+                'name' => $this->channel->name,
+                'type' => $this->channel->type,
+            ]),
+            'incident_id' => $this->incident_id,
+            'incident' => $this->whenLoaded('incident', fn () => $this->incident ? [
+                'id' => $this->incident->id,
+                'started_at' => optional($this->incident->started_at)->toIso8601String(),
+                'resolved_at' => optional($this->incident->resolved_at)?->toIso8601String(),
+            ] : null),
+            'event_type' => $this->event_type,
+            'status' => $this->status,
+            'latency_ms' => $this->latency_ms,
+            'error' => $this->error,
+            'dispatched_at' => optional($this->dispatched_at)->toIso8601String(),
+        ];
+    }
+}

--- a/app/Jobs/SendNotificationJob.php
+++ b/app/Jobs/SendNotificationJob.php
@@ -40,6 +40,10 @@ class SendNotificationJob implements ShouldQueue
 
     public function handle(): void
     {
+        if ($this->channel->team_id !== $this->monitor->team_id) {
+            throw new \LogicException('Channel and monitor must belong to the same team.');
+        }
+
         $notifier = $this->resolveNotifier();
         $ackUrl = $this->resolveAckUrl();
 
@@ -59,12 +63,20 @@ class SendNotificationJob implements ShouldQueue
             throw $e;
         }
 
-        $this->recordDelivery(
-            status: 'delivered',
-            latencyMs: (int) round((microtime(true) - $start) * 1000),
-            error: null,
-            dispatchedAt: $dispatchedAt,
-        );
+        try {
+            $this->recordDelivery(
+                status: 'delivered',
+                latencyMs: (int) round((microtime(true) - $start) * 1000),
+                error: null,
+                dispatchedAt: $dispatchedAt,
+            );
+        } catch (Throwable $loggingException) {
+            Log::warning('Notification delivery logging failed after successful send', [
+                'channel_id' => $this->channel->id,
+                'monitor_id' => $this->monitor->id,
+                'error' => $loggingException->getMessage(),
+            ]);
+        }
 
         Log::info('Notification sent', [
             'channel_id' => $this->channel->id,
@@ -80,7 +92,7 @@ class SendNotificationJob implements ShouldQueue
     private function recordDelivery(string $status, int $latencyMs, ?string $error, Carbon $dispatchedAt): void
     {
         NotificationDelivery::create([
-            'team_id' => $this->channel->team_id ?? $this->monitor->team_id,
+            'team_id' => $this->monitor->team_id,
             'channel_id' => $this->channel->id,
             'monitor_id' => $this->monitor->id,
             'incident_id' => $this->incidentId,

--- a/app/Jobs/SendNotificationJob.php
+++ b/app/Jobs/SendNotificationJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Models\Incident;
 use App\Models\Monitor;
 use App\Models\NotificationChannel;
+use App\Models\NotificationDelivery;
 use App\Services\Notifiers\DiscordNotifier;
 use App\Services\Notifiers\EmailNotifier;
 use App\Services\Notifiers\Notifier;
@@ -13,6 +14,7 @@ use App\Services\Notifiers\TelegramNotifier;
 use App\Services\Notifiers\WebhookNotifier;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Throwable;
@@ -31,6 +33,7 @@ class SendNotificationJob implements ShouldQueue
         public string $status,
         public ?string $message = null,
         public ?int $incidentId = null,
+        public string $eventType = 'status_flip',
     ) {
         $this->onQueue('notifications');
     }
@@ -40,7 +43,28 @@ class SendNotificationJob implements ShouldQueue
         $notifier = $this->resolveNotifier();
         $ackUrl = $this->resolveAckUrl();
 
-        $notifier->send($this->channel, $this->monitor, $this->status, $this->message, $ackUrl);
+        $start = microtime(true);
+        $dispatchedAt = now();
+
+        try {
+            $notifier->send($this->channel, $this->monitor, $this->status, $this->message, $ackUrl);
+        } catch (Throwable $e) {
+            $this->recordDelivery(
+                status: 'failed',
+                latencyMs: (int) round((microtime(true) - $start) * 1000),
+                error: $e->getMessage(),
+                dispatchedAt: $dispatchedAt,
+            );
+
+            throw $e;
+        }
+
+        $this->recordDelivery(
+            status: 'delivered',
+            latencyMs: (int) round((microtime(true) - $start) * 1000),
+            error: null,
+            dispatchedAt: $dispatchedAt,
+        );
 
         Log::info('Notification sent', [
             'channel_id' => $this->channel->id,
@@ -49,6 +73,22 @@ class SendNotificationJob implements ShouldQueue
             'monitor_name' => $this->monitor->name,
             'status' => $this->status,
             'incident_id' => $this->incidentId,
+            'event_type' => $this->eventType,
+        ]);
+    }
+
+    private function recordDelivery(string $status, int $latencyMs, ?string $error, Carbon $dispatchedAt): void
+    {
+        NotificationDelivery::create([
+            'team_id' => $this->channel->team_id ?? $this->monitor->team_id,
+            'channel_id' => $this->channel->id,
+            'monitor_id' => $this->monitor->id,
+            'incident_id' => $this->incidentId,
+            'event_type' => $this->eventType,
+            'status' => $status,
+            'latency_ms' => $latencyMs,
+            'error' => $error,
+            'dispatched_at' => $dispatchedAt,
         ]);
     }
 
@@ -82,6 +122,10 @@ class SendNotificationJob implements ShouldQueue
 
     private function resolveNotifier(): Notifier
     {
+        if (app()->bound(Notifier::class)) {
+            return app(Notifier::class);
+        }
+
         return match ($this->channel->type) {
             'email' => new EmailNotifier,
             'slack' => new SlackNotifier,

--- a/app/Models/NotificationDelivery.php
+++ b/app/Models/NotificationDelivery.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\NotificationDeliveryFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotificationDelivery extends Model
+{
+    /** @use HasFactory<NotificationDeliveryFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id',
+        'channel_id',
+        'monitor_id',
+        'incident_id',
+        'event_type',
+        'status',
+        'latency_ms',
+        'error',
+        'dispatched_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'dispatched_at' => 'datetime',
+            'latency_ms' => 'integer',
+        ];
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(NotificationChannel::class, 'channel_id');
+    }
+
+    public function monitor(): BelongsTo
+    {
+        return $this->belongsTo(Monitor::class);
+    }
+
+    public function incident(): BelongsTo
+    {
+        return $this->belongsTo(Incident::class);
+    }
+}

--- a/database/factories/NotificationDeliveryFactory.php
+++ b/database/factories/NotificationDeliveryFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Monitor;
+use App\Models\NotificationChannel;
+use App\Models\NotificationDelivery;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<NotificationDelivery>
+ */
+class NotificationDeliveryFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'channel_id' => NotificationChannel::factory(),
+            'monitor_id' => Monitor::factory(),
+            'incident_id' => null,
+            'event_type' => 'status_flip',
+            'status' => 'delivered',
+            'latency_ms' => fake()->numberBetween(20, 800),
+            'error' => null,
+            'dispatched_at' => now(),
+        ];
+    }
+
+    public function failed(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'failed',
+            'error' => 'upstream error',
+        ]);
+    }
+}

--- a/database/factories/NotificationDeliveryFactory.php
+++ b/database/factories/NotificationDeliveryFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use App\Models\Monitor;
 use App\Models\NotificationChannel;
 use App\Models\NotificationDelivery;
-use App\Models\Team;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -15,10 +15,19 @@ class NotificationDeliveryFactory extends Factory
 {
     public function definition(): array
     {
+        $user = User::factory()->create();
+        $teamId = $user->current_team_id;
+
         return [
-            'team_id' => Team::factory(),
-            'channel_id' => NotificationChannel::factory(),
-            'monitor_id' => Monitor::factory(),
+            'team_id' => $teamId,
+            'channel_id' => NotificationChannel::factory()->state([
+                'user_id' => $user->id,
+                'team_id' => $teamId,
+            ]),
+            'monitor_id' => Monitor::factory()->state([
+                'user_id' => $user->id,
+                'team_id' => $teamId,
+            ]),
             'incident_id' => null,
             'event_type' => 'status_flip',
             'status' => 'delivered',

--- a/database/migrations/2026_04_30_194823_create_notification_deliveries_table.php
+++ b/database/migrations/2026_04_30_194823_create_notification_deliveries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('channel_id')->constrained('notification_channels')->cascadeOnDelete();
+            $table->foreignId('monitor_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('incident_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('event_type');
+            $table->string('status');
+            $table->unsignedInteger('latency_ms')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamp('dispatched_at');
+            $table->timestamps();
+
+            $table->index(['channel_id', 'dispatched_at']);
+            $table->index(['team_id', 'dispatched_at']);
+            $table->index(['monitor_id', 'dispatched_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_deliveries');
+    }
+};

--- a/resources/js/pages/monitors/components/__tests__/notification-delivery-log.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/notification-delivery-log.test.tsx
@@ -1,0 +1,88 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NotificationDeliveryLog } from "@/pages/monitors/components/notification-delivery-log"
+import type { NotificationDelivery } from "@/types/monitor"
+
+const sample = (overrides: Partial<NotificationDelivery> = {}): NotificationDelivery => ({
+  id: 1,
+  channel_id: 1,
+  channel: { id: 1, name: "Team Email", type: "email" },
+  incident_id: 42,
+  incident: { id: 42, started_at: "2026-04-30T10:00:00Z", resolved_at: null },
+  event_type: "status_flip",
+  status: "delivered",
+  latency_ms: 120,
+  error: null,
+  dispatched_at: "2026-04-30T10:00:01Z",
+  ...overrides,
+})
+
+describe("NotificationDeliveryLog", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders rows fetched from the deliveries endpoint", async () => {
+    const fetcher = vi.fn().mockResolvedValue({
+      data: [sample({ id: 1 }), sample({ id: 2, status: "failed", error: "boom" })],
+      meta: { current_page: 1, last_page: 1, per_page: 20, total: 2 },
+    })
+
+    render(<NotificationDeliveryLog monitorId={5} fetcher={fetcher} />)
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalled()
+    })
+
+    expect(fetcher.mock.calls[0][0]).toBe("/monitors/5/notification-deliveries?status=all&page=1")
+
+    expect(await screen.findAllByText("Team Email")).toHaveLength(2)
+    expect(await screen.findByText("delivered")).toBeInTheDocument()
+    expect(await screen.findByText("failed")).toBeInTheDocument()
+    expect(await screen.findByText("boom")).toBeInTheDocument()
+  })
+
+  it("re-fetches when the failed filter is selected", async () => {
+    const fetcher = vi.fn().mockResolvedValue({
+      data: [],
+      meta: { current_page: 1, last_page: 1, per_page: 20, total: 0 },
+    })
+
+    render(<NotificationDeliveryLog monitorId={5} fetcher={fetcher} />)
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Failed" }))
+    })
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2))
+    expect(fetcher.mock.calls[1][0]).toBe(
+      "/monitors/5/notification-deliveries?status=failed&page=1",
+    )
+  })
+
+  it("paginates with next/previous buttons", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [sample({ id: 1 })],
+        meta: { current_page: 1, last_page: 3, per_page: 20, total: 60 },
+      })
+      .mockResolvedValueOnce({
+        data: [sample({ id: 21 })],
+        meta: { current_page: 2, last_page: 3, per_page: 20, total: 60 },
+      })
+
+    render(<NotificationDeliveryLog monitorId={5} fetcher={fetcher} />)
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    })
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2))
+    expect(fetcher.mock.calls[1][0]).toBe("/monitors/5/notification-deliveries?status=all&page=2")
+  })
+})

--- a/resources/js/pages/monitors/components/__tests__/notification-delivery-log.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/notification-delivery-log.test.tsx
@@ -62,6 +62,29 @@ describe("NotificationDeliveryLog", () => {
     )
   })
 
+  it("clears previously rendered rows when a later fetch fails", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [sample({ id: 1 })],
+        meta: { current_page: 1, last_page: 1, per_page: 20, total: 1 },
+      })
+      .mockRejectedValueOnce(new Error("Failed to load deliveries (500)"))
+
+    render(<NotificationDeliveryLog monitorId={5} fetcher={fetcher} />)
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText("Team Email")).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Failed" }))
+    })
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2))
+    await screen.findByRole("alert")
+    expect(screen.queryByText("Team Email")).toBeNull()
+  })
+
   it("paginates with next/previous buttons", async () => {
     const fetcher = vi
       .fn()

--- a/resources/js/pages/monitors/components/notification-delivery-log.tsx
+++ b/resources/js/pages/monitors/components/notification-delivery-log.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from "react"
+import MonitorNotificationDeliveryController from "@/actions/App/Http/Controllers/MonitorNotificationDeliveryController"
+import { SegmentedToggle, type SegmentedToggleOption } from "@/components/primitives"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { NotificationDelivery, NotificationDeliveryStatus } from "@/types/monitor"
+
+type Filter = "all" | "delivered" | "failed"
+
+interface PaginationMeta {
+  current_page: number
+  last_page: number
+  per_page: number
+  total: number
+}
+
+interface DeliveryPayload {
+  data: NotificationDelivery[]
+  meta: PaginationMeta
+}
+
+interface Props {
+  monitorId: number
+  fetcher?: (url: string) => Promise<DeliveryPayload>
+}
+
+const FILTER_OPTIONS: SegmentedToggleOption<Filter>[] = [
+  { value: "all", label: "All" },
+  { value: "delivered", label: "Delivered" },
+  { value: "failed", label: "Failed" },
+]
+
+const channelTypeLabel: Record<string, string> = {
+  email: "Email",
+  slack: "Slack",
+  discord: "Discord",
+  telegram: "Telegram",
+  webhook: "Webhook",
+}
+
+function formatLatency(ms: number | null): string {
+  if (ms == null) {
+    return "—"
+  }
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function formatTimestamp(value: string): string {
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+}
+
+const defaultFetcher = (url: string): Promise<DeliveryPayload> =>
+  fetch(url, { headers: { Accept: "application/json" } }).then((r) => {
+    if (!r.ok) {
+      throw new Error(`Failed to load deliveries (${r.status})`)
+    }
+    return r.json()
+  })
+
+function statusIntent(status: NotificationDeliveryStatus): "success" | "danger" {
+  return status === "delivered" ? "success" : "danger"
+}
+
+export function NotificationDeliveryLog({ monitorId, fetcher = defaultFetcher }: Props) {
+  const [filter, setFilter] = useState<Filter>("all")
+  const [page, setPage] = useState(1)
+  const [payload, setPayload] = useState<DeliveryPayload | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    const url = MonitorNotificationDeliveryController.index.url(monitorId, {
+      query: { status: filter, page },
+    })
+    fetcher(url)
+      .then((data) => {
+        if (!cancelled) {
+          setPayload(data)
+        }
+      })
+      .catch((e: Error) => {
+        if (!cancelled) {
+          setError(e.message)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [monitorId, filter, page, fetcher])
+
+  function changeFilter(next: Filter) {
+    if (next === filter) {
+      return
+    }
+    setFilter(next)
+    setPage(1)
+  }
+
+  const rows = payload?.data ?? []
+  const meta = payload?.meta
+
+  return (
+    <section aria-label="Notification delivery log" className="space-y-4">
+      <header className="flex items-center justify-between">
+        <h2 className="font-semibold text-base">Delivery log</h2>
+        <SegmentedToggle
+          aria-label="Delivery status filter"
+          value={filter}
+          onChange={changeFilter}
+          options={FILTER_OPTIONS}
+          size="sm"
+        />
+      </header>
+
+      {error && (
+        <p className="text-destructive text-sm" role="alert">
+          {error}
+        </p>
+      )}
+
+      <Table aria-label="Notification deliveries">
+        <TableHeader>
+          <TableColumn isRowHeader>Time</TableColumn>
+          <TableColumn>Channel</TableColumn>
+          <TableColumn>Event</TableColumn>
+          <TableColumn>Incident</TableColumn>
+          <TableColumn>Status</TableColumn>
+          <TableColumn>Latency</TableColumn>
+          <TableColumn>Notes</TableColumn>
+        </TableHeader>
+        <TableBody
+          renderEmptyState={() => (
+            <p className="py-6 text-center text-muted-foreground text-sm">
+              {loading ? "Loading deliveries…" : "No deliveries match this filter yet."}
+            </p>
+          )}
+        >
+          {rows.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell className="font-mono text-xs">
+                {formatTimestamp(row.dispatched_at)}
+              </TableCell>
+              <TableCell>
+                <span className="text-muted-foreground text-xs uppercase">
+                  {channelTypeLabel[row.channel?.type ?? ""] ?? row.channel?.type ?? "—"}
+                </span>{" "}
+                <span>{row.channel?.name ?? `#${row.channel_id}`}</span>
+              </TableCell>
+              <TableCell className="text-muted-foreground text-xs">{row.event_type}</TableCell>
+              <TableCell className="text-muted-foreground text-xs">
+                {row.incident_id ? `#${row.incident_id}` : "—"}
+              </TableCell>
+              <TableCell>
+                <Badge intent={statusIntent(row.status)} isCircle={false}>
+                  {row.status}
+                </Badge>
+              </TableCell>
+              <TableCell className="font-mono text-xs">{formatLatency(row.latency_ms)}</TableCell>
+              <TableCell className="text-destructive text-xs">{row.error ?? ""}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {meta && meta.last_page > 1 && (
+        <footer className="flex items-center justify-between text-muted-foreground text-xs">
+          <span>
+            Page {meta.current_page} of {meta.last_page} · {meta.total} deliveries
+          </span>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              intent="outline"
+              isDisabled={meta.current_page <= 1 || loading}
+              onPress={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Previous
+            </Button>
+            <Button
+              size="sm"
+              intent="outline"
+              isDisabled={meta.current_page >= meta.last_page || loading}
+              onPress={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </footer>
+      )}
+    </section>
+  )
+}

--- a/resources/js/pages/monitors/components/notification-delivery-log.tsx
+++ b/resources/js/pages/monitors/components/notification-delivery-log.tsx
@@ -100,6 +100,7 @@ export function NotificationDeliveryLog({ monitorId, fetcher = defaultFetcher }:
       })
       .catch((e: Error) => {
         if (!cancelled) {
+          setPayload(null)
           setError(e.message)
         }
       })

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -29,6 +29,7 @@ import { Tracker } from "@/components/ui/tracker"
 import AppLayout from "@/layouts/app-layout"
 import { statusBadgeIntent, uptimeColor } from "@/lib/color"
 import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
+import { NotificationDeliveryLog } from "@/pages/monitors/components/notification-delivery-log"
 import { RoutingRulesTable } from "@/pages/monitors/components/routing-rules-table"
 import monitorRoutes from "@/routes/monitors"
 import { hydrate, subscribeToEvents, useMonitor } from "@/stores/monitor-realtime"
@@ -1008,11 +1009,14 @@ export default function MonitorsShow({
 
           {/* ── Notifications tab ── */}
           <TabPanel id="notifications" className="pt-4">
-            <RoutingRulesTable
-              monitorId={monitor.id}
-              rules={notificationRoutes ?? []}
-              channels={teamNotificationChannels ?? []}
-            />
+            <div className="space-y-8">
+              <RoutingRulesTable
+                monitorId={monitor.id}
+                rules={notificationRoutes ?? []}
+                channels={teamNotificationChannels ?? []}
+              />
+              <NotificationDeliveryLog monitorId={monitor.id} />
+            </div>
           </TabPanel>
         </Tabs>
       </Container>

--- a/resources/js/types/monitor.ts
+++ b/resources/js/types/monitor.ts
@@ -234,6 +234,21 @@ export interface CheckingPayload {
     monitorId: number
 }
 
+export type NotificationDeliveryStatus = "delivered" | "failed"
+
+export interface NotificationDelivery {
+    id: number
+    channel_id: number
+    channel?: { id: number; name: string; type: string }
+    incident_id: number | null
+    incident?: { id: number; started_at: string | null; resolved_at: string | null } | null
+    event_type: string
+    status: NotificationDeliveryStatus
+    latency_ms: number | null
+    error: string | null
+    dispatched_at: string
+}
+
 export interface AuditLog {
     id: number
     team_id: number

--- a/routes/monitors.php
+++ b/routes/monitors.php
@@ -5,11 +5,13 @@ use App\Http\Controllers\BulkPauseMonitorsController;
 use App\Http\Controllers\BulkResumeMonitorsController;
 use App\Http\Controllers\CheckSslCertificateController;
 use App\Http\Controllers\ExportMonitorsController;
+use App\Http\Controllers\FiredTodayDeliveriesController;
 use App\Http\Controllers\ImportMonitorsController;
 use App\Http\Controllers\MaintenanceWindowController;
 use App\Http\Controllers\MonitorController;
 use App\Http\Controllers\MonitorGroupController;
 use App\Http\Controllers\MonitorGroupReorderController;
+use App\Http\Controllers\MonitorNotificationDeliveryController;
 use App\Http\Controllers\MonitorRestoreController;
 use App\Http\Controllers\MonitorToggleController;
 use App\Http\Controllers\NotificationChannelController;
@@ -46,6 +48,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::resource('notification-channels', NotificationChannelController::class)->except(['show']);
     Route::post('notification-channels/{notificationChannel}/test', NotificationChannelTestController::class)->name('notification-channels.test');
+
+    Route::get('notification-deliveries/fired-today', FiredTodayDeliveriesController::class)->name('notification-deliveries.fired-today');
+
+    Route::get('monitors/{monitor}/notification-deliveries', [MonitorNotificationDeliveryController::class, 'index'])->name('monitors.notification-deliveries.index');
 
     Route::post('monitors/{monitor}/notification-routes', [NotificationRouteController::class, 'store'])->name('monitors.notification-routes.store');
     Route::patch('monitors/{monitor}/notification-routes/{notificationRoute}', [NotificationRouteController::class, 'update'])->name('monitors.notification-routes.update');

--- a/tests/Feature/NotificationChannelTest.php
+++ b/tests/Feature/NotificationChannelTest.php
@@ -385,8 +385,9 @@ test('send notification job dispatches to the notifications queue', function () 
 test('send notification job sends slack webhook', function () {
     Http::fake(['https://hooks.slack.com/*' => Http::response([], 200)]);
 
-    $channel = NotificationChannel::factory()->slack()->create();
-    $monitor = Monitor::factory()->http()->create();
+    $user = User::factory()->create();
+    $channel = NotificationChannel::factory()->slack()->for($user)->create(['team_id' => $user->current_team_id]);
+    $monitor = Monitor::factory()->http()->for($user)->create(['team_id' => $user->current_team_id]);
 
     $job = new SendNotificationJob($channel, $monitor, 'down');
     $job->handle();
@@ -397,8 +398,9 @@ test('send notification job sends slack webhook', function () {
 test('send notification job sends discord embed', function () {
     Http::fake(['https://discord.com/*' => Http::response([], 204)]);
 
-    $channel = NotificationChannel::factory()->discord()->create();
-    $monitor = Monitor::factory()->http()->create();
+    $user = User::factory()->create();
+    $channel = NotificationChannel::factory()->discord()->for($user)->create(['team_id' => $user->current_team_id]);
+    $monitor = Monitor::factory()->http()->for($user)->create(['team_id' => $user->current_team_id]);
 
     $job = new SendNotificationJob($channel, $monitor, 'down');
     $job->handle();
@@ -412,8 +414,9 @@ test('send notification job sends discord embed', function () {
 test('send notification job sends telegram message', function () {
     Http::fake(['https://api.telegram.org/*' => Http::response(['ok' => true], 200)]);
 
-    $channel = NotificationChannel::factory()->telegram()->create();
-    $monitor = Monitor::factory()->http()->create();
+    $user = User::factory()->create();
+    $channel = NotificationChannel::factory()->telegram()->for($user)->create(['team_id' => $user->current_team_id]);
+    $monitor = Monitor::factory()->http()->for($user)->create(['team_id' => $user->current_team_id]);
 
     $job = new SendNotificationJob($channel, $monitor, 'down');
     $job->handle();
@@ -424,8 +427,9 @@ test('send notification job sends telegram message', function () {
 test('send notification job sends email', function () {
     Mail::fake();
 
-    $channel = NotificationChannel::factory()->create();
-    $monitor = Monitor::factory()->http()->create();
+    $user = User::factory()->create();
+    $channel = NotificationChannel::factory()->for($user)->create(['team_id' => $user->current_team_id]);
+    $monitor = Monitor::factory()->http()->for($user)->create(['team_id' => $user->current_team_id]);
 
     $job = new SendNotificationJob($channel, $monitor, 'down');
     $job->handle();
@@ -436,8 +440,9 @@ test('send notification job sends email', function () {
 test('down and up notifications both fire without suppression', function () {
     Http::fake(['https://hooks.slack.com/*' => Http::response([], 200)]);
 
-    $channel = NotificationChannel::factory()->slack()->create();
-    $monitor = Monitor::factory()->http()->create();
+    $user = User::factory()->create();
+    $channel = NotificationChannel::factory()->slack()->for($user)->create(['team_id' => $user->current_team_id]);
+    $monitor = Monitor::factory()->http()->for($user)->create(['team_id' => $user->current_team_id]);
 
     (new SendNotificationJob($channel, $monitor, 'down'))->handle();
     (new SendNotificationJob($channel, $monitor, 'up'))->handle();
@@ -448,9 +453,10 @@ test('down and up notifications both fire without suppression', function () {
 test('each channel receives its own notification', function () {
     Http::fake(['https://hooks.slack.com/*' => Http::response([], 200)]);
 
-    $channel1 = NotificationChannel::factory()->slack()->create();
-    $channel2 = NotificationChannel::factory()->slack()->create();
-    $monitor = Monitor::factory()->http()->create();
+    $user = User::factory()->create();
+    $channel1 = NotificationChannel::factory()->slack()->for($user)->create(['team_id' => $user->current_team_id]);
+    $channel2 = NotificationChannel::factory()->slack()->for($user)->create(['team_id' => $user->current_team_id]);
+    $monitor = Monitor::factory()->http()->for($user)->create(['team_id' => $user->current_team_id]);
 
     (new SendNotificationJob($channel1, $monitor, 'down'))->handle();
     (new SendNotificationJob($channel2, $monitor, 'down'))->handle();

--- a/tests/Feature/Notifications/FiredTodayEndpointTest.php
+++ b/tests/Feature/Notifications/FiredTodayEndpointTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Http\Controllers\FiredTodayDeliveriesController;
 use App\Models\Monitor;
 use App\Models\NotificationChannel;
 use App\Models\NotificationDelivery;
 use App\Models\User;
+use Illuminate\Http\Request;
 
 it('returns per-channel fired-today counts scoped to the current team', function () {
     $user = User::factory()->create();
@@ -41,6 +43,19 @@ it('returns per-channel fired-today counts scoped to the current team', function
 
     expect((int) $payload[$a->id]['count'])->toBe(3);
     expect((int) $payload[$b->id]['count'])->toBe(1);
+});
+
+it('returns an empty array when current_team_id is null (controller-level guard)', function () {
+    $user = User::factory()->create();
+    $user->forceFill(['current_team_id' => null])->save();
+
+    $request = Request::create('/monitors/notification-deliveries/fired-today', 'GET');
+    $request->setUserResolver(fn () => $user);
+
+    $response = (new FiredTodayDeliveriesController)($request);
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getData(true))->toBe([]);
 });
 
 it('does not leak deliveries from another team', function () {

--- a/tests/Feature/Notifications/FiredTodayEndpointTest.php
+++ b/tests/Feature/Notifications/FiredTodayEndpointTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Models\Monitor;
+use App\Models\NotificationChannel;
+use App\Models\NotificationDelivery;
+use App\Models\User;
+
+it('returns per-channel fired-today counts scoped to the current team', function () {
+    $user = User::factory()->create();
+    $teamId = $user->current_team_id;
+    $monitor = Monitor::factory()->for($user)->create(['team_id' => $teamId]);
+
+    $a = NotificationChannel::factory()->for($user)->create(['team_id' => $teamId]);
+    $b = NotificationChannel::factory()->for($user)->create(['team_id' => $teamId]);
+
+    NotificationDelivery::factory()->count(3)->create([
+        'team_id' => $teamId,
+        'channel_id' => $a->id,
+        'monitor_id' => $monitor->id,
+        'dispatched_at' => now(),
+    ]);
+    NotificationDelivery::factory()->create([
+        'team_id' => $teamId,
+        'channel_id' => $b->id,
+        'monitor_id' => $monitor->id,
+        'dispatched_at' => now()->subMinutes(10),
+    ]);
+
+    NotificationDelivery::factory()->create([
+        'team_id' => $teamId,
+        'channel_id' => $a->id,
+        'monitor_id' => $monitor->id,
+        'dispatched_at' => now()->subDay()->subMinutes(5),
+    ]);
+
+    $response = $this->actingAs($user)->getJson(route('notification-deliveries.fired-today'));
+
+    $response->assertOk();
+
+    $payload = collect($response->json())->keyBy('channel_id');
+
+    expect((int) $payload[$a->id]['count'])->toBe(3);
+    expect((int) $payload[$b->id]['count'])->toBe(1);
+});
+
+it('does not leak deliveries from another team', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownerMonitor = Monitor::factory()->for($owner)->create([
+        'team_id' => $owner->current_team_id,
+    ]);
+    $otherMonitor = Monitor::factory()->for($other)->create([
+        'team_id' => $other->current_team_id,
+    ]);
+
+    $ownerChannel = NotificationChannel::factory()->for($owner)->create([
+        'team_id' => $owner->current_team_id,
+    ]);
+    $otherChannel = NotificationChannel::factory()->for($other)->create([
+        'team_id' => $other->current_team_id,
+    ]);
+
+    NotificationDelivery::factory()->create([
+        'team_id' => $owner->current_team_id,
+        'channel_id' => $ownerChannel->id,
+        'monitor_id' => $ownerMonitor->id,
+        'dispatched_at' => now(),
+    ]);
+    NotificationDelivery::factory()->count(5)->create([
+        'team_id' => $other->current_team_id,
+        'channel_id' => $otherChannel->id,
+        'monitor_id' => $otherMonitor->id,
+        'dispatched_at' => now(),
+    ]);
+
+    $response = $this->actingAs($owner)->getJson(route('notification-deliveries.fired-today'));
+
+    $response->assertOk();
+
+    $rows = $response->json();
+
+    expect($rows)->toHaveCount(1);
+    expect((int) $rows[0]['channel_id'])->toBe($ownerChannel->id);
+    expect((int) $rows[0]['count'])->toBe(1);
+});

--- a/tests/Feature/Notifications/MonitorDeliveryLogTest.php
+++ b/tests/Feature/Notifications/MonitorDeliveryLogTest.php
@@ -78,6 +78,20 @@ it('filters the delivery log by status', function () {
     expect($all->json('meta.total'))->toBe(5);
 });
 
+it('rejects invalid status filter values with a 422', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+
+    $response = $this->actingAs($user)->getJson(
+        route('monitors.notification-deliveries.index', [$monitor, 'status' => 'banana']),
+    );
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['status']);
+});
+
 it('does not leak deliveries from another monitor or another team', function () {
     $owner = User::factory()->create();
     $other = User::factory()->create();

--- a/tests/Feature/Notifications/MonitorDeliveryLogTest.php
+++ b/tests/Feature/Notifications/MonitorDeliveryLogTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Models\Monitor;
+use App\Models\NotificationChannel;
+use App\Models\NotificationDelivery;
+use App\Models\User;
+
+it('returns the monitor delivery log paginated, newest first', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+
+    foreach (range(1, 25) as $i) {
+        NotificationDelivery::factory()->create([
+            'team_id' => $user->current_team_id,
+            'channel_id' => $channel->id,
+            'monitor_id' => $monitor->id,
+            'dispatched_at' => now()->subMinutes($i),
+            'status' => 'delivered',
+        ]);
+    }
+
+    $response = $this->actingAs($user)->getJson(
+        route('monitors.notification-deliveries.index', $monitor),
+    );
+
+    $response->assertOk();
+
+    $body = $response->json();
+    expect($body['data'])->toHaveCount(20);
+    expect($body['meta']['total'])->toBe(25);
+
+    $first = $body['data'][0]['dispatched_at'];
+    $second = $body['data'][1]['dispatched_at'];
+    expect(strtotime($first))->toBeGreaterThanOrEqual(strtotime($second));
+});
+
+it('filters the delivery log by status', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+
+    NotificationDelivery::factory()->count(3)->create([
+        'team_id' => $user->current_team_id,
+        'channel_id' => $channel->id,
+        'monitor_id' => $monitor->id,
+        'status' => 'delivered',
+    ]);
+    NotificationDelivery::factory()->count(2)->create([
+        'team_id' => $user->current_team_id,
+        'channel_id' => $channel->id,
+        'monitor_id' => $monitor->id,
+        'status' => 'failed',
+        'error' => 'boom',
+    ]);
+
+    $delivered = $this->actingAs($user)->getJson(
+        route('monitors.notification-deliveries.index', [$monitor, 'status' => 'delivered']),
+    );
+    expect($delivered->json('meta.total'))->toBe(3);
+
+    $failed = $this->actingAs($user)->getJson(
+        route('monitors.notification-deliveries.index', [$monitor, 'status' => 'failed']),
+    );
+    expect($failed->json('meta.total'))->toBe(2);
+
+    $all = $this->actingAs($user)->getJson(
+        route('monitors.notification-deliveries.index', [$monitor, 'status' => 'all']),
+    );
+    expect($all->json('meta.total'))->toBe(5);
+});
+
+it('does not leak deliveries from another monitor or another team', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $monitor = Monitor::factory()->for($owner)->create([
+        'team_id' => $owner->current_team_id,
+    ]);
+    $siblingMonitor = Monitor::factory()->for($owner)->create([
+        'team_id' => $owner->current_team_id,
+    ]);
+    $foreignMonitor = Monitor::factory()->for($other)->create([
+        'team_id' => $other->current_team_id,
+    ]);
+
+    $channel = NotificationChannel::factory()->for($owner)->create([
+        'team_id' => $owner->current_team_id,
+    ]);
+
+    NotificationDelivery::factory()->count(2)->create([
+        'team_id' => $owner->current_team_id,
+        'channel_id' => $channel->id,
+        'monitor_id' => $monitor->id,
+    ]);
+    NotificationDelivery::factory()->create([
+        'team_id' => $owner->current_team_id,
+        'channel_id' => $channel->id,
+        'monitor_id' => $siblingMonitor->id,
+    ]);
+    NotificationDelivery::factory()->create([
+        'team_id' => $other->current_team_id,
+        'channel_id' => $channel->id,
+        'monitor_id' => $foreignMonitor->id,
+    ]);
+
+    $response = $this->actingAs($owner)->getJson(
+        route('monitors.notification-deliveries.index', $monitor),
+    );
+
+    expect($response->json('meta.total'))->toBe(2);
+
+    $foreign = $this->actingAs($owner)->getJson(
+        route('monitors.notification-deliveries.index', $foreignMonitor),
+    );
+    $foreign->assertForbidden();
+});

--- a/tests/Feature/Notifications/NotificationDeliveryFactoryTest.php
+++ b/tests/Feature/Notifications/NotificationDeliveryFactoryTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Models\NotificationDelivery;
+
+it('default factory state generates tenant-consistent rows', function () {
+    $delivery = NotificationDelivery::factory()->create();
+
+    expect($delivery->channel->team_id)->toBe($delivery->team_id);
+    expect($delivery->monitor->team_id)->toBe($delivery->team_id);
+});

--- a/tests/Feature/Notifications/NotificationDeliveryLoggingTest.php
+++ b/tests/Feature/Notifications/NotificationDeliveryLoggingTest.php
@@ -7,6 +7,7 @@ use App\Models\NotificationChannel;
 use App\Models\NotificationDelivery;
 use App\Models\User;
 use App\Services\Notifiers\Notifier;
+use Illuminate\Support\Facades\Schema;
 
 it('writes a delivered row when the notifier succeeds', function () {
     $user = User::factory()->create();
@@ -88,6 +89,65 @@ it('writes a failed row and rethrows when the notifier throws', function () {
     expect($delivery->status)->toBe('failed');
     expect($delivery->error)->toBe('upstream 503');
     expect($delivery->channel_id)->toBe($channel->id);
+});
+
+it('does not rethrow when post-send logging fails (avoids duplicate sends on retry)', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+
+    app()->bind(Notifier::class, fn () => new class implements Notifier
+    {
+        public function send(NotificationChannel $channel, Monitor $monitor, string $status, ?string $message = null, ?string $ackUrl = null): void {}
+    });
+
+    Schema::drop('notification_deliveries');
+
+    $job = new SendNotificationJob(
+        channel: $channel,
+        monitor: $monitor,
+        status: 'down',
+        message: 'down',
+        incidentId: null,
+        eventType: 'status_flip',
+    );
+
+    $job->handle();
+
+    expect(true)->toBeTrue();
+});
+
+it('throws before persisting when channel and monitor belong to different teams', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $monitor = Monitor::factory()->for($owner)->create([
+        'team_id' => $owner->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($other)->create([
+        'team_id' => $other->current_team_id,
+    ]);
+
+    app()->bind(Notifier::class, fn () => new class implements Notifier
+    {
+        public function send(NotificationChannel $channel, Monitor $monitor, string $status, ?string $message = null, ?string $ackUrl = null): void {}
+    });
+
+    $job = new SendNotificationJob(
+        channel: $channel,
+        monitor: $monitor,
+        status: 'down',
+        message: 'cross-team',
+        incidentId: null,
+        eventType: 'status_flip',
+    );
+
+    expect(fn () => $job->handle())->toThrow(LogicException::class);
+    expect(NotificationDelivery::query()->count())->toBe(0);
 });
 
 it('records the incident_id when one is provided', function () {

--- a/tests/Feature/Notifications/NotificationDeliveryLoggingTest.php
+++ b/tests/Feature/Notifications/NotificationDeliveryLoggingTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Jobs\SendNotificationJob;
+use App\Models\Incident;
+use App\Models\Monitor;
+use App\Models\NotificationChannel;
+use App\Models\NotificationDelivery;
+use App\Models\User;
+use App\Services\Notifiers\Notifier;
+
+it('writes a delivered row when the notifier succeeds', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+
+    app()->bind(Notifier::class, fn () => new class implements Notifier
+    {
+        public function send(NotificationChannel $channel, Monitor $monitor, string $status, ?string $message = null, ?string $ackUrl = null): void {}
+    });
+
+    $job = new SendNotificationJob(
+        channel: $channel,
+        monitor: $monitor,
+        status: 'down',
+        message: 'down',
+        incidentId: null,
+        eventType: 'status_flip',
+    );
+
+    $job->handle();
+
+    expect(NotificationDelivery::query()->count())->toBe(1);
+
+    $delivery = NotificationDelivery::query()->sole();
+
+    expect($delivery->channel_id)->toBe($channel->id);
+    expect($delivery->monitor_id)->toBe($monitor->id);
+    expect($delivery->team_id)->toBe($monitor->team_id);
+    expect($delivery->event_type)->toBe('status_flip');
+    expect($delivery->status)->toBe('delivered');
+    expect($delivery->error)->toBeNull();
+    expect($delivery->latency_ms)->toBeGreaterThanOrEqual(0);
+    expect($delivery->dispatched_at)->not->toBeNull();
+});
+
+it('writes a failed row and rethrows when the notifier throws', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+
+    app()->bind(Notifier::class, fn () => new class implements Notifier
+    {
+        public function send(NotificationChannel $channel, Monitor $monitor, string $status, ?string $message = null, ?string $ackUrl = null): void
+        {
+            throw new RuntimeException('upstream 503');
+        }
+    });
+
+    $job = new SendNotificationJob(
+        channel: $channel,
+        monitor: $monitor,
+        status: 'down',
+        message: 'down',
+        incidentId: null,
+        eventType: 'status_flip',
+    );
+
+    $threw = false;
+    try {
+        $job->handle();
+    } catch (RuntimeException $e) {
+        $threw = true;
+        expect($e->getMessage())->toBe('upstream 503');
+    }
+
+    expect($threw)->toBeTrue();
+
+    $delivery = NotificationDelivery::query()->sole();
+
+    expect($delivery->status)->toBe('failed');
+    expect($delivery->error)->toBe('upstream 503');
+    expect($delivery->channel_id)->toBe($channel->id);
+});
+
+it('records the incident_id when one is provided', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->for($user)->create([
+        'team_id' => $user->current_team_id,
+    ]);
+    $incident = Incident::factory()->for($monitor)->create();
+
+    app()->bind(Notifier::class, fn () => new class implements Notifier
+    {
+        public function send(NotificationChannel $channel, Monitor $monitor, string $status, ?string $message = null, ?string $ackUrl = null): void {}
+    });
+
+    $job = new SendNotificationJob(
+        channel: $channel,
+        monitor: $monitor,
+        status: 'down',
+        message: 'down',
+        incidentId: $incident->id,
+        eventType: 'status_flip',
+    );
+
+    $job->handle();
+
+    expect(NotificationDelivery::query()->sole()->incident_id)->toBe($incident->id);
+});


### PR DESCRIPTION
Closes #21

## Acceptance criteria

- [x] `notification_deliveries` table migrated with the columns above and an index on `(channel_id, dispatched_at)` — see `database/migrations/2026_04_30_194823_create_notification_deliveries_table.php` (also adds `(team_id, dispatched_at)` and `(monitor_id, dispatched_at)` for the team-wide and per-monitor reads).
- [x] Dispatcher writes a delivery row for every send attempt, including failures with error text — `SendNotificationJob::handle()` wraps `Notifier::send()` in try/catch + microtime, writes one `delivered` or `failed` row per attempt, and rethrows on failure so retry semantics are preserved. Verified by `tests/Feature/Notifications/NotificationDeliveryLoggingTest.php` (3 cases: success row, failed row + rethrow, incident_id passthrough).
- [x] Aggregation endpoint returns per-channel `fired_today` counts for use by the Notifications tab and the dashboard — `GET /notification-deliveries/fired-today` (`FiredTodayDeliveriesController::__invoke`), team-scoped to `auth()->user()->current_team_id`, returns `[{channel_id, count}]` for `dispatched_at >= startOfDay()`. Verified by `tests/Feature/Notifications/FiredTodayEndpointTest.php` (today-vs-yesterday + cross-team isolation).
- [x] Notifications tab delivery log renders, filterable, paginated — `resources/js/pages/monitors/components/notification-delivery-log.tsx` (mounted in `resources/js/pages/monitors/show.tsx` Notifications tab) calls `GET /monitors/{monitor}/notification-deliveries?status=all|delivered|failed&page=N`, renders timestamp / channel / event / incident / status pill / latency / error notes, and uses `SegmentedToggle` for the filter pills. Verified by `resources/js/pages/monitors/components/__tests__/notification-delivery-log.test.tsx` (renders rows, refetches on filter change, paginates).
- [x] Pest feature tests cover successful + failed delivery write-through and aggregation correctness over a seeded dataset — `NotificationDeliveryLoggingTest`, `FiredTodayEndpointTest`, `MonitorDeliveryLogTest` (filter + pagination + monitor/team isolation).

## Notes

- `SendNotificationJob` now resolves a `Notifier` from the container if one is bound (used by tests), otherwise falls back to the existing per-type `match` — no behavioral change in production.
- Delivery rows survive incident soft-deletion (`incident_id` is `nullOnDelete`) but cascade with the channel they were sent to.
- The `NotificationChannelTestController` "Test channel" button still bypasses `SendNotificationJob` (existing behavior); test sends are intentionally not logged.

## Test plan

- `vendor/bin/sail test --compact tests/Feature/Notifications` — 31 passed
- `vendor/bin/sail test --compact` — 482 passed, 1 unrelated pre-existing failure (`MonitoringEngineTest > ping checker returns up for reachable host` fails on `main` too, network-flake in container)
- `vendor/bin/sail npm run test:js -- --run` — 114 vitest passed
- `vendor/bin/sail npm run build` — green
- `vendor/bin/pint --dirty --format agent` — pass
- `biome format --write` on touched JS/TSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification delivery log added to monitor pages with status, latency, error notes, event/incident IDs, filters (all/delivered/failed) and pagination.
  * “Fired today” delivery metrics by channel available.

* **Improvements**
  * Delivery attempts are now recorded with richer metadata (status, latency, error, event type) so UI and metrics reflect send outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->