### PR TITLE
Sail dev stack missing dev:fake-servers fleet (ports 9001-9020)

### DIFF
--- a/.env.example.sail
+++ b/.env.example.sail
@@ -93,3 +93,10 @@ WWWGROUP=1000
 # Host port forwarded by the laravel.test container.
 APP_PORT=80
 SAIL_XDEBUG_MODE=off
+
+# --- Dev fake-server fleet (ports 9001-9020) ---
+# In the Sail stack the fleet runs as the `fake-servers` service. Other compose services
+# (queue) reach it via the `fake-servers` hostname. On host (composer run dev), unset both
+# so seeded URLs use 127.0.0.1 and the command binds to loopback.
+FAKE_SERVERS_HOST=fake-servers
+FAKE_SERVERS_BIND_HOST=0.0.0.0

--- a/app/Console/Commands/DevFakeServersCommand.php
+++ b/app/Console/Commands/DevFakeServersCommand.php
@@ -118,6 +118,15 @@ class DevFakeServersCommand extends Command
         return $registry;
     }
 
+    /**
+     * Interface to bind fake-servers to. 127.0.0.1 on host (default); 0.0.0.0 inside Sail
+     * so other compose services (queue) can resolve `fake-servers:{port}` over the network.
+     */
+    public static function bindHost(): string
+    {
+        return (string) config('services.fake_servers.bind_host', '127.0.0.1');
+    }
+
     public function handle(): int
     {
         if (! app()->environment('local')) {
@@ -134,6 +143,7 @@ class DevFakeServersCommand extends Command
         }
 
         $stream = $this->output->isVerbose();
+        $bindHost = self::bindHost();
 
         /** @var array<int, Process> $processes */
         $processes = [];
@@ -151,7 +161,7 @@ class DevFakeServersCommand extends Command
             }
 
             $process = new Process(
-                [PHP_BINARY, '-S', "127.0.0.1:{$port}", $router],
+                [PHP_BINARY, '-S', "{$bindHost}:{$port}", $router],
                 base_path(),
                 ['FAKE_SERVER_PROFILE' => json_encode($profile)],
             );
@@ -167,7 +177,7 @@ class DevFakeServersCommand extends Command
             }
 
             $processes[$port] = $process;
-            $this->line("fake-server up on 127.0.0.1:{$port} ({$profile['kind']})");
+            $this->line("fake-server up on {$bindHost}:{$port} ({$profile['kind']})");
         }
 
         $this->registerSignalHandlers($processes);

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,9 @@ return [
         ],
     ],
 
+    'fake_servers' => [
+        'host' => env('FAKE_SERVERS_HOST', '127.0.0.1'),
+        'bind_host' => env('FAKE_SERVERS_BIND_HOST', '127.0.0.1'),
+    ],
+
 ];

--- a/database/seeders/MonitorSeeder.php
+++ b/database/seeders/MonitorSeeder.php
@@ -236,6 +236,8 @@ class MonitorSeeder extends Seeder
             'timeout' => 'Request exceeded monitor timeout',
         ];
 
+        $fakeServerHost = config('services.fake_servers.host', '127.0.0.1');
+
         foreach (DevFakeServersCommand::profileRegistry() as $port => $profile) {
             $isPersistentDown = in_array($profile['kind'], $persistentDownKinds, true);
 
@@ -243,7 +245,7 @@ class MonitorSeeder extends Seeder
                 ...$base,
                 'name' => $profile['name'],
                 'type' => 'http',
-                'url' => "http://127.0.0.1:{$port}",
+                'url' => "http://{$fakeServerHost}:{$port}",
                 'method' => 'GET',
                 'interval' => $profile['interval'],
                 'accepted_status_codes' => [200],

--- a/docker-compose.sail.yml
+++ b/docker-compose.sail.yml
@@ -97,6 +97,27 @@ services:
             pgsql:
                 condition: service_healthy
         restart: unless-stopped
+    fake-servers:
+        image: sail-8.4/app
+        command:
+            - php
+            - artisan
+            - 'dev:fake-servers'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            APP_ENV: local
+            FAKE_SERVERS_BIND_HOST: 0.0.0.0
+        ports:
+            - '9001-9020:9001-9020'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            laravel.test:
+                condition: service_started
+        restart: unless-stopped
     pgsql:
         image: 'postgres:18-alpine'
         ports:

--- a/tests/Feature/MonitorSeederTest.php
+++ b/tests/Feature/MonitorSeederTest.php
@@ -16,8 +16,10 @@ beforeEach(function () {
 test('seeder registers one local monitor per registry port', function () {
     (new MonitorSeeder)->run();
 
+    $host = config('services.fake_servers.host');
+
     foreach (DevFakeServersCommand::profileRegistry() as $port => $profile) {
-        $monitor = Monitor::where('url', "http://127.0.0.1:{$port}")->first();
+        $monitor = Monitor::where('url', "http://{$host}:{$port}")->first();
 
         expect($monitor)->not->toBeNull();
         expect($monitor->name)->toBe($profile['name']);
@@ -30,10 +32,11 @@ test('seeder registers one local monitor per registry port', function () {
 test('persistent-down profiles get one open incident; flap profiles get none', function () {
     (new MonitorSeeder)->run();
 
+    $host = config('services.fake_servers.host');
     $persistentDownKinds = ['down_500', 'unbound', 'timeout'];
 
     foreach (DevFakeServersCommand::profileRegistry() as $port => $profile) {
-        $monitor = Monitor::where('url', "http://127.0.0.1:{$port}")->firstOrFail();
+        $monitor = Monitor::where('url', "http://{$host}:{$port}")->firstOrFail();
         $openIncidents = Incident::where('monitor_id', $monitor->id)->whereNull('resolved_at')->count();
 
         if (in_array($profile['kind'], $persistentDownKinds, true)) {
@@ -56,8 +59,36 @@ test('seeder retains the two HTTPS demo monitors for SSL coverage', function () 
 test('seeder produces 20 local fake-server monitors and 35 total', function () {
     (new MonitorSeeder)->run();
 
-    $local = Monitor::where('url', 'like', 'http://127.0.0.1:%')->count();
+    $host = config('services.fake_servers.host');
+    $local = Monitor::where('url', 'like', "http://{$host}:%")->count();
 
     expect($local)->toBe(20);
     expect(Monitor::count())->toBe(35);
+});
+
+test('seeder uses configured services.fake_servers.host for local monitor URLs', function () {
+    config(['services.fake_servers.host' => 'fake-servers']);
+
+    (new MonitorSeeder)->run();
+
+    expect(Monitor::where('url', 'http://fake-servers:9001')->exists())->toBeTrue();
+    expect(Monitor::where('url', 'like', 'http://127.0.0.1:%')->exists())->toBeFalse();
+});
+
+test('default fake-servers host is 127.0.0.1 so composer run dev path is preserved', function () {
+    expect(config('services.fake_servers.host'))->toBe('127.0.0.1');
+});
+
+test('default fake-servers bind host is 127.0.0.1', function () {
+    expect(config('services.fake_servers.bind_host'))->toBe('127.0.0.1');
+});
+
+test('DevFakeServersCommand bind host reflects services.fake_servers.bind_host config', function () {
+    config(['services.fake_servers.bind_host' => '0.0.0.0']);
+
+    expect(DevFakeServersCommand::bindHost())->toBe('0.0.0.0');
+
+    config(['services.fake_servers.bind_host' => '127.0.0.1']);
+
+    expect(DevFakeServersCommand::bindHost())->toBe('127.0.0.1');
 });


### PR DESCRIPTION
Closes #50

## Summary

- Add a `fake-servers` service to `docker-compose.sail.yml` that runs `php artisan dev:fake-servers` inside the existing `sail-8.4/app` image and exposes ports 9001-9020 to the host.
- Make the seeded monitor URL host configurable via `services.fake_servers.host` (default `127.0.0.1`). The Sail env template sets it to `fake-servers` so the `queue` container resolves the fleet over docker DNS.
- Make the `php -S` bind interface configurable via `services.fake_servers.bind_host` (default `127.0.0.1`). Sail env sets it to `0.0.0.0` so the fleet is reachable from sibling containers.
- `composer run dev` path is preserved: `.env.example` (host template) declares no fake-server vars, so the defaults (`127.0.0.1`/`127.0.0.1`) apply.

## Acceptance

- [x] `sail up -d` brings the fake-server fleet online — covered by the new `fake-servers` compose service which runs `php artisan dev:fake-servers` and forwards 9001-9020 to host (`docker compose -f docker-compose.sail.yml config --services` lists the service).
- [x] Seeded monitors show the expected status mix on a fresh `./bin/build_sail.sh --fresh` — `MonitorSeeder` now reads `config('services.fake_servers.host')`; `.env.example.sail` sets it to `fake-servers`. Verified by `tests/Feature/MonitorSeederTest.php::seeder uses configured services.fake_servers.host for local monitor URLs`.
- [x] No regression to `composer run dev` path — host `.env.example` remains unchanged (no `FAKE_SERVERS_*` keys), so `services.fake_servers.host` defaults to `127.0.0.1`. Verified by `tests/Feature/MonitorSeederTest.php::default fake-servers host is 127.0.0.1` and the existing seeder tests which still pass against the default host.

## Test plan

- [x] `vendor/bin/sail test --compact` — 479 passed
- [x] `vendor/bin/sail npm run test:js -- --run` — 111 passed
- [x] `vendor/bin/sail npm run build` — green
- [x] `vendor/bin/pint --dirty --format agent` — pass
- [x] `docker compose -f docker-compose.sail.yml config --services` — fake-servers listed alongside existing services

🤖 Generated with [Claude Code](https://claude.com/claude-code)