### PR TITLE
13. Escalation policies (schema + EscalationEngine + periodic job + UI timeline)

### DIFF
--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -6,6 +6,9 @@ use App\Http\Requests\StoreMonitorRequest;
 use App\Http\Requests\UpdateMonitorRequest;
 use App\Http\Resources\HeartbeatResource;
 use App\Jobs\CheckSslCertificateJob;
+use App\Models\EscalationFire;
+use App\Models\EscalationPolicy;
+use App\Models\Incident;
 use App\Models\Monitor;
 use App\Models\MonitorGroup;
 use App\Models\NotificationChannel;
@@ -159,10 +162,15 @@ class MonitorController extends Controller
             ->orderBy('id')
             ->get();
 
+        $escalationPolicy = $this->resolveEscalationPolicy($monitor);
+        $activeEscalation = $this->resolveActiveEscalation($monitor);
+
         return inertia('monitors/show', [
             'monitor' => $monitor,
             'teamNotificationChannels' => $teamChannels,
             'notificationRoutes' => $notificationRoutes,
+            'escalationPolicy' => $escalationPolicy,
+            'activeEscalation' => $activeEscalation,
             'chartPeriod' => $period,
             'sslCertificate' => Inertia::defer(
                 fn () => $monitor->sslCertificate
@@ -215,6 +223,54 @@ class MonitorController extends Controller
         }
 
         return $heartbeats;
+    }
+
+    private function resolveEscalationPolicy(Monitor $monitor): ?EscalationPolicy
+    {
+        $policy = EscalationPolicy::query()
+            ->where('is_active', true)
+            ->where('monitor_id', $monitor->id)
+            ->with('steps')
+            ->first();
+
+        if ($policy !== null) {
+            return $policy;
+        }
+
+        return EscalationPolicy::query()
+            ->where('is_active', true)
+            ->whereNull('monitor_id')
+            ->where('team_id', $monitor->team_id)
+            ->with('steps')
+            ->first();
+    }
+
+    /**
+     * @return array{incident_id: int, fired_step_ids: array<int>}|null
+     */
+    private function resolveActiveEscalation(Monitor $monitor): ?array
+    {
+        $incident = Incident::query()
+            ->where('monitor_id', $monitor->id)
+            ->whereNull('resolved_at')
+            ->whereNull('acked_at')
+            ->latest('started_at')
+            ->first();
+
+        if ($incident === null) {
+            return null;
+        }
+
+        $firedStepIds = EscalationFire::query()
+            ->where('incident_id', $incident->id)
+            ->pluck('escalation_step_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        return [
+            'incident_id' => $incident->id,
+            'fired_step_ids' => $firedStepIds,
+        ];
     }
 
     /**

--- a/app/Jobs/RunEscalationsJob.php
+++ b/app/Jobs/RunEscalationsJob.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\EscalationFire;
+use App\Models\EscalationPolicy;
+use App\Models\Incident;
+use App\Models\NotificationChannel;
+use App\Services\EscalationContext;
+use App\Services\EscalationEngine;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+
+class RunEscalationsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        $incidents = Incident::query()
+            ->unacked()
+            ->whereNull('resolved_at')
+            ->with('monitor')
+            ->get();
+
+        if ($incidents->isEmpty()) {
+            return;
+        }
+
+        $contexts = [];
+        $engine = new EscalationEngine(now()->toDateTimeImmutable());
+
+        foreach ($incidents as $incident) {
+            if ($incident->monitor === null) {
+                continue;
+            }
+
+            $policy = $this->resolvePolicy($incident);
+
+            if ($policy === null) {
+                continue;
+            }
+
+            $firedStepIds = EscalationFire::query()
+                ->where('incident_id', $incident->id)
+                ->pluck('escalation_step_id')
+                ->all();
+
+            $contexts[] = new EscalationContext($incident, $policy, $firedStepIds);
+        }
+
+        $dispatches = $engine->tick($contexts);
+
+        foreach ($dispatches as $dispatch) {
+            $this->fireDispatch($dispatch->incident, $dispatch->step);
+        }
+    }
+
+    private function resolvePolicy(Incident $incident): ?EscalationPolicy
+    {
+        $monitor = $incident->monitor;
+
+        $policy = EscalationPolicy::query()
+            ->where('is_active', true)
+            ->where('monitor_id', $monitor->id)
+            ->with('steps')
+            ->first();
+
+        if ($policy !== null) {
+            return $policy;
+        }
+
+        return EscalationPolicy::query()
+            ->where('is_active', true)
+            ->whereNull('monitor_id')
+            ->where('team_id', $monitor->team_id)
+            ->with('steps')
+            ->first();
+    }
+
+    private function fireDispatch(Incident $incident, $step): void
+    {
+        $inserted = DB::table('escalation_fires')->insertOrIgnore([
+            'incident_id' => $incident->id,
+            'escalation_step_id' => $step->id,
+            'fired_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        if ($inserted === 0) {
+            return;
+        }
+
+        $monitor = $incident->monitor;
+        $channelIds = array_map('intval', $step->channel_ids ?? []);
+
+        if ($channelIds === []) {
+            return;
+        }
+
+        $channels = NotificationChannel::query()
+            ->whereIn('id', $channelIds)
+            ->where('team_id', $monitor->team_id)
+            ->where('is_enabled', true)
+            ->get();
+
+        foreach ($channels as $channel) {
+            SendNotificationJob::dispatch(
+                $channel,
+                $monitor,
+                $monitor->status,
+                $incident->cause,
+                $incident->id,
+                'escalation',
+            )->onQueue('notifications');
+        }
+    }
+}

--- a/app/Models/EscalationFire.php
+++ b/app/Models/EscalationFire.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EscalationFireFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EscalationFire extends Model
+{
+    /** @use HasFactory<EscalationFireFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'incident_id',
+        'escalation_step_id',
+        'fired_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'fired_at' => 'datetime',
+        ];
+    }
+
+    public function incident(): BelongsTo
+    {
+        return $this->belongsTo(Incident::class);
+    }
+
+    public function step(): BelongsTo
+    {
+        return $this->belongsTo(EscalationStep::class, 'escalation_step_id');
+    }
+}

--- a/app/Models/EscalationPolicy.php
+++ b/app/Models/EscalationPolicy.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EscalationPolicyFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class EscalationPolicy extends Model
+{
+    /** @use HasFactory<EscalationPolicyFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id',
+        'monitor_id',
+        'name',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function monitor(): BelongsTo
+    {
+        return $this->belongsTo(Monitor::class);
+    }
+
+    public function steps(): HasMany
+    {
+        return $this->hasMany(EscalationStep::class)->orderBy('order');
+    }
+}

--- a/app/Models/EscalationStep.php
+++ b/app/Models/EscalationStep.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EscalationStepFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EscalationStep extends Model
+{
+    /** @use HasFactory<EscalationStepFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'escalation_policy_id',
+        'order',
+        'delay_minutes',
+        'channel_ids',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'channel_ids' => 'array',
+            'order' => 'integer',
+            'delay_minutes' => 'integer',
+        ];
+    }
+
+    public function policy(): BelongsTo
+    {
+        return $this->belongsTo(EscalationPolicy::class, 'escalation_policy_id');
+    }
+}

--- a/app/Services/EscalationContext.php
+++ b/app/Services/EscalationContext.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EscalationPolicy;
+use App\Models\Incident;
+
+final class EscalationContext
+{
+    /**
+     * @param  array<int>  $alreadyFiredStepIds  Step IDs already persisted in escalation_fires for this incident
+     */
+    public function __construct(
+        public Incident $incident,
+        public EscalationPolicy $policy,
+        public array $alreadyFiredStepIds = [],
+    ) {}
+}

--- a/app/Services/EscalationDispatch.php
+++ b/app/Services/EscalationDispatch.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EscalationStep;
+use App\Models\Incident;
+
+final class EscalationDispatch
+{
+    public function __construct(
+        public Incident $incident,
+        public EscalationStep $step,
+    ) {}
+}

--- a/app/Services/EscalationEngine.php
+++ b/app/Services/EscalationEngine.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+
+final class EscalationEngine
+{
+    private DateTimeInterface $now;
+
+    public function __construct(?DateTimeInterface $now = null)
+    {
+        $this->now = $now ?? new DateTimeImmutable;
+    }
+
+    /**
+     * Decide which (incident, step) pairs should fire at the engine's "now".
+     *
+     * Side-effect-free: no DB writes, no jobs dispatched, no broadcasts.
+     *
+     * @param  iterable<EscalationContext>  $contexts
+     * @return array<EscalationDispatch>
+     */
+    public function tick(iterable $contexts): array
+    {
+        $dispatches = [];
+        $nowTs = $this->now->getTimestamp();
+
+        foreach ($contexts as $context) {
+            $incident = $context->incident;
+
+            if ($incident->acked_at !== null || $incident->resolved_at !== null) {
+                continue;
+            }
+
+            if ($incident->started_at === null) {
+                continue;
+            }
+
+            $startedTs = $incident->started_at->getTimestamp();
+            $alreadyFired = array_flip($context->alreadyFiredStepIds);
+
+            $orderedSteps = collect($context->policy->steps)->sortBy('order')->values();
+
+            foreach ($orderedSteps as $step) {
+                $fireAt = $startedTs + ($step->delay_minutes * 60);
+
+                if ($fireAt > $nowTs) {
+                    break;
+                }
+
+                if (isset($alreadyFired[$step->id])) {
+                    continue;
+                }
+
+                $dispatches[] = new EscalationDispatch($incident, $step);
+            }
+        }
+
+        return $dispatches;
+    }
+}

--- a/database/factories/EscalationFireFactory.php
+++ b/database/factories/EscalationFireFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EscalationFire;
+use App\Models\EscalationStep;
+use App\Models\Incident;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EscalationFire>
+ */
+class EscalationFireFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'incident_id' => Incident::factory(),
+            'escalation_step_id' => EscalationStep::factory(),
+            'fired_at' => now(),
+        ];
+    }
+}

--- a/database/factories/EscalationPolicyFactory.php
+++ b/database/factories/EscalationPolicyFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EscalationPolicy;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EscalationPolicy>
+ */
+class EscalationPolicyFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'monitor_id' => null,
+            'name' => fake()->words(3, true),
+            'is_active' => true,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn () => ['is_active' => false]);
+    }
+}

--- a/database/factories/EscalationStepFactory.php
+++ b/database/factories/EscalationStepFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EscalationPolicy;
+use App\Models\EscalationStep;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EscalationStep>
+ */
+class EscalationStepFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'escalation_policy_id' => EscalationPolicy::factory(),
+            'order' => 1,
+            'delay_minutes' => 0,
+            'channel_ids' => [],
+        ];
+    }
+}

--- a/database/migrations/2026_04_30_202430_create_escalation_policies_table.php
+++ b/database/migrations/2026_04_30_202430_create_escalation_policies_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('escalation_policies', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('monitor_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['team_id', 'is_active']);
+            $table->index(['monitor_id', 'is_active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('escalation_policies');
+    }
+};

--- a/database/migrations/2026_04_30_202431_create_escalation_steps_table.php
+++ b/database/migrations/2026_04_30_202431_create_escalation_steps_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('escalation_steps', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('escalation_policy_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('order');
+            $table->unsignedInteger('delay_minutes');
+            $table->json('channel_ids');
+            $table->timestamps();
+
+            $table->unique(['escalation_policy_id', 'order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('escalation_steps');
+    }
+};

--- a/database/migrations/2026_04_30_202432_create_escalation_fires_table.php
+++ b/database/migrations/2026_04_30_202432_create_escalation_fires_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('escalation_fires', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('incident_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('escalation_step_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('fired_at');
+            $table->timestamps();
+
+            $table->unique(['incident_id', 'escalation_step_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('escalation_fires');
+    }
+};

--- a/resources/js/pages/monitors/components/__tests__/escalation-timeline.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/escalation-timeline.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { EscalationTimeline } from "@/pages/monitors/components/escalation-timeline"
+import type { EscalationPolicy, NotificationChannel } from "@/types/monitor"
+
+const channels: NotificationChannel[] = [
+  {
+    id: 1,
+    user_id: 1,
+    team_id: 1,
+    name: "Team Email",
+    type: "email",
+    is_enabled: true,
+    created_at: "2026-04-30T00:00:00Z",
+    updated_at: "2026-04-30T00:00:00Z",
+  },
+  {
+    id: 2,
+    user_id: 1,
+    team_id: 1,
+    name: "Slack #alerts",
+    type: "slack",
+    is_enabled: true,
+    created_at: "2026-04-30T00:00:00Z",
+    updated_at: "2026-04-30T00:00:00Z",
+  },
+]
+
+const policy: EscalationPolicy = {
+  id: 5,
+  team_id: 1,
+  monitor_id: 7,
+  name: "Critical incidents",
+  is_active: true,
+  created_at: "2026-04-30T00:00:00Z",
+  updated_at: "2026-04-30T00:00:00Z",
+  steps: [
+    {
+      id: 50,
+      escalation_policy_id: 5,
+      order: 1,
+      delay_minutes: 0,
+      channel_ids: [1],
+      created_at: "",
+      updated_at: "",
+    },
+    {
+      id: 51,
+      escalation_policy_id: 5,
+      order: 2,
+      delay_minutes: 15,
+      channel_ids: [2],
+      created_at: "",
+      updated_at: "",
+    },
+  ],
+}
+
+afterEach(() => cleanup())
+
+describe("EscalationTimeline", () => {
+  it("renders steps with delay labels and channel chips", () => {
+    render(<EscalationTimeline policy={policy} channels={channels} active={null} />)
+
+    expect(screen.getByText(/\+0m/)).toBeInTheDocument()
+    expect(screen.getByText(/\+15m/)).toBeInTheDocument()
+    expect(screen.getByText("Team Email")).toBeInTheDocument()
+    expect(screen.getByText("Slack #alerts")).toBeInTheDocument()
+  })
+
+  it("highlights the active step from the activeEscalation payload", () => {
+    render(
+      <EscalationTimeline
+        policy={policy}
+        channels={channels}
+        active={{ incident_id: 123, fired_step_ids: [50] }}
+      />,
+    )
+
+    const step1 = screen.getByTestId("escalation-step-50")
+    const step2 = screen.getByTestId("escalation-step-51")
+    expect(step2.getAttribute("data-active")).toBe("true")
+    expect(step1.getAttribute("data-active")).toBe("false")
+  })
+
+  it("renders an empty state when no policy is provided", () => {
+    render(<EscalationTimeline policy={null} channels={channels} active={null} />)
+
+    expect(screen.getByTestId("escalation-empty")).toBeInTheDocument()
+  })
+})

--- a/resources/js/pages/monitors/components/escalation-timeline.tsx
+++ b/resources/js/pages/monitors/components/escalation-timeline.tsx
@@ -1,0 +1,123 @@
+import type {
+  ActiveEscalation,
+  EscalationPolicy,
+  EscalationStep,
+  NotificationChannel,
+} from "@/types/monitor"
+
+interface Props {
+  policy: EscalationPolicy | null
+  channels: NotificationChannel[]
+  active: ActiveEscalation | null
+}
+
+function formatDelay(minutes: number): string {
+  if (minutes === 0) return "+0m"
+  if (minutes < 60) return `+${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const rem = minutes % 60
+  return rem === 0 ? `+${hours}h` : `+${hours}h${rem}m`
+}
+
+function pickActiveStepId(steps: EscalationStep[], active: ActiveEscalation | null): number | null {
+  if (steps.length === 0) return null
+  if (!active || active.fired_step_ids.length === 0) {
+    return steps[0]?.id ?? null
+  }
+
+  const firedSet = new Set(active.fired_step_ids)
+  const ordered = [...steps].sort((a, b) => a.order - b.order)
+  const nextUnfired = ordered.find((s) => !firedSet.has(s.id))
+  if (nextUnfired) return nextUnfired.id
+
+  return ordered[ordered.length - 1]?.id ?? null
+}
+
+function channelLabel(channel: NotificationChannel | undefined, id: number): string {
+  if (!channel) return `#${id}`
+  return channel.name || channel.type
+}
+
+export function EscalationTimeline({ policy, channels, active }: Props) {
+  if (!policy || !policy.steps || policy.steps.length === 0) {
+    return (
+      <div
+        data-testid="escalation-empty"
+        className="rounded-lg border border-border px-4 py-6 text-muted-foreground text-sm"
+      >
+        No escalation policy. Add steps to escalate unacked incidents through additional channels.
+      </div>
+    )
+  }
+
+  const channelById = new Map(channels.map((c) => [c.id, c]))
+  const orderedSteps = [...policy.steps].sort((a, b) => a.order - b.order)
+  const activeStepId = pickActiveStepId(orderedSteps, active)
+
+  return (
+    <div data-testid="escalation-timeline" className="rounded-lg border border-border">
+      <div className="flex items-center justify-between border-border border-b px-4 py-3">
+        <div>
+          <p className="font-semibold text-foreground text-sm">{policy.name}</p>
+          <p className="mt-1 text-muted-foreground text-xs">
+            Escalation policy · {orderedSteps.length} step{orderedSteps.length === 1 ? "" : "s"}
+          </p>
+        </div>
+      </div>
+
+      <ol className="px-4 py-4">
+        {orderedSteps.map((step, index) => {
+          const isActive = step.id === activeStepId
+          const isLast = index === orderedSteps.length - 1
+          return (
+            <li
+              key={step.id}
+              data-testid={`escalation-step-${step.id}`}
+              data-active={isActive ? "true" : "false"}
+              className="grid grid-cols-[5rem_1.5rem_1fr] gap-3 pb-4 last:pb-0"
+            >
+              <div className="text-right">
+                <p
+                  className={`font-mono text-xs ${isActive ? "text-foreground" : "text-muted-foreground"}`}
+                >
+                  {formatDelay(step.delay_minutes)}
+                </p>
+                <p className="mt-0.5 text-[10px] text-muted-foreground uppercase tracking-wide">
+                  step {step.order}
+                </p>
+              </div>
+
+              <div className="relative flex justify-center">
+                <span
+                  className={`mt-1 size-2.5 rounded-full ring-2 ${
+                    isActive ? "bg-primary ring-primary-subtle" : "bg-muted-foreground ring-border"
+                  }`}
+                  aria-hidden
+                />
+                {!isLast && (
+                  <span className="absolute top-4 bottom-[-1rem] w-px bg-border" aria-hidden />
+                )}
+              </div>
+
+              <div className={`min-w-0 ${isActive ? "" : "opacity-80"}`}>
+                <div className="flex flex-wrap gap-1.5">
+                  {(step.channel_ids ?? []).map((id) => (
+                    <span
+                      key={id}
+                      className="rounded-sm border border-border bg-primary-subtle px-2 py-0.5 text-foreground text-xs"
+                    >
+                      {channelLabel(channelById.get(id), id)}
+                    </span>
+                  ))}
+                  {(!step.channel_ids || step.channel_ids.length === 0) && (
+                    <span className="text-muted-foreground text-xs">No channels</span>
+                  )}
+                </div>
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -29,11 +29,14 @@ import { Tracker } from "@/components/ui/tracker"
 import AppLayout from "@/layouts/app-layout"
 import { statusBadgeIntent, uptimeColor } from "@/lib/color"
 import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
+import { EscalationTimeline } from "@/pages/monitors/components/escalation-timeline"
 import { RoutingRulesTable } from "@/pages/monitors/components/routing-rules-table"
 import monitorRoutes from "@/routes/monitors"
 import { hydrate, subscribeToEvents, useMonitor } from "@/stores/monitor-realtime"
 import type {
+  ActiveEscalation,
   ChartDataPoint,
+  EscalationPolicy,
   Heartbeat,
   Incident,
   Monitor,
@@ -69,6 +72,8 @@ interface Props {
   chartPeriod?: string
   teamNotificationChannels?: NotificationChannel[]
   notificationRoutes?: NotificationRoute[]
+  escalationPolicy?: EscalationPolicy | null
+  activeEscalation?: ActiveEscalation | null
 }
 
 function formatDuration(start: string, end: string | null): string {
@@ -134,6 +139,8 @@ export default function MonitorsShow({
   chartPeriod: initialChartPeriod,
   teamNotificationChannels,
   notificationRoutes,
+  escalationPolicy,
+  activeEscalation,
 }: Props) {
   useEffect(() => {
     const seed: Monitor = {
@@ -1008,11 +1015,18 @@ export default function MonitorsShow({
 
           {/* ── Notifications tab ── */}
           <TabPanel id="notifications" className="pt-4">
-            <RoutingRulesTable
-              monitorId={monitor.id}
-              rules={notificationRoutes ?? []}
-              channels={teamNotificationChannels ?? []}
-            />
+            <div className="space-y-8">
+              <RoutingRulesTable
+                monitorId={monitor.id}
+                rules={notificationRoutes ?? []}
+                channels={teamNotificationChannels ?? []}
+              />
+              <EscalationTimeline
+                policy={escalationPolicy ?? null}
+                channels={teamNotificationChannels ?? []}
+                active={activeEscalation ?? null}
+              />
+            </div>
           </TabPanel>
         </Tabs>
       </Container>

--- a/resources/js/types/monitor.ts
+++ b/resources/js/types/monitor.ts
@@ -113,6 +113,32 @@ export interface Incident {
     updated_at: string
 }
 
+export interface EscalationStep {
+    id: number
+    escalation_policy_id: number
+    order: number
+    delay_minutes: number
+    channel_ids: number[]
+    created_at: string
+    updated_at: string
+}
+
+export interface EscalationPolicy {
+    id: number
+    team_id: number
+    monitor_id: number | null
+    name: string
+    is_active: boolean
+    created_at: string
+    updated_at: string
+    steps: EscalationStep[]
+}
+
+export interface ActiveEscalation {
+    incident_id: number
+    fired_step_ids: number[]
+}
+
 export interface SslCertificate {
     id: number
     monitor_id: number

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\RunEscalationsJob;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
@@ -10,3 +11,4 @@ Artisan::command('inspire', function () {
 
 Schedule::command('monitors:check')->everyMinute();
 Schedule::command('monitors:check-ssl')->hourly();
+Schedule::job(new RunEscalationsJob)->everyMinute()->withoutOverlapping();

--- a/tests/Feature/Monitors/MonitorShowEscalationTest.php
+++ b/tests/Feature/Monitors/MonitorShowEscalationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Models\EscalationFire;
+use App\Models\EscalationPolicy;
+use App\Models\EscalationStep;
+use App\Models\Incident;
+use App\Models\Monitor;
+use App\Models\NotificationChannel;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('passes a monitor-specific escalation policy with steps to the show view', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+
+    $policy = EscalationPolicy::factory()->create([
+        'team_id' => $user->current_team_id,
+        'monitor_id' => $monitor->id,
+        'name' => 'Critical incidents',
+    ]);
+    EscalationStep::factory()->create([
+        'escalation_policy_id' => $policy->id,
+        'order' => 1,
+        'delay_minutes' => 0,
+        'channel_ids' => [$channel->id],
+    ]);
+    EscalationStep::factory()->create([
+        'escalation_policy_id' => $policy->id,
+        'order' => 2,
+        'delay_minutes' => 15,
+        'channel_ids' => [$channel->id],
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.show', $monitor))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('monitors/show')
+            ->has('escalationPolicy.steps', 2)
+            ->where('escalationPolicy.name', 'Critical incidents')
+            ->where('escalationPolicy.steps.0.order', 1)
+            ->where('escalationPolicy.steps.1.delay_minutes', 15)
+        );
+});
+
+it('falls back to a team-wide policy when no monitor policy exists', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+
+    $policy = EscalationPolicy::factory()->create([
+        'team_id' => $user->current_team_id,
+        'monitor_id' => null,
+        'name' => 'Team default',
+    ]);
+    EscalationStep::factory()->create([
+        'escalation_policy_id' => $policy->id,
+        'order' => 1,
+        'delay_minutes' => 0,
+        'channel_ids' => [],
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.show', $monitor))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('escalationPolicy.name', 'Team default')
+        );
+});
+
+it('exposes activeEscalation with fired step ids when an incident is in flight', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+
+    $policy = EscalationPolicy::factory()->create([
+        'team_id' => $user->current_team_id,
+        'monitor_id' => $monitor->id,
+    ]);
+    $step = EscalationStep::factory()->create([
+        'escalation_policy_id' => $policy->id,
+        'order' => 1,
+        'delay_minutes' => 0,
+        'channel_ids' => [],
+    ]);
+
+    $incident = Incident::factory()->create([
+        'monitor_id' => $monitor->id,
+        'started_at' => now()->subMinutes(5),
+        'resolved_at' => null,
+        'acked_at' => null,
+    ]);
+    EscalationFire::factory()->create([
+        'incident_id' => $incident->id,
+        'escalation_step_id' => $step->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.show', $monitor))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('activeEscalation.incident_id', $incident->id)
+            ->where('activeEscalation.fired_step_ids', [$step->id])
+        );
+});
+
+it('null escalation props when no policy', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.show', $monitor))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('escalationPolicy', null)
+            ->where('activeEscalation', null)
+        );
+});

--- a/tests/Feature/Notifications/EscalationEngineTest.php
+++ b/tests/Feature/Notifications/EscalationEngineTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\EscalationPolicy;
+use App\Models\EscalationStep;
+use App\Models\Incident;
+use App\Models\Monitor;
+use App\Models\User;
+use App\Services\EscalationContext;
+use App\Services\EscalationEngine;
+
+function makeIncidentForTeamMonitor(array $overrides = []): Incident
+{
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+
+    return Incident::factory()->create(array_merge([
+        'monitor_id' => $monitor->id,
+        'started_at' => now()->subMinutes(30),
+        'resolved_at' => null,
+        'acked_at' => null,
+    ], $overrides));
+}
+
+function makePolicyWithSteps(Incident $incident, array $stepDelays): EscalationPolicy
+{
+    $policy = EscalationPolicy::factory()->create([
+        'team_id' => $incident->monitor->team_id,
+        'monitor_id' => $incident->monitor_id,
+    ]);
+
+    foreach ($stepDelays as $i => $delay) {
+        EscalationStep::factory()->create([
+            'escalation_policy_id' => $policy->id,
+            'order' => $i + 1,
+            'delay_minutes' => $delay,
+            'channel_ids' => [],
+        ]);
+    }
+
+    return $policy->fresh(['steps']);
+}
+
+it('fires step 1 immediately when delay is zero', function () {
+    $incident = makeIncidentForTeamMonitor(['started_at' => now()]);
+    $policy = makePolicyWithSteps($incident, [0]);
+
+    $dispatches = (new EscalationEngine(now()))->tick([
+        new EscalationContext($incident, $policy, []),
+    ]);
+
+    expect($dispatches)->toHaveCount(1)
+        ->and($dispatches[0]->step->order)->toBe(1);
+});
+
+it('does not fire step 2 before its delay elapses', function () {
+    $incident = makeIncidentForTeamMonitor(['started_at' => now()]);
+    $policy = makePolicyWithSteps($incident, [0, 15]);
+
+    $dispatches = (new EscalationEngine(now()->addMinutes(5)))->tick([
+        new EscalationContext($incident, $policy, []),
+    ]);
+
+    expect(collect($dispatches)->pluck('step.order')->all())->toBe([1]);
+});
+
+it('fires step 2 once its delay has elapsed', function () {
+    $incident = makeIncidentForTeamMonitor(['started_at' => now()]);
+    $policy = makePolicyWithSteps($incident, [0, 15]);
+
+    $dispatches = (new EscalationEngine(now()->addMinutes(20)))->tick([
+        new EscalationContext($incident, $policy, []),
+    ]);
+
+    expect(collect($dispatches)->pluck('step.order')->all())->toBe([1, 2]);
+});
+
+it('does not return steps already in alreadyFiredStepIds', function () {
+    $incident = makeIncidentForTeamMonitor(['started_at' => now()]);
+    $policy = makePolicyWithSteps($incident, [0, 15]);
+    $alreadyFiredId = $policy->steps[0]->id;
+
+    $dispatches = (new EscalationEngine(now()->addMinutes(20)))->tick([
+        new EscalationContext($incident, $policy, [$alreadyFiredId]),
+    ]);
+
+    expect(collect($dispatches)->pluck('step.order')->all())->toBe([2]);
+});
+
+it('returns no dispatches for an acked incident', function () {
+    $incident = makeIncidentForTeamMonitor([
+        'started_at' => now(),
+        'acked_at' => now(),
+    ]);
+    $policy = makePolicyWithSteps($incident, [0]);
+
+    $dispatches = (new EscalationEngine(now()))->tick([
+        new EscalationContext($incident, $policy, []),
+    ]);
+
+    expect($dispatches)->toBeEmpty();
+});
+
+it('returns no dispatches for a resolved incident', function () {
+    $incident = makeIncidentForTeamMonitor([
+        'started_at' => now(),
+        'resolved_at' => now(),
+    ]);
+    $policy = makePolicyWithSteps($incident, [0]);
+
+    $dispatches = (new EscalationEngine(now()))->tick([
+        new EscalationContext($incident, $policy, []),
+    ]);
+
+    expect($dispatches)->toBeEmpty();
+});
+
+it('fires multiple due steps in order in one tick', function () {
+    $incident = makeIncidentForTeamMonitor(['started_at' => now()]);
+    $policy = makePolicyWithSteps($incident, [0, 5, 10]);
+
+    $dispatches = (new EscalationEngine(now()->addMinutes(11)))->tick([
+        new EscalationContext($incident, $policy, []),
+    ]);
+
+    expect(collect($dispatches)->pluck('step.order')->all())->toBe([1, 2, 3]);
+});

--- a/tests/Feature/Notifications/RunEscalationsJobTest.php
+++ b/tests/Feature/Notifications/RunEscalationsJobTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Jobs\RunEscalationsJob;
+use App\Jobs\SendNotificationJob;
+use App\Models\EscalationFire;
+use App\Models\EscalationPolicy;
+use App\Models\EscalationStep;
+use App\Models\Incident;
+use App\Models\Monitor;
+use App\Models\NotificationChannel;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+
+function setUpTeamMonitorIncident(): array
+{
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+    ]);
+    $incident = Incident::factory()->create([
+        'monitor_id' => $monitor->id,
+        'started_at' => now()->subMinutes(20),
+        'resolved_at' => null,
+        'acked_at' => null,
+    ]);
+
+    return compact('user', 'monitor', 'incident', 'channel');
+}
+
+function setUpMonitorPolicy(int $monitorId, int $teamId, int $channelId, array $delays = [0, 15]): EscalationPolicy
+{
+    $policy = EscalationPolicy::factory()->create([
+        'team_id' => $teamId,
+        'monitor_id' => $monitorId,
+    ]);
+    foreach ($delays as $i => $delay) {
+        EscalationStep::factory()->create([
+            'escalation_policy_id' => $policy->id,
+            'order' => $i + 1,
+            'delay_minutes' => $delay,
+            'channel_ids' => [$channelId],
+        ]);
+    }
+
+    return $policy;
+}
+
+it('dispatches a SendNotificationJob for each due step channel', function () {
+    Bus::fake();
+    $ctx = setUpTeamMonitorIncident();
+    setUpMonitorPolicy($ctx['monitor']->id, $ctx['monitor']->team_id, $ctx['channel']->id, [0, 15]);
+
+    (new RunEscalationsJob)->handle();
+
+    Bus::assertDispatchedTimes(SendNotificationJob::class, 2);
+    expect(EscalationFire::count())->toBe(2);
+});
+
+it('is idempotent across repeated runs', function () {
+    Bus::fake();
+    $ctx = setUpTeamMonitorIncident();
+    setUpMonitorPolicy($ctx['monitor']->id, $ctx['monitor']->team_id, $ctx['channel']->id, [0, 15]);
+
+    (new RunEscalationsJob)->handle();
+    (new RunEscalationsJob)->handle();
+    (new RunEscalationsJob)->handle();
+
+    Bus::assertDispatchedTimes(SendNotificationJob::class, 2);
+    expect(EscalationFire::count())->toBe(2);
+});
+
+it('does not dispatch for an acked incident', function () {
+    Bus::fake();
+    $ctx = setUpTeamMonitorIncident();
+    $ctx['incident']->update(['acked_at' => now()]);
+    setUpMonitorPolicy($ctx['monitor']->id, $ctx['monitor']->team_id, $ctx['channel']->id, [0, 15]);
+
+    (new RunEscalationsJob)->handle();
+
+    Bus::assertNothingDispatched();
+    expect(EscalationFire::count())->toBe(0);
+});
+
+it('does not dispatch for a resolved incident', function () {
+    Bus::fake();
+    $ctx = setUpTeamMonitorIncident();
+    $ctx['incident']->update(['resolved_at' => now()]);
+    setUpMonitorPolicy($ctx['monitor']->id, $ctx['monitor']->team_id, $ctx['channel']->id, [0, 15]);
+
+    (new RunEscalationsJob)->handle();
+
+    Bus::assertNothingDispatched();
+});
+
+it('prefers a monitor-specific policy over a team-wide policy', function () {
+    Bus::fake();
+    $ctx = setUpTeamMonitorIncident();
+    $teamChannel = NotificationChannel::factory()->create([
+        'user_id' => $ctx['user']->id,
+        'team_id' => $ctx['user']->current_team_id,
+    ]);
+
+    $teamPolicy = EscalationPolicy::factory()->create([
+        'team_id' => $ctx['user']->current_team_id,
+        'monitor_id' => null,
+    ]);
+    EscalationStep::factory()->create([
+        'escalation_policy_id' => $teamPolicy->id,
+        'order' => 1,
+        'delay_minutes' => 0,
+        'channel_ids' => [$teamChannel->id],
+    ]);
+
+    setUpMonitorPolicy($ctx['monitor']->id, $ctx['monitor']->team_id, $ctx['channel']->id, [0]);
+
+    (new RunEscalationsJob)->handle();
+
+    Bus::assertDispatchedTimes(SendNotificationJob::class, 1);
+    Bus::assertDispatched(SendNotificationJob::class, fn ($job) => $job->channel->id === $ctx['channel']->id);
+});
+
+it('falls back to a team-wide policy when no monitor policy exists', function () {
+    Bus::fake();
+    $ctx = setUpTeamMonitorIncident();
+    $teamPolicy = EscalationPolicy::factory()->create([
+        'team_id' => $ctx['user']->current_team_id,
+        'monitor_id' => null,
+    ]);
+    EscalationStep::factory()->create([
+        'escalation_policy_id' => $teamPolicy->id,
+        'order' => 1,
+        'delay_minutes' => 0,
+        'channel_ids' => [$ctx['channel']->id],
+    ]);
+
+    (new RunEscalationsJob)->handle();
+
+    Bus::assertDispatchedTimes(SendNotificationJob::class, 1);
+});


### PR DESCRIPTION
Closes #22.

## Acceptance criteria

- [x] `escalation_policies` and `escalation_steps` tables migrated
  - `database/migrations/2026_04_30_202430_create_escalation_policies_table.php`
  - `database/migrations/2026_04_30_202431_create_escalation_steps_table.php`
  - Plus `escalation_fires` (idempotency ledger) at `2026_04_30_202432_create_escalation_fires_table.php`
- [x] `EscalationEngine` is a deep, idempotent module returning dispatch actions for elapsed steps
  - `app/Services/EscalationEngine.php` — pure `tick(iterable<EscalationContext>): array<EscalationDispatch>`; no DB writes / jobs / broadcasts
  - Tests: `tests/Feature/Notifications/EscalationEngineTest.php` covers step 1 immediate, step 2 delayed, idempotency via `alreadyFiredStepIds`, multiple due steps, acked/resolved guards
- [x] Periodic background job runs every minute and dispatches via the existing notification dispatcher
  - `app/Jobs/RunEscalationsJob.php` + `Schedule::job(new RunEscalationsJob)->everyMinute()->withoutOverlapping();` in `routes/console.php`
  - Atomic gate: `escalation_fires` has `unique(incident_id, escalation_step_id)`; job uses `insertOrIgnore` and only dispatches `SendNotificationJob` when the row was inserted
- [x] Engine respects ack state — acked incidents stop escalating
  - Engine returns no dispatches for `acked_at !== null`; job query filters with `unacked()` scope
  - Test: `it does not dispatch for an acked incident` in `RunEscalationsJobTest`
- [x] Notifications tab escalation timeline renders the policy with the active step highlighted
  - `resources/js/pages/monitors/components/escalation-timeline.tsx` wired into `monitors/show` Notifications tab
  - Active = next unfired step when an active unacked incident exists, else step 1
  - Vitest: `escalation-timeline.test.tsx` covers labels, active highlight, empty state
  - Backend props: `MonitorController::show` exposes `escalationPolicy` (with steps) + `activeEscalation` (incident_id + fired_step_ids); covered by `MonitorShowEscalationTest`
- [x] Pest feature tests cover step 1 immediate, step 2 delayed, ack stops escalation, idempotency under repeated job runs
  - All in `EscalationEngineTest` + `RunEscalationsJobTest` (idempotency: 3× run → 2 fire rows + 2 dispatches)

## Notes

- Escalation steps carry their own `channel_ids` per the PRD — they do **not** flow through `NotificationRouter` (router is for status-flip events). `SendNotificationJob` is dispatched directly with `eventType='escalation'` so the existing `notification_deliveries` log captures each fire.
- Snooze action mentioned in the issue narrative is **not** implemented — no backend exists for it and it is not in the AC checklist; deferred to a future issue. Active incidents still surface their existing one-click ack URL via the existing `incidents.ack` signed route from #17.
- Monitor-specific policies are preferred over team-wide policies (`monitor_id IS NULL`).

## Test plan

- [x] `vendor/bin/sail test --compact` — only the 2 pre-existing `MonitorSeederTest` fake-servers config failures remain (unrelated to this change; verified by stashing the diff and re-running)
- [x] `npm run test:js -- --run` — 22 files, 114 tests passing
- [x] `npm run build` — green
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `npx biome format --write` on touched JS/TSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)