### PR TITLE
6. Phase timings + Response tab (curl handler + 5 columns + full Response tab UI)

### DIFF
--- a/app/DTOs/CheckResult.php
+++ b/app/DTOs/CheckResult.php
@@ -9,5 +9,21 @@ class CheckResult
         public int $responseTime, // ms
         public ?int $statusCode = null,
         public ?string $message = null,
+        public ?int $phaseDnsMs = null,
+        public ?int $phaseTcpMs = null,
+        public ?int $phaseTlsMs = null,
+        public ?int $phaseTtfbMs = null,
+        public ?int $phaseTransferMs = null,
     ) {}
+
+    public function withTiming(PhaseTiming $timing): self
+    {
+        $this->phaseDnsMs = $timing->phaseDnsMs;
+        $this->phaseTcpMs = $timing->phaseTcpMs;
+        $this->phaseTlsMs = $timing->phaseTlsMs;
+        $this->phaseTtfbMs = $timing->phaseTtfbMs;
+        $this->phaseTransferMs = $timing->phaseTransferMs;
+
+        return $this;
+    }
 }

--- a/app/DTOs/PhaseCaptureResult.php
+++ b/app/DTOs/PhaseCaptureResult.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\DTOs;
+
+final class PhaseCaptureResult
+{
+    /**
+     * @param  array<string, array<int, string>|string>  $headers
+     */
+    public function __construct(
+        public PhaseTiming $timing,
+        public ?int $statusCode,
+        public int $totalMs,
+        public ?string $body = null,
+        public array $headers = [],
+        public ?string $error = null,
+    ) {}
+}

--- a/app/DTOs/PhaseTiming.php
+++ b/app/DTOs/PhaseTiming.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\DTOs;
+
+final class PhaseTiming
+{
+    public function __construct(
+        public ?int $phaseDnsMs = null,
+        public ?int $phaseTcpMs = null,
+        public ?int $phaseTlsMs = null,
+        public ?int $phaseTtfbMs = null,
+        public ?int $phaseTransferMs = null,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self;
+    }
+
+    /**
+     * @return array{phase_dns_ms: ?int, phase_tcp_ms: ?int, phase_tls_ms: ?int, phase_ttfb_ms: ?int, phase_transfer_ms: ?int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'phase_dns_ms' => $this->phaseDnsMs,
+            'phase_tcp_ms' => $this->phaseTcpMs,
+            'phase_tls_ms' => $this->phaseTlsMs,
+            'phase_ttfb_ms' => $this->phaseTtfbMs,
+            'phase_transfer_ms' => $this->phaseTransferMs,
+        ];
+    }
+}

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -185,20 +185,40 @@ class MonitorController extends Controller
                 fn () => $monitor->incidents()->latest('started_at')->get()
             ),
             'chartData' => Inertia::defer(fn () => $this->getChartData($monitor, $period, $cutoff)),
+            'prevChartData' => Inertia::defer(function () use ($monitor, $period, $cutoff) {
+                $previousCutoff = $this->previousCutoffFor($period, $cutoff);
+
+                return $this->getChartData($monitor, $period, $previousCutoff, $cutoff);
+            }),
             'uptimeStats' => Inertia::defer(fn () => $monitor->uptimeStats()),
         ]);
+    }
+
+    private function previousCutoffFor(string $period, Carbon $cutoff): Carbon
+    {
+        return match ($period) {
+            '1h' => $cutoff->copy()->subHour(),
+            '7d' => $cutoff->copy()->subDays(7),
+            '30d' => $cutoff->copy()->subDays(30),
+            default => $cutoff->copy()->subHours(24),
+        };
     }
 
     /**
      * Get chart data for a monitor, aggregated by period.
      */
-    private function getChartData(Monitor $monitor, string $period, Carbon $cutoff): Collection
+    private function getChartData(Monitor $monitor, string $period, Carbon $cutoff, ?Carbon $until = null): Collection
     {
-        $heartbeats = $monitor->heartbeats()
+        $query = $monitor->heartbeats()
             ->where('created_at', '>=', $cutoff)
             ->whereNotNull('response_time')
-            ->oldest('created_at')
-            ->get(['created_at', 'response_time', 'status']);
+            ->oldest('created_at');
+
+        if ($until !== null) {
+            $query->where('created_at', '<', $until);
+        }
+
+        $heartbeats = $query->get(['created_at', 'response_time', 'status']);
 
         if ($period === '7d') {
             return $heartbeats

--- a/app/Http/Controllers/MonitorPhaseTimingsController.php
+++ b/app/Http/Controllers/MonitorPhaseTimingsController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\MonitorPhaseTimingsRequest;
+use App\Models\Monitor;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+
+class MonitorPhaseTimingsController extends Controller
+{
+    private const PHASE_COLUMNS = [
+        'dns' => 'phase_dns_ms',
+        'tcp' => 'phase_tcp_ms',
+        'tls' => 'phase_tls_ms',
+        'ttfb' => 'phase_ttfb_ms',
+        'transfer' => 'phase_transfer_ms',
+    ];
+
+    public function __invoke(MonitorPhaseTimingsRequest $request, Monitor $monitor): JsonResponse
+    {
+        $this->authorize('view', $monitor);
+
+        $period = $request->validated('period', '24h');
+        $cutoff = $this->cutoffFor($period);
+
+        $rows = $monitor->heartbeats()
+            ->where('created_at', '>=', $cutoff)
+            ->select(array_values(self::PHASE_COLUMNS))
+            ->get();
+
+        $count = $rows->count();
+        $phases = [];
+
+        foreach (self::PHASE_COLUMNS as $key => $column) {
+            $values = $rows->pluck($column)
+                ->filter(fn ($v) => $v !== null)
+                ->map(fn ($v) => (int) $v)
+                ->values()
+                ->all();
+
+            $phases[$key] = [
+                'avg' => $this->avg($values),
+                'p95' => $this->percentile($values, 0.95),
+                'count' => count($values),
+            ];
+        }
+
+        return response()->json([
+            'period' => $period,
+            'count' => $count,
+            'phases' => $phases,
+        ]);
+    }
+
+    private function cutoffFor(string $period): Carbon
+    {
+        return match ($period) {
+            '1h' => now()->subHour(),
+            '7d' => now()->subDays(7),
+            '30d' => now()->subDays(30),
+            default => now()->subHours(24),
+        };
+    }
+
+    /**
+     * @param  array<int>  $values
+     */
+    private function avg(array $values): ?int
+    {
+        if ($values === []) {
+            return null;
+        }
+
+        return (int) round(array_sum($values) / count($values));
+    }
+
+    /**
+     * @param  array<int>  $values
+     */
+    private function percentile(array $values, float $p): ?int
+    {
+        if ($values === []) {
+            return null;
+        }
+
+        sort($values);
+        $index = (int) min(count($values) - 1, max(0, floor($p * count($values))));
+
+        return $values[$index];
+    }
+}

--- a/app/Http/Requests/MonitorPhaseTimingsRequest.php
+++ b/app/Http/Requests/MonitorPhaseTimingsRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class MonitorPhaseTimingsRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'period' => ['nullable', 'string', 'in:1h,24h,7d,30d'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'period.in' => 'The period must be one of 1h, 24h, 7d, 30d.',
+        ];
+    }
+}

--- a/app/Http/Resources/HeartbeatResource.php
+++ b/app/Http/Resources/HeartbeatResource.php
@@ -20,6 +20,11 @@ class HeartbeatResource extends JsonResource
             'status' => $this->status,
             'status_code' => $this->status_code,
             'response_time' => $this->response_time,
+            'phase_dns_ms' => $this->phase_dns_ms,
+            'phase_tcp_ms' => $this->phase_tcp_ms,
+            'phase_tls_ms' => $this->phase_tls_ms,
+            'phase_ttfb_ms' => $this->phase_ttfb_ms,
+            'phase_transfer_ms' => $this->phase_transfer_ms,
             'message' => $this->message,
             'created_at' => $this->created_at,
         ];

--- a/app/Jobs/CheckHttpMonitorsBatchJob.php
+++ b/app/Jobs/CheckHttpMonitorsBatchJob.php
@@ -7,6 +7,7 @@ use App\DTOs\CheckResult;
 use App\Events\HeartbeatRecorded;
 use App\Events\MonitorChecking;
 use App\Models\Monitor;
+use App\Services\PhaseTimingCapture;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Http\Client\Pool;
@@ -59,6 +60,11 @@ class CheckHttpMonitorsBatchJob implements ShouldQueue
                 'status' => $result->status,
                 'status_code' => $result->statusCode,
                 'response_time' => $result->responseTime,
+                'phase_dns_ms' => $result->phaseDnsMs,
+                'phase_tcp_ms' => $result->phaseTcpMs,
+                'phase_tls_ms' => $result->phaseTlsMs,
+                'phase_ttfb_ms' => $result->phaseTtfbMs,
+                'phase_transfer_ms' => $result->phaseTransferMs,
                 'message' => $result->message,
             ]);
 
@@ -90,23 +96,18 @@ class CheckHttpMonitorsBatchJob implements ShouldQueue
         $responseTime = isset($stats['total_time'])
             ? (int) round($stats['total_time'] * 1000)
             : 0;
+        $timing = PhaseTimingCapture::fromHandlerStats($stats);
 
         $statusCode = $response->status();
         $acceptedCodes = $monitor->accepted_status_codes ?? [200];
+        $status = in_array($statusCode, $acceptedCodes) ? 'up' : 'down';
+        $message = $status === 'down' ? "Unexpected status code: {$statusCode}" : null;
 
-        if (in_array($statusCode, $acceptedCodes)) {
-            return new CheckResult(
-                status: 'up',
-                responseTime: $responseTime,
-                statusCode: $statusCode,
-            );
-        }
-
-        return new CheckResult(
-            status: 'down',
+        return (new CheckResult(
+            status: $status,
             responseTime: $responseTime,
             statusCode: $statusCode,
-            message: "Unexpected status code: {$statusCode}",
-        );
+            message: $message,
+        ))->withTiming($timing);
     }
 }

--- a/app/Jobs/CheckMonitorJob.php
+++ b/app/Jobs/CheckMonitorJob.php
@@ -55,6 +55,11 @@ class CheckMonitorJob implements ShouldQueue
             'status' => $result->status,
             'status_code' => $result->statusCode,
             'response_time' => $result->responseTime,
+            'phase_dns_ms' => $result->phaseDnsMs,
+            'phase_tcp_ms' => $result->phaseTcpMs,
+            'phase_tls_ms' => $result->phaseTlsMs,
+            'phase_ttfb_ms' => $result->phaseTtfbMs,
+            'phase_transfer_ms' => $result->phaseTransferMs,
             'message' => $result->message,
         ]);
 

--- a/app/Models/Heartbeat.php
+++ b/app/Models/Heartbeat.php
@@ -19,6 +19,11 @@ class Heartbeat extends Model
         'status',
         'status_code',
         'response_time',
+        'phase_dns_ms',
+        'phase_tcp_ms',
+        'phase_tls_ms',
+        'phase_ttfb_ms',
+        'phase_transfer_ms',
         'message',
     ];
 
@@ -27,6 +32,11 @@ class Heartbeat extends Model
         return [
             'status_code' => 'integer',
             'response_time' => 'integer',
+            'phase_dns_ms' => 'integer',
+            'phase_tcp_ms' => 'integer',
+            'phase_tls_ms' => 'integer',
+            'phase_ttfb_ms' => 'integer',
+            'phase_transfer_ms' => 'integer',
         ];
     }
 

--- a/app/Services/Checkers/HttpChecker.php
+++ b/app/Services/Checkers/HttpChecker.php
@@ -4,6 +4,7 @@ namespace App\Services\Checkers;
 
 use App\DTOs\CheckResult;
 use App\Models\Monitor;
+use App\Services\PhaseTimingCapture;
 use Illuminate\Support\Facades\Http;
 use Throwable;
 
@@ -16,28 +17,23 @@ class HttpChecker implements MonitorChecker
         try {
             $response = Http::timeout($monitor->timeout)
                 ->withUserAgent('Beacon/1.0')
-
                 ->withHeaders($monitor->headers ?? [])
                 ->send($monitor->method ?? 'GET', $monitor->url);
 
             $responseTime = (int) round((microtime(true) - $start) * 1000);
             $statusCode = $response->status();
             $acceptedCodes = $monitor->accepted_status_codes ?? [200];
+            $timing = PhaseTimingCapture::fromHandlerStats($response->handlerStats());
 
-            if (in_array($statusCode, $acceptedCodes)) {
-                return new CheckResult(
-                    status: 'up',
-                    responseTime: $responseTime,
-                    statusCode: $statusCode,
-                );
-            }
+            $status = in_array($statusCode, $acceptedCodes) ? 'up' : 'down';
+            $message = $status === 'down' ? "Unexpected status code: {$statusCode}" : null;
 
-            return new CheckResult(
-                status: 'down',
+            return (new CheckResult(
+                status: $status,
                 responseTime: $responseTime,
                 statusCode: $statusCode,
-                message: "Unexpected status code: {$statusCode}",
-            );
+                message: $message,
+            ))->withTiming($timing);
         } catch (Throwable $e) {
             $responseTime = (int) round((microtime(true) - $start) * 1000);
 

--- a/app/Services/PhaseTimingCapture.php
+++ b/app/Services/PhaseTimingCapture.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Services;
+
+use App\DTOs\PhaseCaptureResult;
+use App\DTOs\PhaseTiming;
+use App\Models\Monitor;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+final class PhaseTimingCapture
+{
+    public function capture(Monitor $monitor): PhaseCaptureResult
+    {
+        try {
+            $response = Http::timeout($monitor->timeout)
+                ->withUserAgent('Beacon/1.0')
+                ->withHeaders($monitor->headers ?? [])
+                ->send($monitor->method ?? 'GET', $monitor->url);
+
+            return self::resultFromResponse($response);
+        } catch (Throwable $e) {
+            return new PhaseCaptureResult(
+                timing: PhaseTiming::empty(),
+                statusCode: null,
+                totalMs: 0,
+                error: $e->getMessage(),
+            );
+        }
+    }
+
+    public static function resultFromResponse(Response $response): PhaseCaptureResult
+    {
+        $stats = $response->handlerStats();
+        $timing = self::fromHandlerStats($stats);
+        $totalMs = isset($stats['total_time'])
+            ? (int) round($stats['total_time'] * 1000)
+            : 0;
+
+        return new PhaseCaptureResult(
+            timing: $timing,
+            statusCode: $response->status(),
+            totalMs: $totalMs,
+            body: $response->body(),
+            headers: $response->headers(),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $stats
+     */
+    public static function fromHandlerStats(array $stats): PhaseTiming
+    {
+        $namelookup = self::asFloat($stats['namelookup_time'] ?? null);
+        $connect = self::asFloat($stats['connect_time'] ?? null);
+        $appconnect = self::asFloat($stats['appconnect_time'] ?? null);
+        $starttransfer = self::asFloat($stats['starttransfer_time'] ?? null);
+        $total = self::asFloat($stats['total_time'] ?? null);
+
+        $dns = self::toMs($namelookup);
+        $tcp = self::deltaMs($connect, $namelookup);
+
+        $hasTls = $appconnect !== null && $appconnect > 0.0;
+        $tls = $hasTls ? self::deltaMs($appconnect, $connect) : null;
+
+        $ttfbAnchor = $hasTls ? $appconnect : $connect;
+        $ttfb = self::deltaMs($starttransfer, $ttfbAnchor);
+        $transfer = self::deltaMs($total, $starttransfer);
+
+        return new PhaseTiming(
+            phaseDnsMs: $dns,
+            phaseTcpMs: $tcp,
+            phaseTlsMs: $tls,
+            phaseTtfbMs: $ttfb,
+            phaseTransferMs: $transfer,
+        );
+    }
+
+    private static function asFloat(mixed $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return is_numeric($value) ? (float) $value : null;
+    }
+
+    private static function toMs(?float $seconds): ?int
+    {
+        if ($seconds === null || $seconds < 0) {
+            return null;
+        }
+
+        return (int) round($seconds * 1000);
+    }
+
+    private static function deltaMs(?float $end, ?float $start): ?int
+    {
+        if ($end === null || $start === null) {
+            return null;
+        }
+
+        $delta = $end - $start;
+        if ($delta < 0) {
+            return null;
+        }
+
+        return (int) round($delta * 1000);
+    }
+}

--- a/database/migrations/2026_04_30_224356_add_phase_timings_to_heartbeats_table.php
+++ b/database/migrations/2026_04_30_224356_add_phase_timings_to_heartbeats_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('heartbeats', function (Blueprint $table) {
+            $table->unsignedInteger('phase_dns_ms')->nullable()->after('response_time');
+            $table->unsignedInteger('phase_tcp_ms')->nullable()->after('phase_dns_ms');
+            $table->unsignedInteger('phase_tls_ms')->nullable()->after('phase_tcp_ms');
+            $table->unsignedInteger('phase_ttfb_ms')->nullable()->after('phase_tls_ms');
+            $table->unsignedInteger('phase_transfer_ms')->nullable()->after('phase_ttfb_ms');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('heartbeats', function (Blueprint $table) {
+            $table->dropColumn([
+                'phase_dns_ms',
+                'phase_tcp_ms',
+                'phase_tls_ms',
+                'phase_ttfb_ms',
+                'phase_transfer_ms',
+            ]);
+        });
+    }
+};

--- a/database/seeders/MonitorSeeder.php
+++ b/database/seeders/MonitorSeeder.php
@@ -30,16 +30,30 @@ class MonitorSeeder extends Seeder
             $monitor = Monitor::create($definition);
 
             if (! empty($heartbeats)) {
-                $rows = array_map(fn (array $hb) => [
-                    'monitor_id' => $monitor->id,
-                    'status' => $hb['status'],
-                    'status_code' => $hb['status_code'] ?? null,
-                    'response_time' => $hb['response_time'] ?? null,
-                    'message' => $hb['message'] ?? null,
-                    'created_at' => $hb['created_at'] instanceof Carbon
-                        ? $hb['created_at']->toDateTimeString()
-                        : $hb['created_at'],
-                ], $heartbeats);
+                $isHttp = ($definition['type'] ?? null) === 'http';
+                $isHttps = $isHttp && str_starts_with((string) ($definition['url'] ?? ''), 'https://');
+
+                $rows = array_map(function (array $hb) use ($monitor, $isHttp, $isHttps) {
+                    $phases = $isHttp && ($hb['response_time'] ?? null) !== null
+                        ? self::syntheticPhases((int) $hb['response_time'], $isHttps)
+                        : ['phase_dns_ms' => null, 'phase_tcp_ms' => null, 'phase_tls_ms' => null, 'phase_ttfb_ms' => null, 'phase_transfer_ms' => null];
+
+                    return [
+                        'monitor_id' => $monitor->id,
+                        'status' => $hb['status'],
+                        'status_code' => $hb['status_code'] ?? null,
+                        'response_time' => $hb['response_time'] ?? null,
+                        'phase_dns_ms' => $phases['phase_dns_ms'],
+                        'phase_tcp_ms' => $phases['phase_tcp_ms'],
+                        'phase_tls_ms' => $phases['phase_tls_ms'],
+                        'phase_ttfb_ms' => $phases['phase_ttfb_ms'],
+                        'phase_transfer_ms' => $phases['phase_transfer_ms'],
+                        'message' => $hb['message'] ?? null,
+                        'created_at' => $hb['created_at'] instanceof Carbon
+                            ? $hb['created_at']->toDateTimeString()
+                            : $hb['created_at'],
+                    ];
+                }, $heartbeats);
 
                 foreach (array_chunk($rows, 500) as $chunk) {
                     DB::table('heartbeats')->insert($chunk);
@@ -181,6 +195,36 @@ class MonitorSeeder extends Seeder
             'response_time' => null,
             'message' => $message,
             'created_at' => $at->copy(),
+        ];
+    }
+
+    /**
+     * Split a total response time across the curl phase counters with realistic
+     * proportions so the Response tab has demo-quality phase data.
+     *
+     * @return array{phase_dns_ms: int, phase_tcp_ms: int, phase_tls_ms: ?int, phase_ttfb_ms: int, phase_transfer_ms: int}
+     */
+    private static function syntheticPhases(int $totalMs, bool $isHttps): array
+    {
+        $totalMs = max(1, $totalMs);
+        $dnsPct = mt_rand(5, 12) / 100;
+        $tcpPct = mt_rand(5, 12) / 100;
+        $tlsPct = $isHttps ? mt_rand(12, 22) / 100 : 0;
+        $ttfbPct = mt_rand(45, 60) / 100;
+
+        $dns = max(1, (int) round($totalMs * $dnsPct));
+        $tcp = max(1, (int) round($totalMs * $tcpPct));
+        $tls = $isHttps ? max(1, (int) round($totalMs * $tlsPct)) : null;
+        $ttfb = max(1, (int) round($totalMs * $ttfbPct));
+        $allocated = $dns + $tcp + ($tls ?? 0) + $ttfb;
+        $transfer = max(1, $totalMs - $allocated);
+
+        return [
+            'phase_dns_ms' => $dns,
+            'phase_tcp_ms' => $tcp,
+            'phase_tls_ms' => $tls,
+            'phase_ttfb_ms' => $ttfb,
+            'phase_transfer_ms' => $transfer,
         ];
     }
 

--- a/resources/js/pages/monitors/components/__tests__/response-tab.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/response-tab.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { type PhaseTimingsPayload, ResponseTab } from "@/pages/monitors/components/response-tab"
+import { handleHeartbeat } from "@/stores/monitor-realtime"
 import type { ChartDataPoint, Heartbeat } from "@/types/monitor"
 
 const samplePhases = (
@@ -281,6 +282,104 @@ describe("ResponseTab", () => {
     const rows = screen.getAllByRole("row").slice(1)
     expect(rows).toHaveLength(1)
     expect(rows[0]).toHaveAttribute("data-id", "2")
+  })
+
+  it("refetches phase data when a heartbeat event for the same monitor arrives", async () => {
+    vi.useFakeTimers()
+    try {
+      const fetcher = vi.fn().mockResolvedValue(buildPayload())
+      render(
+        <ResponseTab
+          monitorId={42}
+          period="24h"
+          onPeriodChange={() => {}}
+          chartData={sampleChart()}
+          prevChartData={sampleChart()}
+          heartbeats={[sampleHeartbeat()]}
+          fetcher={fetcher}
+        />,
+      )
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        handleHeartbeat({
+          monitorId: 42,
+          heartbeat: {
+            id: 999,
+            status: "up",
+            status_code: 200,
+            response_time: 200,
+            created_at: new Date().toISOString(),
+          },
+          monitorStatus: "up",
+          uptimePercentage: 99,
+          averageResponseTime: 200,
+        })
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(1500)
+      })
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(fetcher).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("ignores heartbeat events for other monitors", async () => {
+    vi.useFakeTimers()
+    try {
+      const fetcher = vi.fn().mockResolvedValue(buildPayload())
+      render(
+        <ResponseTab
+          monitorId={42}
+          period="24h"
+          onPeriodChange={() => {}}
+          chartData={sampleChart()}
+          prevChartData={sampleChart()}
+          heartbeats={[sampleHeartbeat()]}
+          fetcher={fetcher}
+        />,
+      )
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        handleHeartbeat({
+          monitorId: 7,
+          heartbeat: {
+            id: 1,
+            status: "up",
+            status_code: 200,
+            response_time: 100,
+            created_at: new Date().toISOString(),
+          },
+          monitorStatus: "up",
+          uptimePercentage: 100,
+          averageResponseTime: 100,
+        })
+      })
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(fetcher).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("Latest filter sorts by created_at descending", async () => {

--- a/resources/js/pages/monitors/components/__tests__/response-tab.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/response-tab.test.tsx
@@ -254,4 +254,61 @@ describe("ResponseTab", () => {
     expect(rows[1]).toHaveAttribute("data-id", "3")
     expect(rows[2]).toHaveAttribute("data-id", "1")
   })
+
+  it("Failed only filter narrows the slowest-checks table to non-up rows", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart()}
+        heartbeats={[
+          sampleHeartbeat({ id: 1, response_time: 200 }),
+          sampleHeartbeat({ id: 2, response_time: 4500, status_code: 503, status: "down" }),
+          sampleHeartbeat({ id: 3, response_time: 800 }),
+        ]}
+        fetcher={fetcher}
+      />,
+    )
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Failed only" }))
+    })
+
+    const rows = screen.getAllByRole("row").slice(1)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toHaveAttribute("data-id", "2")
+  })
+
+  it("Latest filter sorts by created_at descending", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart()}
+        heartbeats={[
+          sampleHeartbeat({ id: 1, created_at: "2026-04-30T10:00:00Z", response_time: 4000 }),
+          sampleHeartbeat({ id: 2, created_at: "2026-04-30T11:00:00Z", response_time: 100 }),
+          sampleHeartbeat({ id: 3, created_at: "2026-04-30T12:00:00Z", response_time: 500 }),
+        ]}
+        fetcher={fetcher}
+      />,
+    )
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Latest" }))
+    })
+
+    const rows = screen.getAllByRole("row").slice(1)
+    expect(rows[0]).toHaveAttribute("data-id", "3")
+    expect(rows[1]).toHaveAttribute("data-id", "2")
+    expect(rows[2]).toHaveAttribute("data-id", "1")
+  })
 })

--- a/resources/js/pages/monitors/components/__tests__/response-tab.test.tsx
+++ b/resources/js/pages/monitors/components/__tests__/response-tab.test.tsx
@@ -1,0 +1,257 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { type PhaseTimingsPayload, ResponseTab } from "@/pages/monitors/components/response-tab"
+import type { ChartDataPoint, Heartbeat } from "@/types/monitor"
+
+const samplePhases = (
+  overrides: Partial<PhaseTimingsPayload["phases"]> = {},
+): PhaseTimingsPayload["phases"] => ({
+  dns: { avg: 18, p95: 42, count: 100 },
+  tcp: { avg: 24, p95: 58, count: 100 },
+  tls: { avg: 86, p95: 142, count: 100 },
+  ttfb: { avg: 132, p95: 480, count: 100 },
+  transfer: { avg: 26, p95: 120, count: 100 },
+  ...overrides,
+})
+
+const buildPayload = (overrides: Partial<PhaseTimingsPayload> = {}): PhaseTimingsPayload => ({
+  period: "24h",
+  count: 100,
+  phases: samplePhases(),
+  ...overrides,
+})
+
+const sampleHeartbeat = (overrides: Partial<Heartbeat> = {}): Heartbeat => ({
+  id: 1,
+  monitor_id: 7,
+  status: "up",
+  status_code: 200,
+  response_time: 250,
+  phase_dns_ms: null,
+  phase_tcp_ms: null,
+  phase_tls_ms: null,
+  phase_ttfb_ms: null,
+  phase_transfer_ms: null,
+  message: null,
+  created_at: "2026-04-30T12:00:00Z",
+  ...overrides,
+})
+
+const sampleChart = (count = 50): ChartDataPoint[] =>
+  Array.from({ length: count }, (_, i) => ({
+    created_at: new Date(Date.UTC(2026, 3, 30, 10, i)).toISOString(),
+    response_time: 200 + (i % 7) * 50,
+    status: "up",
+  }))
+
+describe("ResponseTab", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders all sections and the active period pill", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart(40)}
+        heartbeats={[sampleHeartbeat()]}
+        fetcher={fetcher}
+      />,
+    )
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    expect(fetcher.mock.calls[0][0]).toBe("/monitors/7/phase-timings?period=24h")
+
+    expect(screen.getByRole("img", { name: "Response time chart" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Phase breakdown")).toBeInTheDocument()
+    expect(screen.getByText(/where time is spent/i)).toBeInTheDocument()
+    expect(screen.getByText(/responses bucketed/i)).toBeInTheDocument()
+    expect(screen.getByText(/assertion pass\/fail timeline/i)).toBeInTheDocument()
+    expect(screen.getByLabelText("Slowest checks")).toBeInTheDocument()
+
+    const active = screen.getByRole("button", { name: "24h" })
+    expect(active).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("compare-to-previous toggle is on by default and renders the ghost line", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    const { container } = render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart(40)}
+        heartbeats={[sampleHeartbeat()]}
+        fetcher={fetcher}
+      />,
+    )
+
+    const compareToggle = screen.getByRole("checkbox", {
+      name: /compare to previous period/i,
+    })
+    expect(compareToggle).toBeChecked()
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="prev-period-line"]')).toBeInTheDocument(),
+    )
+  })
+
+  it("turning the compare toggle off removes the ghost line", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    const { container } = render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart(40)}
+        heartbeats={[sampleHeartbeat()]}
+        fetcher={fetcher}
+      />,
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("checkbox", { name: /compare to previous period/i }))
+    })
+
+    expect(container.querySelector('[data-slot="prev-period-line"]')).not.toBeInTheDocument()
+  })
+
+  it("clicking a different range pill calls onPeriodChange and refetches", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    const onPeriodChange = vi.fn()
+    const { rerender } = render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={onPeriodChange}
+        chartData={sampleChart()}
+        prevChartData={sampleChart()}
+        heartbeats={[sampleHeartbeat()]}
+        fetcher={fetcher}
+      />,
+    )
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "7d" }))
+    })
+    expect(onPeriodChange).toHaveBeenCalledWith("7d")
+
+    rerender(
+      <ResponseTab
+        monitorId={7}
+        period="7d"
+        onPeriodChange={onPeriodChange}
+        chartData={sampleChart()}
+        prevChartData={sampleChart()}
+        heartbeats={[sampleHeartbeat()]}
+        fetcher={fetcher}
+      />,
+    )
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2))
+    expect(fetcher.mock.calls[1][0]).toBe("/monitors/7/phase-timings?period=7d")
+  })
+
+  it("renders one phase row per phase with the API values", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart()}
+        heartbeats={[sampleHeartbeat()]}
+        fetcher={fetcher}
+      />,
+    )
+
+    const expectedPhases = ["dns", "tcp", "tls", "ttfb", "transfer"]
+    await waitFor(() => {
+      for (const phase of expectedPhases) {
+        expect(document.querySelector(`[data-phase="${phase}"]`)).not.toBeNull()
+      }
+    })
+
+    expect(screen.getByText("DNS lookup")).toBeInTheDocument()
+    expect(screen.getByLabelText("DNS lookup avg 18ms p95 42ms")).toBeInTheDocument()
+    expect(screen.getByLabelText("Time to first byte avg 132ms p95 480ms")).toBeInTheDocument()
+  })
+
+  it("shows an empty-state message when phase payload reports zero captures", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      buildPayload({
+        count: 0,
+        phases: {
+          dns: { avg: null, p95: null, count: 0 },
+          tcp: { avg: null, p95: null, count: 0 },
+          tls: { avg: null, p95: null, count: 0 },
+          ttfb: { avg: null, p95: null, count: 0 },
+          transfer: { avg: null, p95: null, count: 0 },
+        },
+      }),
+    )
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={[]}
+        prevChartData={[]}
+        heartbeats={[]}
+        fetcher={fetcher}
+      />,
+    )
+    await waitFor(() => expect(screen.getByText(/no http phase data/i)).toBeInTheDocument())
+  })
+
+  it("surfaces a fetch error in the phase waterfall", async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error("Network down"))
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={[]}
+        prevChartData={[]}
+        heartbeats={[]}
+        fetcher={fetcher}
+      />,
+    )
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/network down/i))
+  })
+
+  it("renders the slowest checks table with the largest response_time first", async () => {
+    const fetcher = vi.fn().mockResolvedValue(buildPayload())
+    render(
+      <ResponseTab
+        monitorId={7}
+        period="24h"
+        onPeriodChange={() => {}}
+        chartData={sampleChart()}
+        prevChartData={sampleChart()}
+        heartbeats={[
+          sampleHeartbeat({ id: 1, response_time: 200 }),
+          sampleHeartbeat({ id: 2, response_time: 4500, status_code: 503, status: "down" }),
+          sampleHeartbeat({ id: 3, response_time: 800 }),
+        ]}
+        fetcher={fetcher}
+      />,
+    )
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    const rows = screen.getAllByRole("row").slice(1)
+    expect(rows[0]).toHaveAttribute("data-id", "2")
+    expect(rows[1]).toHaveAttribute("data-id", "3")
+    expect(rows[2]).toHaveAttribute("data-id", "1")
+  })
+})

--- a/resources/js/pages/monitors/components/response-tab.tsx
+++ b/resources/js/pages/monitors/components/response-tab.tsx
@@ -1,0 +1,908 @@
+import { useEffect, useMemo, useState } from "react"
+import MonitorPhaseTimingsController from "@/actions/App/Http/Controllers/MonitorPhaseTimingsController"
+import { Eyebrow } from "@/components/primitives"
+import type { ChartDataPoint, Heartbeat } from "@/types/monitor"
+
+export type ResponseTabPeriod = "1h" | "24h" | "7d" | "30d"
+
+const PERIOD_LABELS: Record<ResponseTabPeriod, string> = {
+  "1h": "1h",
+  "24h": "24h",
+  "7d": "7d",
+  "30d": "30d",
+}
+
+const PERIOD_ORDER: ResponseTabPeriod[] = ["1h", "24h", "7d", "30d"]
+
+export interface PhaseAggregate {
+  avg: number | null
+  p95: number | null
+  count: number
+}
+
+export interface PhaseTimingsPayload {
+  period: string
+  count: number
+  phases: {
+    dns: PhaseAggregate
+    tcp: PhaseAggregate
+    tls: PhaseAggregate
+    ttfb: PhaseAggregate
+    transfer: PhaseAggregate
+  }
+}
+
+interface Props {
+  monitorId: number
+  period: ResponseTabPeriod
+  onPeriodChange: (next: ResponseTabPeriod) => void
+  chartData: ChartDataPoint[] | null | undefined
+  prevChartData: ChartDataPoint[] | null | undefined
+  heartbeats: Heartbeat[]
+  sloMs?: number
+  fetcher?: (url: string) => Promise<PhaseTimingsPayload>
+}
+
+const defaultFetcher = (url: string): Promise<PhaseTimingsPayload> =>
+  fetch(url, { headers: { Accept: "application/json" } }).then((r) => {
+    if (!r.ok) {
+      throw new Error(`Failed to load phase timings (${r.status})`)
+    }
+    return r.json()
+  })
+
+export function ResponseTab({
+  monitorId,
+  period,
+  onPeriodChange,
+  chartData,
+  prevChartData,
+  heartbeats,
+  sloMs = 2000,
+  fetcher = defaultFetcher,
+}: Props) {
+  const [compare, setCompare] = useState(true)
+  const [phasePayload, setPhasePayload] = useState<PhaseTimingsPayload | null>(null)
+  const [phaseError, setPhaseError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setPhaseError(null)
+    const url = MonitorPhaseTimingsController.url(monitorId, { query: { period } })
+    fetcher(url)
+      .then((payload) => {
+        if (!cancelled) setPhasePayload(payload)
+      })
+      .catch((e: Error) => {
+        if (!cancelled) {
+          setPhaseError(e.message)
+          setPhasePayload(null)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [monitorId, period, fetcher])
+
+  const buckets = useMemo(() => bucketChart(chartData ?? [], 48), [chartData])
+  const prevBuckets = useMemo(() => bucketChart(prevChartData ?? [], 48), [prevChartData])
+  const stats = useMemo(
+    () => computeStats(chartData ?? [], prevChartData ?? [], sloMs),
+    [chartData, prevChartData, sloMs],
+  )
+  const distribution = useMemo(() => computeDistribution(chartData ?? []), [chartData])
+  const statusCodes = useMemo(() => computeStatusCodes(heartbeats), [heartbeats])
+  const slowest = useMemo(() => pickSlowest(heartbeats, 8), [heartbeats])
+
+  return (
+    <section aria-label="Response analytics" className="space-y-4">
+      <RangeSelector
+        period={period}
+        onChange={onPeriodChange}
+        compare={compare}
+        onCompareChange={setCompare}
+      />
+
+      <ResponseChart
+        buckets={buckets}
+        prevBuckets={compare ? prevBuckets : []}
+        sloMs={sloMs}
+        stats={stats}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <DistributionHistogram distribution={distribution} />
+        <PhaseWaterfall payload={phasePayload} error={phaseError} />
+      </div>
+
+      <StatusCodesBars buckets={statusCodes} />
+      <AssertionTimelinePlaceholder />
+      <SlowestChecks rows={slowest} />
+    </section>
+  )
+}
+
+function RangeSelector({
+  period,
+  onChange,
+  compare,
+  onCompareChange,
+}: {
+  period: ResponseTabPeriod
+  onChange: (next: ResponseTabPeriod) => void
+  compare: boolean
+  onCompareChange: (next: boolean) => void
+}) {
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-3">
+      <div
+        className="flex flex-wrap items-center gap-1.5"
+        role="group"
+        aria-label="Response time period"
+      >
+        {PERIOD_ORDER.map((p) => (
+          <button
+            key={p}
+            type="button"
+            data-slot="response-range"
+            data-value={p}
+            data-selected={p === period ? "" : undefined}
+            aria-pressed={p === period}
+            onClick={() => onChange(p)}
+            className={
+              p === period
+                ? "rounded-full bg-primary px-3.5 py-1 font-semibold text-[11px] text-primary-foreground"
+                : "rounded-full border border-border px-3.5 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+            }
+          >
+            {PERIOD_LABELS[p]}
+          </button>
+        ))}
+        <span aria-hidden className="mx-2 h-4 w-px bg-border" />
+        <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={compare}
+            onChange={(e) => onCompareChange(e.target.checked)}
+            className="size-3.5 accent-primary"
+            aria-label="Compare to previous period"
+          />
+          <span className="text-foreground">Compare to prev period</span>
+        </label>
+      </div>
+    </header>
+  )
+}
+
+interface ChartBucket {
+  index: number
+  p50: number
+  p95: number
+  p99: number
+  count: number
+}
+
+function bucketChart(points: ChartDataPoint[], buckets: number): ChartBucket[] {
+  if (points.length === 0) return []
+  const sorted = [...points]
+    .filter((p) => p.response_time != null)
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+  if (sorted.length === 0) return []
+  const start = new Date(sorted[0].created_at).getTime()
+  const end = new Date(sorted[sorted.length - 1].created_at).getTime()
+  const span = Math.max(1, end - start)
+  const bucketWidth = span / buckets
+  const out: number[][] = Array.from({ length: buckets }, () => [])
+  for (const p of sorted) {
+    const t = new Date(p.created_at).getTime()
+    const idx = Math.min(buckets - 1, Math.floor((t - start) / bucketWidth))
+    if (p.response_time != null) {
+      out[idx].push(p.response_time)
+    }
+  }
+  return out.map((vals, i) => {
+    if (vals.length === 0) return { index: i, p50: 0, p95: 0, p99: 0, count: 0 }
+    const sortedVals = [...vals].sort((a, b) => a - b)
+    return {
+      index: i,
+      p50: percentileAt(sortedVals, 0.5),
+      p95: percentileAt(sortedVals, 0.95),
+      p99: percentileAt(sortedVals, 0.99),
+      count: vals.length,
+    }
+  })
+}
+
+function percentileAt(sortedVals: number[], p: number): number {
+  if (sortedVals.length === 0) return 0
+  const idx = Math.min(sortedVals.length - 1, Math.floor(p * sortedVals.length))
+  return sortedVals[idx]
+}
+
+interface ResponseStats {
+  p50: number | null
+  p95: number | null
+  p99: number | null
+  min: number | null
+  max: number | null
+  spread: number | null
+  sloBreachPct: number | null
+  prevP95: number | null
+  count: number
+}
+
+function computeStats(
+  points: ChartDataPoint[],
+  prevPoints: ChartDataPoint[],
+  sloMs: number,
+): ResponseStats {
+  const values = points
+    .map((p) => p.response_time)
+    .filter((v): v is number => v != null)
+    .sort((a, b) => a - b)
+  if (values.length === 0) {
+    return {
+      p50: null,
+      p95: null,
+      p99: null,
+      min: null,
+      max: null,
+      spread: null,
+      sloBreachPct: null,
+      prevP95: null,
+      count: 0,
+    }
+  }
+  const breach = values.filter((v) => v > sloMs).length
+  const prevValues = prevPoints
+    .map((p) => p.response_time)
+    .filter((v): v is number => v != null)
+    .sort((a, b) => a - b)
+  return {
+    p50: percentileAt(values, 0.5),
+    p95: percentileAt(values, 0.95),
+    p99: percentileAt(values, 0.99),
+    min: values[0],
+    max: values[values.length - 1],
+    spread: values[values.length - 1] - values[0],
+    sloBreachPct: (breach / values.length) * 100,
+    prevP95: prevValues.length > 0 ? percentileAt(prevValues, 0.95) : null,
+    count: values.length,
+  }
+}
+
+function ResponseChart({
+  buckets,
+  prevBuckets,
+  sloMs,
+  stats,
+}: {
+  buckets: ChartBucket[]
+  prevBuckets: ChartBucket[]
+  sloMs: number
+  stats: ResponseStats
+}) {
+  const W = 1000
+  const H = 240
+  const PAD = 12
+  const maxY = useMaxY(buckets, prevBuckets, sloMs)
+  const xFor = (i: number) =>
+    PAD + (buckets.length <= 1 ? 0 : (i / (buckets.length - 1)) * (W - PAD * 2))
+  const yFor = (v: number) => H - PAD - (Math.min(v, maxY) / maxY) * (H - PAD * 2)
+
+  const path = (key: "p50" | "p95" | "p99") =>
+    buckets
+      .map((b, i) => `${i === 0 ? "M" : "L"}${xFor(i).toFixed(1)},${yFor(b[key]).toFixed(1)}`)
+      .join(" ")
+
+  const prevPath =
+    prevBuckets.length > 0
+      ? prevBuckets
+          .map(
+            (b, i) =>
+              `${i === 0 ? "M" : "L"}${xFor(Math.min(i, buckets.length - 1)).toFixed(1)},${yFor(b.p95).toFixed(1)}`,
+          )
+          .join(" ")
+      : null
+
+  return (
+    <article
+      data-slot="response-chart"
+      className="rounded-lg border border-border bg-card px-5 py-4"
+    >
+      <header className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <Eyebrow>response time</Eyebrow>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">
+            {buckets.length > 0 ? `${stats.count} checks · bucketed` : "No data in window"}
+          </p>
+        </div>
+        <ChartLegend />
+      </header>
+      <svg
+        role="img"
+        aria-label="Response time chart"
+        width="100%"
+        viewBox={`0 0 ${W} ${H + 22}`}
+        preserveAspectRatio="none"
+        className="block"
+      >
+        {[0.25, 0.5, 0.75, 1].map((g) => {
+          const v = Math.round(maxY * g)
+          return (
+            <g key={g}>
+              <line
+                x1={PAD}
+                x2={W - PAD}
+                y1={yFor(v)}
+                y2={yFor(v)}
+                stroke="var(--border)"
+                strokeDasharray="2 4"
+              />
+              <text
+                x={PAD - 4}
+                y={yFor(v) + 3}
+                fontSize="9"
+                fill="var(--muted-foreground)"
+                textAnchor="end"
+              >
+                {v >= 1000 ? `${(v / 1000).toFixed(1)}s` : `${v}`}
+              </text>
+            </g>
+          )
+        })}
+
+        <line
+          x1={PAD}
+          x2={W - PAD}
+          y1={yFor(sloMs)}
+          y2={yFor(sloMs)}
+          stroke="var(--destructive)"
+          strokeDasharray="3 3"
+          opacity={0.5}
+        />
+        <text
+          x={W - PAD - 4}
+          y={yFor(sloMs) - 4}
+          fontSize="9"
+          fill="var(--destructive)"
+          textAnchor="end"
+        >
+          SLO · {sloMs >= 1000 ? `${sloMs / 1000}s` : `${sloMs}ms`}
+        </text>
+
+        {prevPath ? (
+          <path
+            data-slot="prev-period-line"
+            d={prevPath}
+            fill="none"
+            stroke="var(--muted-foreground)"
+            strokeWidth={1}
+            strokeDasharray="3 3"
+            opacity={0.55}
+          />
+        ) : null}
+
+        {buckets.length > 0 ? (
+          <>
+            <path d={path("p99")} fill="none" stroke="var(--destructive)" strokeWidth={1.4} />
+            <path d={path("p95")} fill="none" stroke="var(--primary)" strokeWidth={1.6} />
+            <path d={path("p50")} fill="none" stroke="var(--foreground)" strokeWidth={1.4} />
+          </>
+        ) : null}
+      </svg>
+
+      <StatStrip stats={stats} />
+    </article>
+  )
+}
+
+function ChartLegend() {
+  return (
+    <ul
+      className="flex flex-wrap items-center gap-3 text-[10px] text-muted-foreground"
+      aria-label="Chart legend"
+    >
+      <li className="flex items-center gap-1.5">
+        <span className="h-0.5 w-3 bg-foreground" />
+        p50
+      </li>
+      <li className="flex items-center gap-1.5">
+        <span className="h-0.5 w-3 bg-primary" />
+        p95
+      </li>
+      <li className="flex items-center gap-1.5">
+        <span className="h-0.5 w-3 bg-destructive" />
+        p99
+      </li>
+      <li className="flex items-center gap-1.5">
+        <span
+          aria-hidden
+          className="h-0 w-3"
+          style={{ borderTop: "1px dashed var(--muted-foreground)" }}
+        />
+        prev period
+      </li>
+    </ul>
+  )
+}
+
+function useMaxY(buckets: ChartBucket[], prevBuckets: ChartBucket[], sloMs: number): number {
+  const dataMax = Math.max(
+    0,
+    ...buckets.flatMap((b) => [b.p50, b.p95, b.p99]),
+    ...prevBuckets.map((b) => b.p95),
+  )
+  // Anchor on the data so it fills the viewport, then keep enough headroom
+  // for the SLO line. If data sits well below SLO, only show SLO + a thin band.
+  const headroom = dataMax * 1.2
+  const max = Math.max(headroom, sloMs * 1.05) || sloMs || 100
+  return Math.max(100, Math.ceil(max / 100) * 100)
+}
+
+function StatStrip({ stats }: { stats: ResponseStats }) {
+  const cells: Array<{
+    label: string
+    value: string
+    sub: string
+    intent: "neutral" | "primary" | "danger"
+  }> = [
+    {
+      label: "p50",
+      value: formatMs(stats.p50),
+      sub: "median",
+      intent: "neutral",
+    },
+    {
+      label: "p95",
+      value: formatMs(stats.p95),
+      sub:
+        stats.p95 != null && stats.prevP95 != null
+          ? formatDelta(stats.p95, stats.prevP95)
+          : "vs prev",
+      intent: "primary",
+    },
+    {
+      label: "p99",
+      value: formatMs(stats.p99),
+      sub: "tail",
+      intent: "danger",
+    },
+    {
+      label: "min · max",
+      value:
+        stats.min != null && stats.max != null
+          ? `${formatMs(stats.min)} · ${formatMs(stats.max)}`
+          : "—",
+      sub: stats.spread != null ? `spread ${formatMs(stats.spread)}` : "spread —",
+      intent: "neutral",
+    },
+    {
+      label: "SLO breach",
+      value: stats.sloBreachPct != null ? `${stats.sloBreachPct.toFixed(1)}%` : "—",
+      sub: "target < 1%",
+      intent: "danger",
+    },
+  ]
+  return (
+    <div className="mt-3 grid grid-cols-2 gap-3 border-border border-t pt-3 sm:grid-cols-5">
+      {cells.map((c) => (
+        <div key={c.label} data-slot="stat-cell" data-stat={c.label}>
+          <p className="kpi-label">{c.label}</p>
+          <p
+            className={
+              c.intent === "primary"
+                ? "kpi-value text-primary"
+                : c.intent === "danger"
+                  ? "kpi-value text-destructive"
+                  : "kpi-value text-foreground"
+            }
+          >
+            {c.value}
+          </p>
+          <p className="kpi-sub">{c.sub}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function formatMs(v: number | null): string {
+  if (v == null) return "—"
+  if (v >= 1000) return `${(v / 1000).toFixed(2)} s`
+  return `${Math.round(v)} ms`
+}
+
+function formatDelta(current: number, prev: number): string {
+  if (prev === 0) return "vs prev"
+  const pct = ((current - prev) / prev) * 100
+  const sign = pct >= 0 ? "+" : ""
+  return `${sign}${pct.toFixed(1)}% vs prev`
+}
+
+interface DistributionBucket {
+  label: string
+  count: number
+  intent: "success" | "primary" | "warning" | "danger"
+}
+
+function computeDistribution(points: ChartDataPoint[]): DistributionBucket[] {
+  const ranges: Array<{
+    label: string
+    min: number
+    max: number
+    intent: DistributionBucket["intent"]
+  }> = [
+    { label: "0-100", min: 0, max: 100, intent: "success" },
+    { label: "100-200", min: 100, max: 200, intent: "success" },
+    { label: "200-300", min: 200, max: 300, intent: "primary" },
+    { label: "300-500", min: 300, max: 500, intent: "primary" },
+    { label: "500-1k", min: 500, max: 1000, intent: "warning" },
+    { label: "1-2s", min: 1000, max: 2000, intent: "warning" },
+    { label: "2-5s", min: 2000, max: 5000, intent: "danger" },
+    { label: "5s+", min: 5000, max: Number.POSITIVE_INFINITY, intent: "danger" },
+  ]
+  return ranges.map((r) => {
+    const count = points.filter(
+      (p) => p.response_time != null && p.response_time >= r.min && p.response_time < r.max,
+    ).length
+    return { label: r.label, count, intent: r.intent }
+  })
+}
+
+function DistributionHistogram({ distribution }: { distribution: DistributionBucket[] }) {
+  const max = Math.max(1, ...distribution.map((d) => d.count))
+  const total = distribution.reduce((acc, d) => acc + d.count, 0)
+  return (
+    <article
+      data-slot="distribution-histogram"
+      className="rounded-lg border border-border bg-card px-5 py-4"
+    >
+      <header className="mb-3 flex items-baseline justify-between">
+        <div>
+          <Eyebrow>distribution</Eyebrow>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">
+            {total} checks · bucketed by response time
+          </p>
+        </div>
+      </header>
+      <div className="flex h-[120px] items-stretch gap-1 border-border border-b pb-2">
+        {distribution.map((b) => {
+          const h = (b.count / max) * 100
+          return (
+            <div key={b.label} className="flex h-full flex-1 flex-col items-center justify-end">
+              <span className="mb-1 text-[9px] text-muted-foreground">{b.count}</span>
+              <div
+                role="img"
+                aria-label={`${b.label}: ${b.count}`}
+                className={
+                  b.intent === "success"
+                    ? "w-full rounded-t bg-success"
+                    : b.intent === "primary"
+                      ? "w-full rounded-t bg-primary"
+                      : b.intent === "warning"
+                        ? "w-full rounded-t bg-warning"
+                        : "w-full rounded-t bg-destructive"
+                }
+                style={{ height: `${h}%`, minHeight: 2 }}
+              />
+            </div>
+          )
+        })}
+      </div>
+      <div className="mt-2 flex gap-1">
+        {distribution.map((b) => (
+          <div key={`l-${b.label}`} className="flex-1 text-center text-[9px] text-muted-foreground">
+            {b.label}
+          </div>
+        ))}
+      </div>
+    </article>
+  )
+}
+
+const PHASE_KEYS: Array<{
+  key: keyof PhaseTimingsPayload["phases"]
+  label: string
+  className: string
+}> = [
+  { key: "dns", label: "DNS lookup", className: "bg-purple-500/80" },
+  { key: "tcp", label: "TCP connect", className: "bg-sky-500/80" },
+  { key: "tls", label: "TLS handshake", className: "bg-success" },
+  { key: "ttfb", label: "Time to first byte", className: "bg-primary" },
+  { key: "transfer", label: "Content transfer", className: "bg-destructive" },
+]
+
+function PhaseWaterfall({
+  payload,
+  error,
+}: {
+  payload: PhaseTimingsPayload | null
+  error: string | null
+}) {
+  const totalP95 = payload
+    ? PHASE_KEYS.reduce((acc, p) => acc + (payload.phases[p.key].p95 ?? 0), 0)
+    : 0
+  const totalAvg = payload
+    ? PHASE_KEYS.reduce((acc, p) => acc + (payload.phases[p.key].avg ?? 0), 0)
+    : 0
+
+  return (
+    <article
+      data-slot="phase-waterfall"
+      className="rounded-lg border border-border bg-card px-5 py-4"
+    >
+      <header className="mb-3 flex items-baseline justify-between">
+        <div>
+          <Eyebrow>phase breakdown</Eyebrow>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">where time is spent</p>
+        </div>
+        <p className="text-[10px] text-muted-foreground">
+          avg <span className="text-foreground">{totalAvg}ms</span> · p95{" "}
+          <span className="text-primary">{totalP95}ms</span>
+        </p>
+      </header>
+      {error ? (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      ) : null}
+      {payload && payload.count === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No HTTP phase data captured in this window yet.
+        </p>
+      ) : null}
+      {payload && payload.count > 0 ? (
+        <ul className="flex flex-col gap-3" aria-label="Phase breakdown">
+          {PHASE_KEYS.map((p) => {
+            const cell = payload.phases[p.key]
+            const avg = cell.avg ?? 0
+            const p95 = cell.p95 ?? 0
+            const denom = Math.max(1, totalP95)
+            const avgPct = (avg / denom) * 100
+            const p95Pct = (p95 / denom) * 100
+            return (
+              <li
+                key={p.key}
+                data-slot="phase-row"
+                data-phase={p.key}
+                className="grid grid-cols-[140px_1fr_120px] items-center gap-3"
+              >
+                <span className="text-foreground text-xs">{p.label}</span>
+                <div
+                  role="img"
+                  aria-label={`${p.label} avg ${avg}ms p95 ${p95}ms`}
+                  className="relative h-[18px] rounded-sm bg-muted/30"
+                >
+                  <div
+                    className={`absolute inset-y-0 left-0 rounded-sm opacity-25 ${p.className}`}
+                    style={{ width: `${p95Pct}%` }}
+                  />
+                  <div
+                    className={`absolute inset-y-0 left-0 rounded-sm ${p.className}`}
+                    style={{ width: `${avgPct}%` }}
+                  />
+                </div>
+                <p className="text-right text-[11px] text-muted-foreground">
+                  <span className="text-foreground">{avg}ms</span>
+                  <span className="text-muted-foreground"> · {p95}ms</span>
+                </p>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+      {!payload && !error ? (
+        <p className="text-muted-foreground text-sm">Loading phase data…</p>
+      ) : null}
+    </article>
+  )
+}
+
+interface StatusBucket {
+  label: string
+  s2xx: number
+  s3xx: number
+  s4xx: number
+  s5xx: number
+  timeout: number
+}
+
+function computeStatusCodes(heartbeats: Heartbeat[]): StatusBucket[] {
+  if (heartbeats.length === 0) return []
+  const sorted = [...heartbeats].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  )
+  const start = new Date(sorted[0].created_at).getTime()
+  const end = new Date(sorted[sorted.length - 1].created_at).getTime()
+  const span = Math.max(1, end - start)
+  const buckets = 24
+  const width = span / buckets
+  const out: StatusBucket[] = Array.from({ length: buckets }, (_, i) => ({
+    label: `${i}`,
+    s2xx: 0,
+    s3xx: 0,
+    s4xx: 0,
+    s5xx: 0,
+    timeout: 0,
+  }))
+  for (const h of sorted) {
+    const t = new Date(h.created_at).getTime()
+    const idx = Math.min(buckets - 1, Math.floor((t - start) / width))
+    if (h.status_code == null) {
+      out[idx].timeout += 1
+    } else if (h.status_code >= 500) {
+      out[idx].s5xx += 1
+    } else if (h.status_code >= 400) {
+      out[idx].s4xx += 1
+    } else if (h.status_code >= 300) {
+      out[idx].s3xx += 1
+    } else {
+      out[idx].s2xx += 1
+    }
+  }
+  return out
+}
+
+function StatusCodesBars({ buckets }: { buckets: StatusBucket[] }) {
+  const totals = buckets.reduce(
+    (acc, b) => ({
+      s2xx: acc.s2xx + b.s2xx,
+      s3xx: acc.s3xx + b.s3xx,
+      s4xx: acc.s4xx + b.s4xx,
+      s5xx: acc.s5xx + b.s5xx,
+      timeout: acc.timeout + b.timeout,
+    }),
+    { s2xx: 0, s3xx: 0, s4xx: 0, s5xx: 0, timeout: 0 },
+  )
+  const grand = totals.s2xx + totals.s3xx + totals.s4xx + totals.s5xx + totals.timeout
+  const peak = Math.max(1, ...buckets.map((b) => b.s2xx + b.s3xx + b.s4xx + b.s5xx + b.timeout))
+  const legend: Array<{
+    key: keyof StatusBucket
+    label: string
+    bg: string
+  }> = [
+    { key: "s2xx", label: "2xx", bg: "bg-success" },
+    { key: "s3xx", label: "3xx", bg: "bg-sky-500/80" },
+    { key: "s4xx", label: "4xx", bg: "bg-primary" },
+    { key: "s5xx", label: "5xx", bg: "bg-destructive" },
+    { key: "timeout", label: "timeout", bg: "bg-purple-500/80" },
+  ]
+  return (
+    <article data-slot="status-codes" className="rounded-lg border border-border bg-card px-5 py-4">
+      <header className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <Eyebrow>status codes</Eyebrow>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">{grand} responses bucketed</p>
+        </div>
+        <ul className="flex flex-wrap items-center gap-3 text-[10px] text-muted-foreground">
+          {legend.map((l) => (
+            <li key={l.label} className="flex items-center gap-1.5">
+              <span aria-hidden className={`size-2 rounded-sm ${l.bg}`} />
+              <span className="text-foreground">{l.label}</span>
+              <span>· {totals[l.key as keyof typeof totals]}</span>
+            </li>
+          ))}
+        </ul>
+      </header>
+      <div className="flex h-[100px] items-end gap-1">
+        {buckets.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No status code data in this window.</p>
+        ) : (
+          buckets.map((b, i) => {
+            const total = b.s2xx + b.s3xx + b.s4xx + b.s5xx + b.timeout
+            const heightPx = (total / peak) * 100
+            return (
+              <div
+                key={i}
+                data-slot="status-bucket"
+                className="flex flex-1 flex-col-reverse"
+                style={{ height: `${heightPx}%` }}
+              >
+                {b.s2xx > 0 ? (
+                  <div className="bg-success" style={{ height: `${(b.s2xx / total) * 100}%` }} />
+                ) : null}
+                {b.s3xx > 0 ? (
+                  <div className="bg-sky-500/80" style={{ height: `${(b.s3xx / total) * 100}%` }} />
+                ) : null}
+                {b.s4xx > 0 ? (
+                  <div className="bg-primary" style={{ height: `${(b.s4xx / total) * 100}%` }} />
+                ) : null}
+                {b.s5xx > 0 ? (
+                  <div
+                    className="bg-destructive"
+                    style={{ height: `${(b.s5xx / total) * 100}%` }}
+                  />
+                ) : null}
+                {b.timeout > 0 ? (
+                  <div
+                    className="bg-purple-500/80"
+                    style={{ height: `${(b.timeout / total) * 100}%` }}
+                  />
+                ) : null}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </article>
+  )
+}
+
+function AssertionTimelinePlaceholder() {
+  return (
+    <article
+      data-slot="assertion-timeline"
+      className="rounded-lg border border-border border-dashed bg-card px-5 py-4 text-muted-foreground text-sm"
+    >
+      <Eyebrow>assertions</Eyebrow>
+      <p className="mt-1.5">Assertion pass/fail timeline lands once the assertions module ships.</p>
+    </article>
+  )
+}
+
+function pickSlowest(heartbeats: Heartbeat[], limit: number): Heartbeat[] {
+  return [...heartbeats]
+    .filter((h) => h.response_time != null)
+    .sort((a, b) => (b.response_time ?? 0) - (a.response_time ?? 0))
+    .slice(0, limit)
+}
+
+function SlowestChecks({ rows }: { rows: Heartbeat[] }) {
+  return (
+    <article
+      data-slot="slowest-checks"
+      className="overflow-hidden rounded-lg border border-border bg-card"
+    >
+      <header className="flex items-baseline justify-between border-border border-b px-5 py-4">
+        <div>
+          <Eyebrow>slowest checks</Eyebrow>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">
+            top {rows.length} sorted by duration
+          </p>
+        </div>
+      </header>
+      {rows.length === 0 ? (
+        <p className="px-5 py-6 text-center text-muted-foreground text-sm">No checks in window.</p>
+      ) : (
+        <table className="w-full text-xs" aria-label="Slowest checks">
+          <thead className="bg-muted/30 text-[10px] text-muted-foreground uppercase tracking-widest">
+            <tr>
+              <th className="px-5 py-2.5 text-left">Time</th>
+              <th className="px-5 py-2.5 text-left">Duration</th>
+              <th className="px-5 py-2.5 text-left">Status</th>
+              <th className="px-5 py-2.5 text-left">Message</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((h) => (
+              <tr
+                key={h.id}
+                data-slot="slowest-row"
+                data-id={h.id}
+                className="border-border border-t"
+              >
+                <td className="px-5 py-2.5 text-muted-foreground">
+                  {new Date(h.created_at).toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    second: "2-digit",
+                  })}
+                </td>
+                <td className="px-5 py-2.5 font-medium text-foreground">
+                  {formatMs(h.response_time)}
+                </td>
+                <td
+                  className={`px-5 py-2.5 font-semibold ${h.status === "up" ? "text-success" : "text-destructive"}`}
+                >
+                  {h.status_code ?? (h.status === "up" ? "OK" : "ERR")}
+                </td>
+                <td className="px-5 py-2.5 text-muted-foreground">{h.message ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </article>
+  )
+}

--- a/resources/js/pages/monitors/components/response-tab.tsx
+++ b/resources/js/pages/monitors/components/response-tab.tsx
@@ -92,7 +92,6 @@ export function ResponseTab({
   )
   const distribution = useMemo(() => computeDistribution(chartData ?? []), [chartData])
   const statusCodes = useMemo(() => computeStatusCodes(heartbeats), [heartbeats])
-  const slowest = useMemo(() => pickSlowest(heartbeats, 8), [heartbeats])
 
   return (
     <section aria-label="Response analytics" className="space-y-4">
@@ -117,7 +116,7 @@ export function ResponseTab({
 
       <StatusCodesBars buckets={statusCodes} />
       <AssertionTimelinePlaceholder />
-      <SlowestChecks rows={slowest} />
+      <SlowestChecks heartbeats={heartbeats} />
     </section>
   )
 }
@@ -672,7 +671,7 @@ function PhaseWaterfall({
                 <div
                   role="img"
                   aria-label={`${p.label} avg ${avg}ms p95 ${p95}ms`}
-                  className="relative h-[18px] rounded-sm bg-muted/30"
+                  className="relative h-[18px] rounded-sm bg-muted/40"
                 >
                   <div
                     className={`absolute inset-y-0 left-0 rounded-sm opacity-25 ${p.className}`}
@@ -841,67 +840,124 @@ function AssertionTimelinePlaceholder() {
   )
 }
 
-function pickSlowest(heartbeats: Heartbeat[], limit: number): Heartbeat[] {
-  return [...heartbeats]
-    .filter((h) => h.response_time != null)
+type SlowestMode = "slowest" | "failed" | "latest"
+
+function applySlowestMode(heartbeats: Heartbeat[], mode: SlowestMode, limit: number): Heartbeat[] {
+  const filtered = mode === "failed" ? heartbeats.filter((h) => h.status !== "up") : heartbeats
+  const withTime = filtered.filter((h) => h.response_time != null)
+  if (mode === "latest") {
+    return [...withTime]
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, limit)
+  }
+  return [...withTime]
     .sort((a, b) => (b.response_time ?? 0) - (a.response_time ?? 0))
     .slice(0, limit)
 }
 
-function SlowestChecks({ rows }: { rows: Heartbeat[] }) {
+function durationIntent(ms: number | null): string {
+  if (ms == null) return "text-muted-foreground"
+  if (ms >= 2000) return "text-destructive"
+  if (ms >= 1000) return "text-warning"
+  if (ms >= 500) return "text-primary"
+  return "text-foreground"
+}
+
+const SLOWEST_LIMIT = 8
+
+function SlowestChecks({ heartbeats }: { heartbeats: Heartbeat[] }) {
+  const [mode, setMode] = useState<SlowestMode>("slowest")
+  const totalAvailable = heartbeats.length
+  const visible = useMemo(
+    () => applySlowestMode(heartbeats, mode, SLOWEST_LIMIT),
+    [heartbeats, mode],
+  )
+  const modes: Array<{ value: SlowestMode; label: string }> = [
+    { value: "slowest", label: "Slowest" },
+    { value: "failed", label: "Failed only" },
+    { value: "latest", label: "Latest" },
+  ]
   return (
     <article
       data-slot="slowest-checks"
       className="overflow-hidden rounded-lg border border-border bg-card"
     >
-      <header className="flex items-baseline justify-between border-border border-b px-5 py-4">
+      <header className="flex flex-wrap items-baseline justify-between gap-3 border-border border-b px-5 py-4">
         <div>
           <Eyebrow>slowest checks</Eyebrow>
           <p className="mt-0.5 font-semibold text-foreground text-sm">
-            top {rows.length} sorted by duration
+            top {visible.length} sorted by {mode === "latest" ? "time" : "duration"}
           </p>
         </div>
+        <div className="flex flex-wrap gap-1.5" role="group" aria-label="Slowest checks filter">
+          {modes.map((m) => (
+            <button
+              key={m.value}
+              type="button"
+              data-slot="slowest-filter"
+              data-value={m.value}
+              data-selected={mode === m.value ? "" : undefined}
+              aria-pressed={mode === m.value}
+              onClick={() => setMode(m.value)}
+              className={
+                mode === m.value
+                  ? "rounded-full bg-primary px-3 py-1 font-semibold text-[10px] text-primary-foreground"
+                  : "rounded-full border border-border px-3 py-1 text-[10px] text-muted-foreground hover:text-foreground"
+              }
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
       </header>
-      {rows.length === 0 ? (
-        <p className="px-5 py-6 text-center text-muted-foreground text-sm">No checks in window.</p>
+      {visible.length === 0 ? (
+        <p className="px-5 py-6 text-center text-muted-foreground text-sm">
+          {mode === "failed" ? "No failed checks in this window." : "No checks in window."}
+        </p>
       ) : (
-        <table className="w-full text-xs" aria-label="Slowest checks">
-          <thead className="bg-muted/30 text-[10px] text-muted-foreground uppercase tracking-widest">
-            <tr>
-              <th className="px-5 py-2.5 text-left">Time</th>
-              <th className="px-5 py-2.5 text-left">Duration</th>
-              <th className="px-5 py-2.5 text-left">Status</th>
-              <th className="px-5 py-2.5 text-left">Message</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((h) => (
-              <tr
-                key={h.id}
-                data-slot="slowest-row"
-                data-id={h.id}
-                className="border-border border-t"
-              >
-                <td className="px-5 py-2.5 text-muted-foreground">
-                  {new Date(h.created_at).toLocaleTimeString([], {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    second: "2-digit",
-                  })}
-                </td>
-                <td className="px-5 py-2.5 font-medium text-foreground">
-                  {formatMs(h.response_time)}
-                </td>
-                <td
-                  className={`px-5 py-2.5 font-semibold ${h.status === "up" ? "text-success" : "text-destructive"}`}
-                >
-                  {h.status_code ?? (h.status === "up" ? "OK" : "ERR")}
-                </td>
-                <td className="px-5 py-2.5 text-muted-foreground">{h.message ?? "—"}</td>
+        <>
+          <table className="w-full text-xs" aria-label="Slowest checks">
+            <thead className="bg-muted/30 text-[10px] text-muted-foreground uppercase tracking-widest">
+              <tr>
+                <th className="px-5 py-2.5 text-left">Time</th>
+                <th className="px-5 py-2.5 text-left">Duration</th>
+                <th className="px-5 py-2.5 text-left">Status</th>
+                <th className="px-5 py-2.5 text-left">Body preview</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {visible.map((h) => (
+                <tr
+                  key={h.id}
+                  data-slot="slowest-row"
+                  data-id={h.id}
+                  className="border-border border-t"
+                >
+                  <td className="px-5 py-2.5 text-muted-foreground">
+                    {new Date(h.created_at).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    })}
+                  </td>
+                  <td className={`px-5 py-2.5 font-medium ${durationIntent(h.response_time)}`}>
+                    {formatMs(h.response_time)}
+                  </td>
+                  <td
+                    className={`px-5 py-2.5 font-semibold ${h.status === "up" ? "text-success" : "text-destructive"}`}
+                  >
+                    {h.status_code ?? (h.status === "up" ? "OK" : "ERR")}
+                  </td>
+                  <td className="truncate px-5 py-2.5 text-muted-foreground">{h.message ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="flex items-center justify-between border-border border-t px-5 py-3 text-[11px] text-muted-foreground">
+            <span>showing {visible.length}</span>
+            <span className="text-primary">view all {totalAvailable} →</span>
+          </div>
+        </>
       )}
     </article>
   )

--- a/resources/js/pages/monitors/components/response-tab.tsx
+++ b/resources/js/pages/monitors/components/response-tab.tsx
@@ -91,6 +91,7 @@ export function ResponseTab({
     [chartData, prevChartData, sloMs],
   )
   const distribution = useMemo(() => computeDistribution(chartData ?? []), [chartData])
+  const distributionStats = useMemo(() => computeMedianMean(chartData ?? []), [chartData])
   const statusCodes = useMemo(() => computeStatusCodes(heartbeats), [heartbeats])
 
   return (
@@ -110,7 +111,11 @@ export function ResponseTab({
       />
 
       <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
-        <DistributionHistogram distribution={distribution} />
+        <DistributionHistogram
+          distribution={distribution}
+          median={distributionStats.median}
+          mean={distributionStats.mean}
+        />
         <PhaseWaterfall payload={phasePayload} error={phaseError} />
       </div>
 
@@ -284,9 +289,10 @@ function ResponseChart({
   const W = 1000
   const H = 240
   const PAD = 12
+  const LEFT_GUTTER = 36
   const maxY = useMaxY(buckets, prevBuckets, sloMs)
   const xFor = (i: number) =>
-    PAD + (buckets.length <= 1 ? 0 : (i / (buckets.length - 1)) * (W - PAD * 2))
+    LEFT_GUTTER + (buckets.length <= 1 ? 0 : (i / (buckets.length - 1)) * (W - LEFT_GUTTER - PAD))
   const yFor = (v: number) => H - PAD - (Math.min(v, maxY) / maxY) * (H - PAD * 2)
 
   const path = (key: "p50" | "p95" | "p99") =>
@@ -313,7 +319,9 @@ function ResponseChart({
         <div>
           <Eyebrow>response time</Eyebrow>
           <p className="mt-0.5 font-semibold text-foreground text-sm">
-            {buckets.length > 0 ? `${stats.count} checks · bucketed` : "No data in window"}
+            {buckets.length > 0
+              ? `${stats.count} checks · ${buckets.length}-bucket rollup · p50/p95/p99`
+              : "No data in window"}
           </p>
         </div>
         <ChartLegend />
@@ -331,7 +339,7 @@ function ResponseChart({
           return (
             <g key={g}>
               <line
-                x1={PAD}
+                x1={LEFT_GUTTER}
                 x2={W - PAD}
                 y1={yFor(v)}
                 y2={yFor(v)}
@@ -339,7 +347,7 @@ function ResponseChart({
                 strokeDasharray="2 4"
               />
               <text
-                x={PAD - 4}
+                x={LEFT_GUTTER - 6}
                 y={yFor(v) + 3}
                 fontSize="9"
                 fill="var(--muted-foreground)"
@@ -352,7 +360,7 @@ function ResponseChart({
         })}
 
         <line
-          x1={PAD}
+          x1={LEFT_GUTTER}
           x2={W - PAD}
           y1={yFor(sloMs)}
           y2={yFor(sloMs)}
@@ -525,6 +533,18 @@ interface DistributionBucket {
   intent: "success" | "primary" | "warning" | "danger"
 }
 
+function computeMedianMean(points: ChartDataPoint[]): {
+  median: number | null
+  mean: number | null
+} {
+  const values = points.map((p) => p.response_time).filter((v): v is number => v != null)
+  if (values.length === 0) return { median: null, mean: null }
+  const sorted = [...values].sort((a, b) => a - b)
+  const median = sorted[Math.floor(sorted.length / 2)]
+  const mean = values.reduce((a, b) => a + b, 0) / values.length
+  return { median, mean: Math.round(mean) }
+}
+
 function computeDistribution(points: ChartDataPoint[]): DistributionBucket[] {
   const ranges: Array<{
     label: string
@@ -549,7 +569,15 @@ function computeDistribution(points: ChartDataPoint[]): DistributionBucket[] {
   })
 }
 
-function DistributionHistogram({ distribution }: { distribution: DistributionBucket[] }) {
+function DistributionHistogram({
+  distribution,
+  median,
+  mean,
+}: {
+  distribution: DistributionBucket[]
+  median: number | null
+  mean: number | null
+}) {
   const max = Math.max(1, ...distribution.map((d) => d.count))
   const total = distribution.reduce((acc, d) => acc + d.count, 0)
   return (
@@ -557,13 +585,16 @@ function DistributionHistogram({ distribution }: { distribution: DistributionBuc
       data-slot="distribution-histogram"
       className="rounded-lg border border-border bg-card px-5 py-4"
     >
-      <header className="mb-3 flex items-baseline justify-between">
+      <header className="mb-3 flex items-baseline justify-between gap-3">
         <div>
           <Eyebrow>distribution</Eyebrow>
           <p className="mt-0.5 font-semibold text-foreground text-sm">
             {total} checks · bucketed by response time
           </p>
         </div>
+        <p className="text-[10px] text-muted-foreground">
+          median {formatMs(median)} · mean {formatMs(mean)}
+        </p>
       </header>
       <div className="flex h-[120px] items-stretch gap-1 border-border border-b pb-2">
         {distribution.map((b) => {
@@ -612,6 +643,14 @@ const PHASE_KEYS: Array<{
   { key: "transfer", label: "Content transfer", className: "bg-destructive" },
 ]
 
+const PHASE_DOMINANT_LABEL: Record<keyof PhaseTimingsPayload["phases"], string> = {
+  dns: "DNS lookup dominates",
+  tcp: "TCP connect dominates",
+  tls: "TLS handshake dominates fixed cost",
+  ttfb: "TTFB is where the spike lives",
+  transfer: "Content transfer dominates",
+}
+
 function PhaseWaterfall({
   payload,
   error,
@@ -626,6 +665,20 @@ function PhaseWaterfall({
     ? PHASE_KEYS.reduce((acc, p) => acc + (payload.phases[p.key].avg ?? 0), 0)
     : 0
 
+  const dominantPhase = useMemo(() => {
+    if (!payload) return null
+    let best: keyof PhaseTimingsPayload["phases"] | null = null
+    let bestVal = -1
+    for (const p of PHASE_KEYS) {
+      const v = payload.phases[p.key].p95 ?? 0
+      if (v > bestVal) {
+        bestVal = v
+        best = p.key
+      }
+    }
+    return best
+  }, [payload])
+
   return (
     <article
       data-slot="phase-waterfall"
@@ -634,7 +687,9 @@ function PhaseWaterfall({
       <header className="mb-3 flex items-baseline justify-between">
         <div>
           <Eyebrow>phase breakdown</Eyebrow>
-          <p className="mt-0.5 font-semibold text-foreground text-sm">where time is spent</p>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">
+            where time is spent · avg vs p95
+          </p>
         </div>
         <p className="text-[10px] text-muted-foreground">
           avg <span className="text-foreground">{totalAvg}ms</span> · p95{" "}
@@ -694,6 +749,16 @@ function PhaseWaterfall({
       ) : null}
       {!payload && !error ? (
         <p className="text-muted-foreground text-sm">Loading phase data…</p>
+      ) : null}
+      {payload && payload.count > 0 ? (
+        <p
+          data-slot="phase-footnote"
+          className="mt-3 border-border border-t pt-3 text-[10px] text-muted-foreground"
+        >
+          {`// solid bars = avg · faded bars = p95${
+            dominantPhase ? ` · ${PHASE_DOMINANT_LABEL[dominantPhase]}` : ""
+          }`}
+        </p>
       ) : null}
     </article>
   )
@@ -825,6 +890,15 @@ function StatusCodesBars({ buckets }: { buckets: StatusBucket[] }) {
           })
         )}
       </div>
+      {buckets.length > 0 ? (
+        <div className="mt-2 flex justify-between border-border border-t pt-2 text-[9px] text-muted-foreground">
+          <span>−24h</span>
+          <span>−18h</span>
+          <span>−12h</span>
+          <span>−6h</span>
+          <span>now</span>
+        </div>
+      ) : null}
     </article>
   )
 }
@@ -833,10 +907,24 @@ function AssertionTimelinePlaceholder() {
   return (
     <article
       data-slot="assertion-timeline"
-      className="rounded-lg border border-border border-dashed bg-card px-5 py-4 text-muted-foreground text-sm"
+      className="rounded-lg border border-border border-dashed bg-card px-5 py-4"
     >
-      <Eyebrow>assertions</Eyebrow>
-      <p className="mt-1.5">Assertion pass/fail timeline lands once the assertions module ships.</p>
+      <header className="flex items-baseline justify-between">
+        <div>
+          <Eyebrow>assertions</Eyebrow>
+          <p className="mt-0.5 font-semibold text-foreground text-sm">
+            per-check pass/fail · last 24h
+          </p>
+        </div>
+      </header>
+      <p className="mt-3 text-muted-foreground text-sm">
+        Assertion pass/fail timeline lands once the assertions module ships.
+      </p>
+      <div className="mt-3 flex justify-between border-border border-t pt-2 text-[9px] text-muted-foreground">
+        <span>−24h</span>
+        <span className="text-foreground">last failure window</span>
+        <span>now</span>
+      </div>
     </article>
   )
 }

--- a/resources/js/pages/monitors/components/response-tab.tsx
+++ b/resources/js/pages/monitors/components/response-tab.tsx
@@ -671,7 +671,8 @@ function PhaseWaterfall({
                 <div
                   role="img"
                   aria-label={`${p.label} avg ${avg}ms p95 ${p95}ms`}
-                  className="relative h-[18px] rounded-sm bg-muted/40"
+                  className="relative h-[18px] w-full overflow-hidden rounded-sm"
+                  style={{ background: "color-mix(in oklch, var(--foreground) 8%, transparent)" }}
                 >
                   <div
                     className={`absolute inset-y-0 left-0 rounded-sm opacity-25 ${p.className}`}

--- a/resources/js/pages/monitors/components/response-tab.tsx
+++ b/resources/js/pages/monitors/components/response-tab.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import MonitorPhaseTimingsController from "@/actions/App/Http/Controllers/MonitorPhaseTimingsController"
 import { Eyebrow } from "@/components/primitives"
+import { subscribeToEvents } from "@/stores/monitor-realtime"
 import type { ChartDataPoint, Heartbeat } from "@/types/monitor"
 
 export type ResponseTabPeriod = "1h" | "24h" | "7d" | "30d"
@@ -64,14 +65,17 @@ export function ResponseTab({
   const [compare, setCompare] = useState(true)
   const [phasePayload, setPhasePayload] = useState<PhaseTimingsPayload | null>(null)
   const [phaseError, setPhaseError] = useState<string | null>(null)
+  const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  useEffect(() => {
+  const fetchPhases = useCallback(() => {
     let cancelled = false
-    setPhaseError(null)
     const url = MonitorPhaseTimingsController.url(monitorId, { query: { period } })
     fetcher(url)
       .then((payload) => {
-        if (!cancelled) setPhasePayload(payload)
+        if (!cancelled) {
+          setPhasePayload(payload)
+          setPhaseError(null)
+        }
       })
       .catch((e: Error) => {
         if (!cancelled) {
@@ -83,6 +87,30 @@ export function ResponseTab({
       cancelled = true
     }
   }, [monitorId, period, fetcher])
+
+  useEffect(() => {
+    setPhaseError(null)
+    const cancel = fetchPhases()
+    return cancel
+  }, [fetchPhases])
+
+  // Realtime: when a fresh heartbeat lands for this monitor, debounce-refetch
+  // the phase aggregate so the waterfall stays in sync without hammering the
+  // endpoint when bursts arrive.
+  useEffect(() => {
+    const unsubscribe = subscribeToEvents((event) => {
+      if (event.type !== "heartbeat") return
+      if (event.payload.monitorId !== monitorId) return
+      if (refetchTimerRef.current) clearTimeout(refetchTimerRef.current)
+      refetchTimerRef.current = setTimeout(() => {
+        fetchPhases()
+      }, 1500)
+    })
+    return () => {
+      unsubscribe()
+      if (refetchTimerRef.current) clearTimeout(refetchTimerRef.current)
+    }
+  }, [monitorId, fetchPhases])
 
   const buckets = useMemo(() => bucketChart(chartData ?? [], 48), [chartData])
   const prevBuckets = useMemo(() => bucketChart(prevChartData ?? [], 48), [prevChartData])

--- a/resources/js/pages/monitors/show.tsx
+++ b/resources/js/pages/monitors/show.tsx
@@ -31,6 +31,7 @@ import { statusBadgeIntent, uptimeColor } from "@/lib/color"
 import { formatInterval, heartbeatsToTracker } from "@/lib/heartbeats"
 import { EscalationTimeline } from "@/pages/monitors/components/escalation-timeline"
 import { NotificationDeliveryLog } from "@/pages/monitors/components/notification-delivery-log"
+import { ResponseTab, type ResponseTabPeriod } from "@/pages/monitors/components/response-tab"
 import { RoutingRulesTable } from "@/pages/monitors/components/routing-rules-table"
 import monitorRoutes from "@/routes/monitors"
 import { hydrate, subscribeToEvents, useMonitor } from "@/stores/monitor-realtime"
@@ -68,6 +69,7 @@ interface Props {
   heartbeats?: { data: Heartbeat[]; links: PaginationLinks; meta: PaginationMeta }
   incidents?: Incident[]
   chartData?: ChartDataPoint[]
+  prevChartData?: ChartDataPoint[]
   uptimeStats?: UptimeStats
   sslCertificate?: SslCertificate | null
   chartPeriod?: string
@@ -135,6 +137,7 @@ export default function MonitorsShow({
   heartbeats: initialHeartbeats,
   incidents: initialIncidents,
   chartData: initialChartData,
+  prevChartData: initialPrevChartData,
   uptimeStats,
   sslCertificate,
   chartPeriod: initialChartPeriod,
@@ -157,10 +160,11 @@ export default function MonitorsShow({
   const [heartbeats, setHeartbeats] = useState(initialHeartbeats)
   const [incidents, setIncidents] = useState(initialIncidents)
   const [chartData, setChartData] = useState(initialChartData)
+  const [prevChartData, setPrevChartData] = useState(initialPrevChartData)
   const [chartPeriod, setChartPeriod] = useState(initialChartPeriod ?? "24h")
   const [scanningSSL, setScanningSSL] = useState(false)
 
-  const validTabs = ["overview", "heartbeats", "incidents", "ssl", "notifications"]
+  const validTabs = ["overview", "heartbeats", "incidents", "response", "ssl", "notifications"]
   const getInitialTab = () => {
     const tab = new URLSearchParams(window.location.search).get("tab")
     return validTabs.includes(tab ?? "") ? tab! : "overview"
@@ -187,10 +191,14 @@ export default function MonitorsShow({
     if (initialChartData) setChartData(initialChartData)
   }, [initialChartData])
 
+  useEffect(() => {
+    if (initialPrevChartData) setPrevChartData(initialPrevChartData)
+  }, [initialPrevChartData])
+
   const handlePeriodChange = (period: string) => {
     setChartPeriod(period)
     router.reload({
-      only: ["chartData"],
+      only: ["chartData", "prevChartData"],
       data: { period },
       preserveScroll: true,
     })
@@ -392,6 +400,7 @@ export default function MonitorsShow({
             <Tab id="overview">Overview</Tab>
             <Tab id="heartbeats">Heartbeats</Tab>
             <Tab id="incidents">Incidents</Tab>
+            <Tab id="response">Response</Tab>
             {monitor.type === "http" && monitor.ssl_monitoring_enabled && (
               <Tab id="ssl">SSL Certificate</Tab>
             )}
@@ -903,6 +912,18 @@ export default function MonitorsShow({
                 )}
               </WhenVisible>
             </div>
+          </TabPanel>
+
+          {/* ── Response tab ── */}
+          <TabPanel id="response" className="pt-4">
+            <ResponseTab
+              monitorId={monitor.id}
+              period={(chartPeriod as ResponseTabPeriod) ?? "24h"}
+              onPeriodChange={(p) => handlePeriodChange(p)}
+              chartData={chartData ?? []}
+              prevChartData={prevChartData ?? []}
+              heartbeats={liveHeartbeats}
+            />
           </TabPanel>
 
           {/* ── SSL tab ── */}

--- a/resources/js/types/monitor.ts
+++ b/resources/js/types/monitor.ts
@@ -58,6 +58,11 @@ export interface Heartbeat {
     status: HeartbeatStatus
     status_code: number | null
     response_time: number | null
+    phase_dns_ms: number | null
+    phase_tcp_ms: number | null
+    phase_tls_ms: number | null
+    phase_ttfb_ms: number | null
+    phase_transfer_ms: number | null
     message: string | null
     created_at: string
 }

--- a/routes/monitors.php
+++ b/routes/monitors.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\MonitorController;
 use App\Http\Controllers\MonitorGroupController;
 use App\Http\Controllers\MonitorGroupReorderController;
 use App\Http\Controllers\MonitorNotificationDeliveryController;
+use App\Http\Controllers\MonitorPhaseTimingsController;
 use App\Http\Controllers\MonitorRestoreController;
 use App\Http\Controllers\MonitorToggleController;
 use App\Http\Controllers\NotificationChannelController;
@@ -52,6 +53,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('notification-deliveries/fired-today', FiredTodayDeliveriesController::class)->name('notification-deliveries.fired-today');
 
     Route::get('monitors/{monitor}/notification-deliveries', [MonitorNotificationDeliveryController::class, 'index'])->name('monitors.notification-deliveries.index');
+    Route::get('monitors/{monitor}/phase-timings', MonitorPhaseTimingsController::class)->name('monitors.phase-timings');
 
     Route::post('monitors/{monitor}/notification-routes', [NotificationRouteController::class, 'store'])->name('monitors.notification-routes.store');
     Route::patch('monitors/{monitor}/notification-routes/{notificationRoute}', [NotificationRouteController::class, 'update'])->name('monitors.notification-routes.update');

--- a/tests/Browser/MonitorResponseTabBrowserTest.php
+++ b/tests/Browser/MonitorResponseTabBrowserTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\Heartbeat;
+use App\Models\Monitor;
+use App\Models\User;
+
+beforeEach(function (): void {
+    if (! file_exists(base_path('node_modules/playwright'))) {
+        test()->markTestSkipped('playwright is not installed');
+    }
+});
+
+test('response tab renders all sections for a seeded http monitor', function (): void {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->up()->create([
+        'user_id' => $user->id,
+        'team_id' => $user->current_team_id,
+        'name' => 'response-tab-monitor',
+    ]);
+
+    // Current 24h window.
+    foreach (range(0, 30) as $i) {
+        Heartbeat::factory()->for($monitor)->create([
+            'status' => 'up',
+            'status_code' => 200,
+            'response_time' => 200 + ($i % 7) * 80,
+            'phase_dns_ms' => 12 + ($i % 4),
+            'phase_tcp_ms' => 22 + ($i % 5),
+            'phase_tls_ms' => 80 + ($i % 6),
+            'phase_ttfb_ms' => 130 + ($i % 11) * 10,
+            'phase_transfer_ms' => 25 + ($i % 3),
+            'created_at' => now()->subMinutes($i * 10),
+        ]);
+    }
+
+    // Previous 24h window so the compare ghost line has data to draw.
+    foreach (range(0, 30) as $i) {
+        Heartbeat::factory()->for($monitor)->create([
+            'status' => 'up',
+            'status_code' => 200,
+            'response_time' => 220 + ($i % 6) * 70,
+            'created_at' => now()->subDay()->subMinutes($i * 10),
+        ]);
+    }
+
+    $this->actingAs($user);
+
+    $page = visit("/monitors/{$monitor->id}?tab=response");
+
+    $page->assertPresent('[data-slot="response-chart"]')
+        ->assertPresent('[data-slot="distribution-histogram"]')
+        ->assertPresent('[data-slot="phase-waterfall"]')
+        ->assertPresent('[data-slot="status-codes"]')
+        ->assertPresent('[data-slot="assertion-timeline"]')
+        ->assertPresent('[data-slot="slowest-checks"]');
+
+    $page->assertPresent('[data-phase="dns"]')
+        ->assertPresent('[data-phase="ttfb"]')
+        ->assertPresent('[data-phase="transfer"]');
+
+    $page->assertPresent('[data-slot="prev-period-line"]');
+});

--- a/tests/Feature/MonitorPhaseTimingsTest.php
+++ b/tests/Feature/MonitorPhaseTimingsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Models\Heartbeat;
+use App\Models\Monitor;
+use App\Models\User;
+
+test('phase-timings endpoint returns avg + p95 per phase across the 24h window', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create();
+
+    // 5 in-window heartbeats with deterministic phase values.
+    foreach ([10, 20, 30, 40, 50] as $i => $dns) {
+        Heartbeat::factory()->for($monitor)->create([
+            'response_time' => 100 + $i * 10,
+            'phase_dns_ms' => $dns,
+            'phase_tcp_ms' => $dns * 2,
+            'phase_tls_ms' => $dns * 3,
+            'phase_ttfb_ms' => $dns * 4,
+            'phase_transfer_ms' => $dns * 5,
+            'created_at' => now()->subMinutes(30 + $i),
+        ]);
+    }
+
+    // Heartbeat outside the 24h window — must be excluded.
+    Heartbeat::factory()->for($monitor)->create([
+        'phase_dns_ms' => 9999,
+        'phase_tcp_ms' => 9999,
+        'phase_tls_ms' => 9999,
+        'phase_ttfb_ms' => 9999,
+        'phase_transfer_ms' => 9999,
+        'created_at' => now()->subDays(2),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/monitors/{$monitor->id}/phase-timings?period=24h")
+        ->assertOk();
+
+    $response->assertJsonPath('period', '24h');
+    $response->assertJsonPath('count', 5);
+
+    // avg of 10..50 = 30; p95 picks index floor(0.95 * 5) = 4 → 50.
+    $response->assertJsonPath('phases.dns.avg', 30);
+    $response->assertJsonPath('phases.dns.p95', 50);
+    $response->assertJsonPath('phases.dns.count', 5);
+
+    $response->assertJsonPath('phases.tcp.avg', 60);
+    $response->assertJsonPath('phases.tcp.p95', 100);
+
+    $response->assertJsonPath('phases.tls.avg', 90);
+    $response->assertJsonPath('phases.transfer.avg', 150);
+});
+
+test('phase-timings excludes heartbeats whose phases are null (non-HTTP types)', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create();
+
+    Heartbeat::factory()->for($monitor)->create([
+        'phase_dns_ms' => 100,
+        'phase_tcp_ms' => 200,
+        'phase_tls_ms' => 300,
+        'phase_ttfb_ms' => 400,
+        'phase_transfer_ms' => 500,
+        'created_at' => now()->subMinutes(10),
+    ]);
+
+    Heartbeat::factory()->for($monitor)->create([
+        'phase_dns_ms' => null,
+        'phase_tcp_ms' => null,
+        'phase_tls_ms' => null,
+        'phase_ttfb_ms' => null,
+        'phase_transfer_ms' => null,
+        'created_at' => now()->subMinutes(5),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/monitors/{$monitor->id}/phase-timings?period=24h")
+        ->assertOk();
+
+    $response->assertJsonPath('count', 2);
+    $response->assertJsonPath('phases.dns.count', 1);
+    $response->assertJsonPath('phases.dns.avg', 100);
+    $response->assertJsonPath('phases.dns.p95', 100);
+});
+
+test('phase-timings returns null avg + p95 when no in-window heartbeats exist', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create();
+
+    $response = $this->actingAs($user)
+        ->getJson("/monitors/{$monitor->id}/phase-timings?period=1h")
+        ->assertOk();
+
+    $response->assertJsonPath('count', 0);
+    $response->assertJsonPath('phases.dns.avg', null);
+    $response->assertJsonPath('phases.dns.p95', null);
+    $response->assertJsonPath('phases.dns.count', 0);
+});
+
+test('phase-timings rejects invalid period values', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->getJson("/monitors/{$monitor->id}/phase-timings?period=99d")
+        ->assertStatus(422);
+});
+
+test('phase-timings is gated by the monitor view policy', function () {
+    $owner = User::factory()->create();
+    $stranger = User::factory()->create();
+    $monitor = Monitor::factory()->for($owner)->create();
+
+    $this->actingAs($stranger)
+        ->getJson("/monitors/{$monitor->id}/phase-timings")
+        ->assertForbidden();
+});
+
+test('phase-timings respects the 1h window', function () {
+    $user = User::factory()->create();
+    $monitor = Monitor::factory()->for($user)->create();
+
+    Heartbeat::factory()->for($monitor)->create([
+        'phase_dns_ms' => 50,
+        'created_at' => now()->subMinutes(10),
+    ]);
+
+    Heartbeat::factory()->for($monitor)->create([
+        'phase_dns_ms' => 999,
+        'created_at' => now()->subHours(2),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/monitors/{$monitor->id}/phase-timings?period=1h")
+        ->assertOk();
+
+    $response->assertJsonPath('count', 1);
+    $response->assertJsonPath('phases.dns.avg', 50);
+});

--- a/tests/Feature/PhaseTimingCaptureFeatureTest.php
+++ b/tests/Feature/PhaseTimingCaptureFeatureTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\DTOs\PhaseCaptureResult;
+use App\DTOs\PhaseTiming;
+use App\Models\Monitor;
+use App\Services\PhaseTimingCapture;
+use Illuminate\Support\Facades\Http;
+
+test('capture returns a PhaseCaptureResult with body, headers, status code from a successful response', function () {
+    Http::fake([
+        'https://example.com/health' => Http::response(
+            '{"status":"ok"}',
+            200,
+            ['content-type' => 'application/json'],
+        ),
+    ]);
+
+    $monitor = Monitor::factory()->make([
+        'type' => 'http',
+        'url' => 'https://example.com/health',
+        'method' => 'GET',
+        'timeout' => 10,
+    ]);
+
+    $result = app(PhaseTimingCapture::class)->capture($monitor);
+
+    expect($result)->toBeInstanceOf(PhaseCaptureResult::class)
+        ->and($result->statusCode)->toBe(200)
+        ->and($result->body)->toBe('{"status":"ok"}')
+        ->and($result->headers['content-type'][0] ?? $result->headers['content-type'] ?? null)
+        ->toContain('application/json')
+        ->and($result->error)->toBeNull()
+        ->and($result->timing)->toBeInstanceOf(PhaseTiming::class);
+});
+
+test('capture surfaces error when the request throws', function () {
+    Http::fake([
+        'https://broken.example' => fn () => throw new RuntimeException('connection refused'),
+    ]);
+
+    $monitor = Monitor::factory()->make([
+        'type' => 'http',
+        'url' => 'https://broken.example',
+        'method' => 'GET',
+        'timeout' => 5,
+    ]);
+
+    $result = app(PhaseTimingCapture::class)->capture($monitor);
+
+    expect($result->statusCode)->toBeNull()
+        ->and($result->error)->toContain('connection refused')
+        ->and($result->timing)->toBeInstanceOf(PhaseTiming::class)
+        ->and($result->timing->phaseDnsMs)->toBeNull();
+});

--- a/tests/Unit/PhaseTimingCaptureTest.php
+++ b/tests/Unit/PhaseTimingCaptureTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\DTOs\PhaseTiming;
+use App\Services\PhaseTimingCapture;
+
+test('fromHandlerStats maps full HTTPS curl stats to ms timings', function () {
+    $stats = [
+        'namelookup_time' => 0.018,
+        'connect_time' => 0.042,
+        'appconnect_time' => 0.128,
+        'starttransfer_time' => 0.260,
+        'total_time' => 0.286,
+    ];
+
+    $timing = PhaseTimingCapture::fromHandlerStats($stats);
+
+    expect($timing)->toBeInstanceOf(PhaseTiming::class)
+        ->and($timing->phaseDnsMs)->toBe(18)
+        ->and($timing->phaseTcpMs)->toBe(24)
+        ->and($timing->phaseTlsMs)->toBe(86)
+        ->and($timing->phaseTtfbMs)->toBe(132)
+        ->and($timing->phaseTransferMs)->toBe(26);
+});
+
+test('fromHandlerStats treats appconnect_time of zero as plain HTTP and skips TLS', function () {
+    $stats = [
+        'namelookup_time' => 0.010,
+        'connect_time' => 0.030,
+        'appconnect_time' => 0.0,
+        'starttransfer_time' => 0.150,
+        'total_time' => 0.200,
+    ];
+
+    $timing = PhaseTimingCapture::fromHandlerStats($stats);
+
+    expect($timing->phaseDnsMs)->toBe(10)
+        ->and($timing->phaseTcpMs)->toBe(20)
+        ->and($timing->phaseTlsMs)->toBeNull()
+        ->and($timing->phaseTtfbMs)->toBe(120)
+        ->and($timing->phaseTransferMs)->toBe(50);
+});
+
+test('fromHandlerStats returns all-null timing when stats are missing', function () {
+    $timing = PhaseTimingCapture::fromHandlerStats([]);
+
+    expect($timing->phaseDnsMs)->toBeNull()
+        ->and($timing->phaseTcpMs)->toBeNull()
+        ->and($timing->phaseTlsMs)->toBeNull()
+        ->and($timing->phaseTtfbMs)->toBeNull()
+        ->and($timing->phaseTransferMs)->toBeNull();
+});
+
+test('fromHandlerStats clamps negative deltas to null', function () {
+    $stats = [
+        'namelookup_time' => 0.100,
+        'connect_time' => 0.080, // out of order — TCP delta would be negative
+        'appconnect_time' => 0.090,
+        'starttransfer_time' => 0.050, // earlier than appconnect — TTFB negative
+        'total_time' => 0.040, // earlier than starttransfer — transfer negative
+    ];
+
+    $timing = PhaseTimingCapture::fromHandlerStats($stats);
+
+    expect($timing->phaseDnsMs)->toBe(100)
+        ->and($timing->phaseTcpMs)->toBeNull()
+        ->and($timing->phaseTlsMs)->toBe(10)
+        ->and($timing->phaseTtfbMs)->toBeNull()
+        ->and($timing->phaseTransferMs)->toBeNull();
+});
+
+test('fromHandlerStats rounds fractional millis', function () {
+    $stats = [
+        'namelookup_time' => 0.0125,
+        'connect_time' => 0.0254,
+        'appconnect_time' => 0.0,
+        'starttransfer_time' => 0.1006,
+        'total_time' => 0.1500,
+    ];
+
+    $timing = PhaseTimingCapture::fromHandlerStats($stats);
+
+    expect($timing->phaseDnsMs)->toBe(13)
+        ->and($timing->phaseTcpMs)->toBe(13)
+        ->and($timing->phaseTtfbMs)->toBe(75)
+        ->and($timing->phaseTransferMs)->toBe(49);
+});


### PR DESCRIPTION
Closes #25

## What landed

### Backend
- **Migration**: 5 nullable `unsignedInteger` columns on `heartbeats` — `phase_dns_ms`, `phase_tcp_ms`, `phase_tls_ms`, `phase_ttfb_ms`, `phase_transfer_ms`. Non-HTTP types stay null.
- **`PhaseTimingCapture` deep module** (`app/Services/PhaseTimingCapture.php`) — pure mapper `fromHandlerStats()` + thin orchestrator `capture(Monitor)`. Maps Guzzle `handlerStats()` (curl info via the default Http client) into a typed `PhaseTiming` struct. Plain HTTP gets `tls = null`; out-of-order or missing stats clamp to `null`.
- **DTOs** — `PhaseTiming`, `PhaseCaptureResult`. `CheckResult` extended with the 5 phase fields + `withTiming()` helper.
- **`HttpChecker` + `CheckHttpMonitorsBatchJob` + `CheckMonitorJob`** persist phase columns. `HeartbeatResource` exposes them.
- **`MonitorPhaseTimingsController`** — `GET /monitors/{monitor}/phase-timings?period=1h|24h|7d|30d`. Returns `{ period, count, phases: { dns: { avg, p95, count }, tcp, tls, ttfb, transfer } }`. Authorised via `MonitorPolicy::view`. p95 via in-PHP sort (SQLite + Postgres compatible).
- **`MonitorController::show`** now defers a second `prevChartData` prop so the response chart can render the previous-period ghost line without an extra round-trip.
- **`MonitorSeeder`** synthesises plausible phase splits (DNS / TCP / TLS / TTFB / transfer summing to `response_time`) so the Response tab demo has realistic data out of `migrate:fresh --seed`.

### Frontend
- **`response-tab.tsx`** — new 7th-section composite mounted as a Response tab on `monitors/show.tsx`. Sub-components:
  - **`RangeSelector`** — 1h / 24h / 7d / 30d pills + Compare-to-prev checkbox (defaults to **on**).
  - **`ResponseChart`** — SVG p50 / p95 / p99 lines, dashed prev-period p95 ghost line (`data-slot="prev-period-line"`), SLO threshold line, gridlines.
  - **`StatStrip`** — p50, p95 with vs-prev delta, p99, min · max + spread, SLO breach %.
  - **`DistributionHistogram`** — 8 buckets, colour-graded green→red, height proportional to count.
  - **`PhaseWaterfall`** — 5 phase rows; solid avg bar + faded p95 bar inside a muted lane track, scaled relative to total p95.
  - **`StatusCodesBars`** — 24-bucket stacked bars (2xx / 3xx / 4xx / 5xx / timeout).
  - **`AssertionTimelinePlaceholder`** — labelled placeholder until the assertions module ships in #26.
  - **`SlowestChecks`** — table with Slowest / Failed only / Latest filter pills; duration text colour-graded by threshold; footer with `showing N · view all` link.

## Acceptance criteria

- [x] HTTP checker captures all five phase timings via curl — `HttpChecker::check` and `CheckHttpMonitorsBatchJob::buildResult` both extract `handlerStats()` and call `PhaseTimingCapture::fromHandlerStats`.
- [x] `heartbeats` table has the five nullable phase columns; non-HTTP types (TCP/Ping/DNS/Push) leave them null — see migration `2026_04_30_224356_add_phase_timings_to_heartbeats_table.php`.
- [x] `PhaseTimingCapture` is a deep module testable in isolation — `tests/Unit/PhaseTimingCaptureTest.php` covers HTTPS, plain HTTP, missing stats, negative deltas, fractional rounding.
- [x] Aggregation endpoint returns avg + p95 per phase across the selected window — `MonitorPhaseTimingsController` + `tests/Feature/MonitorPhaseTimingsTest.php`.
- [x] Response tab renders all sections at the size/density of the mock; legends wrap responsively — `resources/js/pages/monitors/components/response-tab.tsx` + the in-tab vitest covers each `data-slot`.
- [x] Compare-to-previous toggle on by default, ghost line renders — vitest `compare-to-previous toggle is on by default and renders the ghost line` asserts both.
- [x] Pest feature test verifies aggregation correctness over seeded heartbeats — `tests/Feature/MonitorPhaseTimingsTest.php` checks deterministic avg + p95 + window exclusion + null filter + auth gate.
- [x] Pest 4 browser test loads the Response tab on a seeded monitor and verifies all sections render — `tests/Browser/MonitorResponseTabBrowserTest.php` asserts every `data-slot` plus the prev-period ghost line.

## Test plan
- `vendor/bin/sail test --compact tests/Unit/PhaseTimingCaptureTest.php tests/Feature/PhaseTimingCaptureFeatureTest.php tests/Feature/MonitorPhaseTimingsTest.php tests/Browser/MonitorResponseTabBrowserTest.php` — all green.
- `vendor/bin/sail test --compact` — full suite green except the 2 pre-existing `MonitorSeederTest` failures present on `main` (unrelated; `services.fake_servers.host` env in CI vs Sail).
- `npm run test:js -- --run` — 24 files, 128 tests pass (10 in the new response-tab suite).
- `npm run build` — Vite build green.
- `vendor/bin/pint --dirty --format agent` — clean.
- `npx biome format --write` on touched JS/TSX — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Response tab: response-time charts, distribution, phase breakdown (DNS/TCP/TLS/TTFB/transfer) and slowest-checks table.
  * Previous-period comparison: ghost-line overlay and p95 delta vs prior window.
  * Phase timings API: per-phase avg/p95/count for configurable periods; realtime-synced phase waterfall.

* **Bug Fixes**
  * HTTP monitors now persist and surface detailed per-phase timing metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->